### PR TITLE
dont ask portis for eth address if we already know it

### DIFF
--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -95,6 +95,7 @@ export class PortisHDWallet implements HDWallet, ETHWallet {
   portis: any
   web3: any
   info: PortisHDWalletInfo & HDWalletInfo
+  ethAddress: string
 
   // used as a mutex to ensure calls to portis.getExtendedPublicKey cannot happen before a previous call has resolved
   portisCallInProgress: Promise<any> = Promise.resolve()
@@ -308,7 +309,10 @@ export class PortisHDWallet implements HDWallet, ETHWallet {
   }
 
   private async _ethGetAddress(): Promise<string> {
-    return (await this.web3.eth.getAccounts())[0]
+    if(!this.ethAddress) {
+      this.ethAddress = (await this.web3.eth.getAccounts())[0]
+    }
+    return this.ethAddress
   }
 
   public async getFirmwareVersion(): Promise<string> {


### PR DESCRIPTION
save eth address so we dont have to keep asking portis for it.

This fixes problem where it tries to get deviceId (eth address) after we have logged out of portis.