### PR TITLE
Don't build the HID package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ orbs:
           - checkout
           - attach_workspace:
               at: .
-          - run: yarn --cache-folder .yarn-cache --no-ignore-optional
+          - run: yarn --cache-folder .yarn-cache
           - run: git status
           - run: ./node_modules/.bin/lerna publish from-package --yes
 workflows:

--- a/packages/hdwallet-keepkey-nodehid/package.json
+++ b/packages/hdwallet-keepkey-nodehid/package.json
@@ -2,9 +2,7 @@
   "name": "@shapeshiftoss/hdwallet-keepkey-nodehid",
   "version": "0.11.3",
   "license": "MIT",
-  "publishConfig": {
-    "access": "public"
-  },
+  "private": true,
   "main": "dist/index.js",
   "source": "src/index.ts",
   "umd:main": "dist/index.umd.js",


### PR DESCRIPTION
It's busted in CI anyway, and currently getting in the way of publishing everything else. Let's drop it for the time being.