### PR TITLE
fix: TransactionBuilder requires output.amount to be a number

### DIFF
--- a/examples/sandbox/index.ts
+++ b/examples/sandbox/index.ts
@@ -450,7 +450,7 @@ $btcTx.on('click', async (e) => {
     let inputs = [{
       addressNList: [0x80000000 + 44, 0x80000000 + 0, 0x80000000 + 0, 0, 0],
       scriptType: BTCInputScriptType.SpendAddress,
-      amount: 14657949219,
+      amount: String(14657949219),
       vout: 0,
       txid: txid,
       tx: btcTxJson,
@@ -461,7 +461,7 @@ $btcTx.on('click', async (e) => {
       address: '1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1',
       addressType: BTCOutputAddressType.Spend,
       scriptType: BTCOutputScriptType.PayToAddress,
-      amount: 390000 - 10000,
+      amount: String(390000 - 10000),
       isChange: false,
     }]
     let res = await wallet.btcSignTx({
@@ -556,7 +556,7 @@ $ltcTx.on('click', async (e) => {
     const inputs = [{
       addressNList: ltcBip44.addressNList,
       scriptType: BTCInputScriptType.SpendAddress,
-      amount: 2160258,
+      amount: String(2160258),
       vout: 0,
       txid,
       segwit: false,
@@ -568,7 +568,7 @@ $ltcTx.on('click', async (e) => {
       address: 'LLe4PciAJgMMJSAtQQ5nkC13t6SSMmERJ3',
       addressType: BTCOutputAddressType.Spend,
       scriptType: BTCOutputScriptType.PayToAddress,
-      amount: 261614,
+      amount: String(261614),
       isChange: false
     }]
 
@@ -650,7 +650,7 @@ $dogeTx.on('click', async (e) => {
     const inputs = [{
       addressNList: dogeBip44.addressNList.concat([0, 0]),
       scriptType: BTCInputScriptType.SpendAddress,
-      amount: 14657949219,
+      amount: String(14657949219),
       vout: 0,
       txid: txid,
       segwit: false,
@@ -662,7 +662,7 @@ $dogeTx.on('click', async (e) => {
       address: 'DMEHVGRsELY5zyYbfgta3pAhedKGeaDeJd',
       addressType: BTCOutputAddressType.Spend,
       scriptType: BTCOutputScriptType.PayToAddress,
-      amount: 14557949219,
+      amount: String(14557949219),
       isChange: false
     }]
 
@@ -726,7 +726,7 @@ $bchTx.on('click', async (e) => {
     const inputs = [{
       addressNList: bchBip44.addressNList.concat([0, 0]),
       scriptType: BTCInputScriptType.SpendAddress,
-      amount: 1567200,
+      amount: String(1567200),
       vout: 0,
       txid: txid,
       segwit: false,
@@ -739,7 +739,7 @@ $bchTx.on('click', async (e) => {
         : '14oWXZFPhgP9DA3ggPzhHpUUaikDSjAuMC',
       addressType: BTCOutputAddressType.Spend,
       scriptType: BTCOutputScriptType.PayToAddress,
-      amount: 1567200,
+      amount: String(1567200),
       isChange: false
     }]
 
@@ -803,7 +803,7 @@ $dashTx.on('click', async (e) => {
     const inputs = [{
       addressNList: dashBip44.addressNList.concat([0, 0]),
       scriptType: BTCInputScriptType.SpendAddress,
-      amount: 20654195,
+      amount: String(20654195),
       vout: 0,
       txid: txid,
       segwit: false,
@@ -815,7 +815,7 @@ $dashTx.on('click', async (e) => {
       address: 'XexybzTUtH9V9eY4UJN2aCcBT3utan5C8N',
       addressType: BTCOutputAddressType.Spend,
       scriptType: BTCOutputScriptType.PayToAddress,
-      amount: 20664195,
+      amount: String(20664195),
       isChange: false
     }]
 
@@ -899,7 +899,7 @@ $btcTxSegWit.on('click', async (e) => {
     let inputs = [
       {
         addressNList: [0x80000000 + 49, 0x80000000 + 0, 0x80000000 + 0, 0, 0],
-        amount: 100000,
+        amount: String(100000),
         vout: 0,
         txid: txid,
         scriptType: BTCInputScriptType.SpendP2SHWitness,
@@ -912,7 +912,7 @@ $btcTxSegWit.on('click', async (e) => {
       address: '3Eq3agTHEhMCC8sZHnJJcCcZFB7BBSJKWr',
       addressType: BTCOutputAddressType.Spend,
       scriptType: BTCOutputScriptType.PayToAddress,
-      amount: 89869,
+      amount: String(89869),
     }]
     let res = await wallet.btcSignTx({
       coin: 'Bitcoin',
@@ -940,7 +940,7 @@ $btcTxSegWitNative.on('click', async (e) => {
     let inputs = [
       {
         addressNList: [0x80000000 + 84, 0x80000000 + 0, 0x80000000 + 0],
-        amount: 100000,
+        amount: String(100000),
         vout: 0,
         txid: txid,
         scriptType: BTCInputScriptType.SpendWitness,
@@ -953,7 +953,7 @@ $btcTxSegWitNative.on('click', async (e) => {
       address: 'bc1qc5dgazasye0yrzdavnw6wau5up8td8gdqh7t6m',
       addressType: BTCOutputAddressType.Spend,
       scriptType: BTCOutputScriptType.PayToAddress,
-      amount: 89869,
+      amount: String(89869),
     }]
     let res = await wallet.btcSignTx({
       coin: 'Bitcoin',

--- a/integration/src/bitcoin/bitcoin.ts
+++ b/integration/src/bitcoin/bitcoin.ts
@@ -97,7 +97,7 @@ export function bitcoinTests (get: () => { wallet: HDWallet, info: HDWalletInfo 
       let inputs = [{
         addressNList: bip32ToAddressNList("m/0"),
         scriptType: BTCInputScriptType.SpendAddress,
-        amount: 390000,
+        amount: String(390000),
         vout: 0,
         txid: 'd5f65ee80147b4bcc70b75e4bbf2d7382021b871bd8867ef8fa525ef50864882',
         tx: {
@@ -133,7 +133,7 @@ export function bitcoinTests (get: () => { wallet: HDWallet, info: HDWalletInfo 
         address: '1MJ2tj2ThBE62zXbBYA5ZaN3fdve5CPAz1',
         addressType: BTCOutputAddressType.Spend,
         scriptType: BTCOutputScriptType.PayToAddress,
-        amount: 390000 - 10000,
+        amount: String(390000 - 10000),
         isChange: false
       }]
       let res = await wallet.btcSignTx({

--- a/integration/src/bitcoin/testnet.ts
+++ b/integration/src/bitcoin/testnet.ts
@@ -46,7 +46,7 @@ export function testnetTests (get: () => {wallet: HDWallet, info: HDWalletInfo})
       let inputs = [{
         addressNList: bip32ToAddressNList("m/49'/1'/0'/1/0"),
         scriptType: BTCInputScriptType.SpendP2SHWitness,
-        amount: 123456789,
+        amount: String(123456789),
         vout: 0,
         txid: '20912f98ea3ed849042efed0fdac8cb4fc301961c5988cba56902d8ffb61c337',
         hex: "01000000013a14418ce8bcac00a0cb56bf8a652110f4897cfcd736e1ab5e943b84f0ab2c80000000006a4730440220548e087d0426b20b8a571b03b9e05829f7558b80c53c12143e342f56ab29e51d02205b68cb7fb223981d4c999725ac1485a982c4259c4f50b8280f137878c232998a012102794a25b254a268e59a5869da57fbae2fadc6727cb3309321dab409b12b2fa17cffffffff0215cd5b070000000017a91458b53ea7f832e8f096e896b8713a8c6df0e892ca87ccc69633000000001976a914b84bacdcd8f4cc59274a5bfb73f804ca10f7fd1488ac00000000",
@@ -54,13 +54,13 @@ export function testnetTests (get: () => {wallet: HDWallet, info: HDWalletInfo})
       let outputs = [{
         address: 'mhRx1CeVfaayqRwq5zgRQmD7W5aWBfD5mC',
         addressType: BTCOutputAddressType.Spend,
-        amount: 12300000,
+        amount: String(12300000),
         isChange: false
       }, {
         addressNList: bip32ToAddressNList("m/49'/1'/0'/1/0"),
         scriptType: BTCOutputScriptType.PayToP2SHWitness,
         addressType: BTCOutputAddressType.Change,
-        amount: 123456789 - 11000 - 12300000,
+        amount: String(123456789 - 11000 - 12300000),
         isChange: true
       }]
       let res = await wallet.btcSignTx({
@@ -80,7 +80,7 @@ export function testnetTests (get: () => {wallet: HDWallet, info: HDWalletInfo})
       let inputs = [{
         addressNList: bip32ToAddressNList("m/84'/1'/0'/0/0"),
         scriptType: BTCInputScriptType.SpendWitness,
-        amount: 12300000,
+        amount: String(12300000),
         vout: 0,
         txid: '09144602765ce3dd8f4329445b20e3684e948709c5cdcaf12da3bb079c99448a',
         hex: "010000000137c361fb8f2d9056ba8c98c5611930fcb48cacfdd0fe2e0449d83eea982f91200000000017160014d16b8c0680c61fc6ed2e407455715055e41052f5ffffffff02e0aebb00000000001600140099a7ecbd938ed1839f5f6bf6d50933c6db9d5c3df39f060000000017a91458b53ea7f832e8f096e896b8713a8c6df0e892ca8700000000",
@@ -88,13 +88,13 @@ export function testnetTests (get: () => {wallet: HDWallet, info: HDWalletInfo})
       let outputs = [{
         address: '2N4Q5FhU2497BryFfUgbqkAJE87aKHUhXMp',
         addressType: BTCOutputAddressType.Spend,
-        amount: 5000000,
+        amount: String(5000000),
         isChange: false
       }, {
         addressNList: bip32ToAddressNList("m/84'/1'/0'/1/0"),
         scriptType: BTCOutputScriptType.PayToWitness,
         addressType: BTCOutputAddressType.Change,
-        amount: 12300000 - 11000 - 5000000,
+        amount: String(12300000 - 11000 - 5000000),
         isChange: true
       }]
       let res = await wallet.btcSignTx({

--- a/packages/hdwallet-core/src/bitcoin.ts
+++ b/packages/hdwallet-core/src/bitcoin.ts
@@ -55,7 +55,7 @@ export interface BTCSignTxInput {
   addressNList: BIP32Path,
   scriptType?: BTCInputScriptType,
   sequence?: number,
-  amount: number,
+  amount: string,
   vout: number,
   txid: string,
   tx?: BitcoinTx, // Required for p2sh, not required for segwit
@@ -74,7 +74,7 @@ export interface BTCSignTxOutput {
   scriptType?: BTCOutputScriptType,
   address?: string,
   addressType: BTCOutputAddressType,
-  amount: number,
+  amount: string,
   isChange: boolean,
   /**
    * Device must `btcSupportsNativeShapeShift()`
@@ -154,7 +154,7 @@ export interface BTCWalletInfo {
   _supportsBTCInfo: boolean
 
   /**
-   * Does the device support the given UTXO coin? 
+   * Does the device support the given UTXO coin?
    */
   btcSupportsCoin (coin: Coin): Promise<boolean>
 

--- a/packages/hdwallet-keepkey/src/bitcoin.ts
+++ b/packages/hdwallet-keepkey/src/bitcoin.ts
@@ -107,14 +107,14 @@ function prepareSignTx (
     if (input.sequence !== undefined) utxo.setSequence(input.sequence)
     utxo.setScriptType(translateInputScriptType(input.scriptType))
     utxo.setAddressNList(input.addressNList)
-    utxo.setAmount(input.amount)
+    utxo.setAmount(Number(input.amount))
     unsignedTx.addInputs(utxo, i)
   })
 
   outputs.forEach((o, k) => {
     const output: BTCSignTxOutput = o
     const newOutput = new Types.TxOutputType()
-    newOutput.setAmount(output.amount)
+    newOutput.setAmount(Number(output.amount))
     newOutput.setScriptType(translateOutputScriptType(output.scriptType || BTCOutputScriptType.PayToAddress))
     if (output.exchangeType) {
       // convert the base64 encoded signedExchangeResponse message into the correct object

--- a/packages/hdwallet-ledger/src/bitcoin.ts
+++ b/packages/hdwallet-ledger/src/bitcoin.ts
@@ -134,7 +134,7 @@ export async function btcSignTx (wallet: BTCWallet, transport: LedgerTransport, 
       if (output.addressType === BTCOutputAddressType.Transfer && !supportsSecureTransfer)
         throw new Error("Ledger does not support SecureTransfer")
     }
-    txBuilder.addOutput(output.address, output.amount)
+    txBuilder.addOutput(output.address, Number(output.amount))
   })
 
   let unsignedHex = txBuilder.buildIncomplete().toHex()

--- a/packages/hdwallet-ledger/src/bitcoin.ts
+++ b/packages/hdwallet-ledger/src/bitcoin.ts
@@ -106,9 +106,9 @@ export async function btcGetAddress (transport: LedgerTransport, msg: BTCGetAddr
     * outputScriptHex string is the hexadecimal serialized outputs of the transaction to sign
            ( lockTime number is the optional lockTime of the transaction to sign, or default (0)
     * sigHashType number is the hash type of the transaction to sign, or default (all)
-    * segwit boolean (is an optional boolean indicating wether to use segwit or not)
+    * segwit boolean (is an optional boolean indicating whether to use segwit or not)
     * initialTimestamp number is an optional timestamp of the function call to use for coins that necessitate timestamps only, (not the one that the tx will include)
-    * additionals Array<string> list of additionnal options- "abc" for bch
+    * additionals Array<string> list of additional options- "abc" for bch
         "gold" for btg
         "bipxxx" for using BIPxxx
         "sapling" to indicate a zec transaction is supporting sapling (to be set over block 419200)

--- a/packages/hdwallet-trezor/src/bitcoin.ts
+++ b/packages/hdwallet-trezor/src/bitcoin.ts
@@ -114,7 +114,7 @@ export async function btcSignTx (wallet: BTCWallet, transport: TrezorTransport, 
       address_n: input.addressNList,
       prev_hash: input.txid,
       prev_index: input.vout,
-      amount: String(input.amount),
+      amount: input.amount,
       script_type: translateInputScriptType(input.scriptType)
     }
   })
@@ -128,7 +128,7 @@ export async function btcSignTx (wallet: BTCWallet, transport: TrezorTransport, 
 
       return {
         address_n: output.addressNList,
-        amount: String(output.amount),
+        amount: output.amount,
         script_type: translateOutputScriptType(output.scriptType)
       }
     } else if (output.addressType == BTCOutputAddressType.Transfer) {
@@ -138,7 +138,7 @@ export async function btcSignTx (wallet: BTCWallet, transport: TrezorTransport, 
     if (output.address) {
       return {
         address: output.address,
-        amount: String(output.amount),
+        amount: output.amount,
         script_type: 'PAYTOADDRESS'
       }
     }


### PR DESCRIPTION
BTCSignTxOutput.amount is declared as type number but for whatever reason that type is not being enforced and strings are able to be passed in for amount. TransactionBuilder.addOutput() throws if it is passed a string for amount so I added a cast to number to fix this.