### PR TITLE
always create new portis object instead of using existing

### DIFF
--- a/packages/hdwallet-portis/src/adapter.ts
+++ b/packages/hdwallet-portis/src/adapter.ts
@@ -51,7 +51,7 @@ export class PortisAdapter {
   }
 
   private async pairPortisDevice(): Promise<HDWallet> {
-    this.portis = this.portis ? this.portis : new Portis(this.portisAppId, 'mainnet')
+    this.portis = new Portis(this.portisAppId, 'mainnet')
     const wallet = new PortisHDWallet(this.portis)
     await wallet.initialize()
     const deviceId = await wallet.getDeviceID()


### PR DESCRIPTION
This fixes problem when we logout of portis and re-pair it tries to use the existing portis object and errors