### PR TITLE
Handle app navigation

### DIFF
--- a/packages/hdwallet-ledger-webusb/src/adapter.ts
+++ b/packages/hdwallet-ledger-webusb/src/adapter.ts
@@ -6,7 +6,7 @@ import TransportWebUSB from '@ledgerhq/hw-transport-webusb'
 const VENDOR_ID = 11415
 const APP_NAVIGATION_DELAY = 1000
 
-function timeout(ms): Promise<void> {
+function timeout(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 

--- a/packages/hdwallet-ledger-webusb/src/adapter.ts
+++ b/packages/hdwallet-ledger-webusb/src/adapter.ts
@@ -4,8 +4,9 @@ import { LedgerWebUsbTransport, getFirstLedgerDevice, getTransport, openTranspor
 import TransportWebUSB from '@ledgerhq/hw-transport-webusb'
 
 const VENDOR_ID = 11415
+const APP_NAVIGATION_DELAY = 1000
 
-function timeout(ms) {
+function timeout(ms): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
@@ -31,7 +32,7 @@ export class WebUSBLedgerAdapter {
 
     this.connectTimestamp = e.timeStamp
 
-    await timeout(1000) // timeout gives time to detect if it is an app navigation based disconnec/connect event
+    await timeout(APP_NAVIGATION_DELAY) // timeout gives time to detect if it is an app navigation based disconnec/connect event
 
     try {
       await this.initialize(e.device)
@@ -46,7 +47,7 @@ export class WebUSBLedgerAdapter {
   private async handleDisconnectWebUSBLedger(e: USBConnectionEvent): Promise<void> {
     if (e.device.vendorId !== VENDOR_ID) return
 
-    await timeout(1000) // timeout gives time to detect if it is an app navigation based disconnec/connect event
+    await timeout(APP_NAVIGATION_DELAY) // timeout gives time to detect if it is an app navigation based disconnec/connect event
 
     if (this.connectTimestamp !== 0) return
 

--- a/packages/hdwallet-ledger-webusb/src/adapter.ts
+++ b/packages/hdwallet-ledger-webusb/src/adapter.ts
@@ -9,11 +9,6 @@ function timeout(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function sleep(fn, ...args) {
-    await timeout(3000);
-    return fn(...args);
-}
-
 export class WebUSBLedgerAdapter {
   keyring: Keyring
   connectTimestamp: number = 0

--- a/packages/hdwallet-ledger-webusb/src/transport.ts
+++ b/packages/hdwallet-ledger-webusb/src/transport.ts
@@ -71,7 +71,6 @@ export class LedgerWebUsbTransport extends LedgerTransport {
   }
 
   public async open() {
-    const ledgerTransport = await getTransport()
     this.transport = await getTransport()
   }
 


### PR DESCRIPTION
Use timeout to determine if usb events are due to app navigation or actual connecting/disconnecting of the device.

This works because for the app navigation events, we are always presented with a disconnect event immediately followed by a connect event. Therefore, if we add the sleep in `handleDisconnect` and give enough time for the connect event to be received and timestamp tracked, we can be sure it was due to app navigation. (we really need to stress test this hard for any edge cases. nobody likes magic sleeps in code, but I can't think of a better way to accomplish this as of right now and even though it's ugly, it seems to provide us the desired behavior)

Connect is run regardless to re-establish the connection to the webusb transport. It would appear that because this is happening on a usb window event, it seems to be being treated as a "user event" and allows for the automatic transport reconnect? Only way I can explain it right now. 

It would appear the open/close around the call might be a fail just due to call stack size on various calls and if the "user event" is still visible at the time `open` is called (which it seems like there are various cases where this isn't true). Note, the open/close behavior attempt was tested on the vanilla branch without any of Ryan's retry logic in place. There did seem to be a difference when the retry logic was added and how open/close was being treated.