### PR TITLE
Update custom errors to work in the browser

### DIFF
--- a/packages/hdwallet-core/src/exceptions.ts
+++ b/packages/hdwallet-core/src/exceptions.ts
@@ -15,9 +15,13 @@ export class HDWalletError extends Error {
 
     constructor (message: string, type: HDWalletErrorType) {
         super(message)
-        Error.captureStackTrace(this, this.constructor)
         this.name = type
         this.type = type
+        if (typeof Error.captureStackTrace === 'function') {
+            Error.captureStackTrace(this, this.constructor);
+        } else {
+            this.stack = (new Error(message)).stack;
+        }
     }
 }
 


### PR DESCRIPTION
`Error.captureStackTrace` is a V8-only function.

If a non-V8 browser runs this code, it'll throw a TypeError.  This PR adds a check so that the custom errors will work in non-V8 browsers.