### PR TITLE
fix: nano x get firmware version call

### DIFF
--- a/packages/hdwallet-ledger-webusb/package.json
+++ b/packages/hdwallet-ledger-webusb/package.json
@@ -16,11 +16,11 @@
     "prepublishOnly": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@ledgerhq/hw-app-btc": "^4.48.0",
-    "@ledgerhq/hw-app-eth": "^4.48.0",
-    "@ledgerhq/hw-transport": "^4.48.0",
-    "@ledgerhq/hw-transport-webusb": "^4.48.0",
-    "@ledgerhq/live-common": "^7.15.4",
+    "@ledgerhq/hw-app-btc": "^4.73.4",
+    "@ledgerhq/hw-app-eth": "^4.73.4",
+    "@ledgerhq/hw-transport": "^4.73.4",
+    "@ledgerhq/hw-transport-webusb": "^4.73.4",
+    "@ledgerhq/live-common": "^8.4.1",
     "@shapeshiftoss/hdwallet-core": "^0.12.0",
     "@shapeshiftoss/hdwallet-ledger": "^0.12.0",
     "bytebuffer": "^5.0.1",

--- a/packages/hdwallet-ledger-webusb/src/adapter.ts
+++ b/packages/hdwallet-ledger-webusb/src/adapter.ts
@@ -1,7 +1,6 @@
 import { create as createLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { Events, Keyring, HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { LedgerWebUsbTransport, getFirstLedgerDevice, getTransport, openTransport } from './transport'
-import TransportWebUSB from '@ledgerhq/hw-transport-webusb'
 
 const VENDOR_ID = 11415
 const APP_NAVIGATION_DELAY = 1000

--- a/packages/hdwallet-ledger/package.json
+++ b/packages/hdwallet-ledger/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.4.0",
-    "@ledgerhq/live-common": "^7.15.4",
+    "@ledgerhq/live-common": "^8.4.1",
     "@shapeshiftoss/hdwallet-core": "^0.12.0",
     "base64-js": "^1.3.0",
     "bchaddrjs": "^0.4.4",

--- a/packages/hdwallet-ledger/src/ledger.ts
+++ b/packages/hdwallet-ledger/src/ledger.ts
@@ -323,12 +323,9 @@ export class LedgerHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
   }
 
   public async getFeatures (): Promise<any> {
-    const res = await this.transport.getDeviceInfo()
+    const res = await this.transport.call(null, 'getDeviceInfo')
     handleError(res, this.transport)
-    if (res.payload) { // no payload prop on the nano s
-      return res.payload
-    }
-    return res
+    return res.payload
   }
 
   public async getFirmwareVersion (): Promise<string> {

--- a/packages/hdwallet-ledger/src/ledger.ts
+++ b/packages/hdwallet-ledger/src/ledger.ts
@@ -325,7 +325,10 @@ export class LedgerHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
   public async getFeatures (): Promise<any> {
     const res = await this.transport.getDeviceInfo()
     handleError(res, this.transport)
-    return res.payload
+    if (res.payload) { // no payload prop on the nano s
+      return res.payload
+    }
+    return res
   }
 
   public async getFirmwareVersion (): Promise<string> {

--- a/packages/hdwallet-ledger/src/transport.ts
+++ b/packages/hdwallet-ledger/src/transport.ts
@@ -15,8 +15,6 @@ export abstract class LedgerTransport extends Transport {
     this.transport = transport
   }
 
-  public abstract async getDeviceInfo(): Promise<any>
-
   public abstract async call(coin: string, method: string, ...args: any[]): Promise<LedgerResponse>
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,6 +947,15 @@
   dependencies:
     commander "^2.20.0"
 
+"@ledgerhq/devices@4", "@ledgerhq/devices@^4.73.4":
+  version "4.73.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.73.4.tgz#0a1866fd1f10e2afc57c5f002f60d52ad5e6bb99"
+  integrity sha512-oEhd1UlbkdRFe5ZQCr8aXZ4Z/uFvrTsIhXv6bDlqA0sR2VYZRqQPR4C0xLdcDo3NG88fP+6Xfi6wq3wBbT5n3A==
+  dependencies:
+    "@ledgerhq/errors" "^4.73.4"
+    "@ledgerhq/logs" "^4.72.0"
+    rxjs "^6.5.3"
+
 "@ledgerhq/devices@^4.68.2":
   version "4.68.2"
   resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.68.2.tgz#73206d526ec3cd34eec49eddb31d8c0086bde518"
@@ -955,30 +964,21 @@
     "@ledgerhq/logs" "^4.68.2"
     rxjs "^6.5.2"
 
-"@ledgerhq/devices@^4.70.0":
-  version "4.70.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-4.70.0.tgz#db335f555851cd575edc9e08c4c7d8b468710d61"
-  integrity sha512-xgcPls2BJivdG4pK8l4RFBf0CaMUNApP0sb+Izr9OlwbOH9iyLcLL2XC9AJuvoHGO1DUkDrCM2TkXJIx3Ui+Xg==
-  dependencies:
-    "@ledgerhq/errors" "^4.70.0"
-    "@ledgerhq/logs" "^4.70.0"
-    rxjs "^6.5.3"
-
-"@ledgerhq/errors@4.70.0", "@ledgerhq/errors@^4.70.0":
-  version "4.70.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.70.0.tgz#3ec196ed8f1211ed2f4e84969c26e9e97a3a4bc0"
-  integrity sha512-XFFuVGJ34dhkIfqTUGudPvnSx3cRGuZ+oVr8lR4UFuc29TwDVjf1X4GJ5wQU4XUqS4rNe+I+Tq7BK7V1DFX9lQ==
+"@ledgerhq/errors@4", "@ledgerhq/errors@^4.73.4":
+  version "4.73.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.73.4.tgz#df4705d11350f252c0f0c202e88a32723f409484"
+  integrity sha512-5Wz48jm0NozGkipPcYRAAFcwm50xLhCWSpmP96Fs7v8BtM72E1AtqOud5SCyTKS6OP10mPuDB1459b7FGFoBcw==
 
 "@ledgerhq/errors@^4.68.2":
   version "4.68.2"
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.68.2.tgz#634f132c9c95935668ac2af90991ce57ebc44d63"
 
-"@ledgerhq/hw-app-btc@4.70.0":
-  version "4.70.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.70.0.tgz#5d458a89182d9b72b73163d2a41b680c0d99b8fd"
-  integrity sha512-KvSdJEnFFhR5JL1cYaavpnvzpi+7K1AZBE+jWj7VDOoA0zJkEbpVf7Ng+Eb+tqT0C4X1DW0gCdXZMIfTZ3OtgA==
+"@ledgerhq/hw-app-btc@4", "@ledgerhq/hw-app-btc@^4.73.4":
+  version "4.73.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.73.4.tgz#388a43e7eca8a8e5a94e1d11e8e4e25ca1aa4793"
+  integrity sha512-37iVrcy1Nv9VH2cYfw3/wm6cKNSTEiYXTo3Gq9TNLY1IlmV9qWsB200z40qiVWoVP0La65b/Yi/AMY9+ML95kQ==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.70.0"
+    "@ledgerhq/hw-transport" "^4.73.4"
     create-hash "^1.1.3"
 
 "@ledgerhq/hw-app-btc@^4.48.0":
@@ -988,13 +988,13 @@
     "@ledgerhq/hw-transport" "^4.68.2"
     create-hash "^1.1.3"
 
-"@ledgerhq/hw-app-eth@4.70.0":
-  version "4.70.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.70.0.tgz#2ddf3be88c983f2e7575229a97b3b4e20f7710a1"
-  integrity sha512-wifUwsdlENpW0TPBDlhDk+NADW3fIcaudIBEaEURvmOXoy0BGdfxfgeBuXrPW9UUiF6VLWVEjlmlSEDJI3GrFw==
+"@ledgerhq/hw-app-eth@4", "@ledgerhq/hw-app-eth@^4.73.4":
+  version "4.73.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-4.73.4.tgz#3696df17c819dea213da56c4841341db7fb571aa"
+  integrity sha512-MJZlzVj6s/ZRQBikNo6Z9n5N/RQLc78xF+Esxo8C9RnFj0K0mTW6J0fqwqRwyfSJrJblAQE3ucTNAoXI4vJDPg==
   dependencies:
-    "@ledgerhq/errors" "^4.70.0"
-    "@ledgerhq/hw-transport" "^4.70.0"
+    "@ledgerhq/errors" "^4.73.4"
+    "@ledgerhq/hw-transport" "^4.73.4"
 
 "@ledgerhq/hw-app-eth@^4.48.0":
   version "4.68.2"
@@ -1003,21 +1003,21 @@
     "@ledgerhq/errors" "^4.68.2"
     "@ledgerhq/hw-transport" "^4.68.2"
 
-"@ledgerhq/hw-app-xrp@4.70.0":
-  version "4.70.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-4.70.0.tgz#c2893217b3ed07bba138ad99a8bd767a0b67af7b"
-  integrity sha512-pmr193Mh+wa0ppYJEqfvP0C8HJUTaXQRo67m5JwbHaCRtD51xax6KgTRKJyWY02UBPajjIUShEEiPH4uAYXzFA==
+"@ledgerhq/hw-app-xrp@4":
+  version "4.73.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-4.73.4.tgz#a7e0f31932fa604b8a78cd74c3bf5e3a208f8c13"
+  integrity sha512-DKBFLjSOqMeZz10mP41YATiImsMlELf5RrC4ezf11m1NHXtS7dCj3FB/eqcTUFuhpeVoCtsrYh9FkQhkeVU8IQ==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.70.0"
+    "@ledgerhq/hw-transport" "^4.73.4"
     bip32-path "0.4.2"
 
-"@ledgerhq/hw-transport-mocker@4.70.0":
-  version "4.70.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-4.70.0.tgz#8e007c183eef27ee06599f90b4f05054e5a4cf6c"
-  integrity sha512-0hDHpNbNc6bNCPibG+xs82Wu9kdEV78K4ivzYvXE/ZlMTxP/j64i4MmQnvsGRGG6dLGiO6R/nkx75v1WHDh6Hg==
+"@ledgerhq/hw-transport-mocker@4":
+  version "4.73.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-4.73.4.tgz#e38fcca700c036864e07dfc17306e8a1b9007db2"
+  integrity sha512-OIx4lm1C8yoehr51k/PBAJoGEGhxfkwHKMkAtgY63j4j4WVC2aTnSKEtKrxy8yXvgiXBi0QEHSx3MX/rY4LbKQ==
   dependencies:
-    "@ledgerhq/hw-transport" "^4.70.0"
-    "@ledgerhq/logs" "^4.70.0"
+    "@ledgerhq/hw-transport" "^4.73.4"
+    "@ledgerhq/logs" "^4.72.0"
 
 "@ledgerhq/hw-transport-u2f@^4.48.0":
   version "4.68.2"
@@ -1028,22 +1028,23 @@
     "@ledgerhq/logs" "^4.68.2"
     u2f-api "0.2.7"
 
-"@ledgerhq/hw-transport-webusb@^4.48.0":
-  version "4.68.2"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-4.68.2.tgz#3874dee59b4dec9206a5559b46e3e5a890de4c4f"
+"@ledgerhq/hw-transport-webusb@^4.73.4":
+  version "4.73.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-webusb/-/hw-transport-webusb-4.73.4.tgz#63ade8af29a02b16fd97a3a1c13732531f676d80"
+  integrity sha512-AKsIqMOhf4vHykSfvCUMvRIvsKkoVyqi92dNMR7M8ExCT1jh+Jh/FyjZvCHaHMJwyd1Dg9L81fUVeQTwvjC3JA==
   dependencies:
-    "@ledgerhq/devices" "^4.68.2"
-    "@ledgerhq/errors" "^4.68.2"
-    "@ledgerhq/hw-transport" "^4.68.2"
-    "@ledgerhq/logs" "^4.68.2"
+    "@ledgerhq/devices" "^4.73.4"
+    "@ledgerhq/errors" "^4.73.4"
+    "@ledgerhq/hw-transport" "^4.73.4"
+    "@ledgerhq/logs" "^4.72.0"
 
-"@ledgerhq/hw-transport@4.70.0", "@ledgerhq/hw-transport@^4.70.0":
-  version "4.70.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.70.0.tgz#2733b83c6d600f8d3c5ffb588d010e40b9d0bcc3"
-  integrity sha512-kl3TGlpy6iH3byVT+9Df9ObN3Ahi7O6eg8FHAWORO4jGUHROPiI8FYL03DTEvBXG5GqyKN1NfvvcKyC3N2dL2w==
+"@ledgerhq/hw-transport@4", "@ledgerhq/hw-transport@^4.73.4":
+  version "4.73.4"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-4.73.4.tgz#e3b58eebbc99b003406838660b7d17611e02ebc7"
+  integrity sha512-UAw7v+le8pyEz+q2sA0TVS9WGmifKqGxuwcYz+hN1quJkfTmivvcHCuSF5t7BDCuuuRNoCT36YjnIzf363Tf2w==
   dependencies:
-    "@ledgerhq/devices" "^4.70.0"
-    "@ledgerhq/errors" "^4.70.0"
+    "@ledgerhq/devices" "^4.73.4"
+    "@ledgerhq/errors" "^4.73.4"
     events "^3.0.0"
 
 "@ledgerhq/hw-transport@^4.48.0", "@ledgerhq/hw-transport@^4.68.2":
@@ -1054,20 +1055,25 @@
     "@ledgerhq/errors" "^4.68.2"
     events "^3.0.0"
 
-"@ledgerhq/live-common@^7.15.4":
-  version "7.15.4"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-7.15.4.tgz#adac72bc103ee2c6b0b59156ae02f8c88743d754"
-  integrity sha512-RgyMYcOz/P/1gd7yoc7+pxyGK2iXK+HwyoZXR+wyi4iCiW+2s20jeBnaFKIaJOVa5c3HQW2A98TIwGw6t0NWdA==
+"@ledgerhq/live-common@^8.4.1":
+  version "8.4.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-8.4.1.tgz#e60726692e6e669e3ec5eca594bffe42659ed651"
+  integrity sha512-geJdm/lF2qAS+0UAIpq0TphzItXVUsL4/GJZkcz/3wc1JKcUgTPn1+xLpy1URVZPPuWq4nHcST9PQYF4ZYjGRg==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
-    "@ledgerhq/errors" "4.70.0"
-    "@ledgerhq/hw-app-btc" "4.70.0"
-    "@ledgerhq/hw-app-eth" "4.70.0"
-    "@ledgerhq/hw-app-xrp" "4.70.0"
-    "@ledgerhq/hw-transport" "4.70.0"
-    "@ledgerhq/hw-transport-mocker" "4.70.0"
-    "@ledgerhq/logs" "4.70.0"
+    "@ledgerhq/devices" "4"
+    "@ledgerhq/errors" "4"
+    "@ledgerhq/hw-app-btc" "4"
+    "@ledgerhq/hw-app-eth" "4"
+    "@ledgerhq/hw-app-xrp" "4"
+    "@ledgerhq/hw-transport" "4"
+    "@ledgerhq/hw-transport-mocker" "4"
+    "@ledgerhq/logs" "4"
     bignumber.js "^9.0.0"
+    bip32-path "^0.4.2"
+    blake2b "^2.1.3"
+    bs58check "^2.1.2"
+    crypto-js "^3.1.9-1"
     eip55 "^1.0.3"
     ethereumjs-tx "^1.3.7"
     invariant "^2.2.2"
@@ -1075,7 +1081,7 @@
     lru-cache "5.1.1"
     numeral "^2.0.6"
     prando "^5.1.1"
-    react "16.9.0"
+    react "16.11.0"
     react-redux "5"
     redux "^4.0.4"
     reselect "^4.0.0"
@@ -1085,11 +1091,12 @@
     ripple-lib "1.1.2"
     rxjs "^6.5.3"
     rxjs-compat "^6.5.3"
+    sha.js "^2.4.11"
 
-"@ledgerhq/logs@4.70.0", "@ledgerhq/logs@^4.70.0":
-  version "4.70.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.70.0.tgz#b5176430ccb5a81becce25fcbbd8afcfa91a4388"
-  integrity sha512-hyMppU1b2tBDRyKJiV71RnN51Tkkriv/7DHQF9thAmrwEDFmfmEwAQaS2VyeIogir0HD7aDcKg7DnHqgiWe/8g==
+"@ledgerhq/logs@4", "@ledgerhq/logs@^4.72.0":
+  version "4.72.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-4.72.0.tgz#43df23af013ad1135407e5cf33ca6e4c4c7708d5"
+  integrity sha512-o+TYF8vBcyySRsb2kqBDv/KMeme8a2nwWoG+lAWzbDmWfb2/MrVWYCVYDYvjXdSoI/Cujqy1i0gIDrkdxa9chA==
 
 "@ledgerhq/logs@^4.68.2":
   version "4.68.2"
@@ -3210,6 +3217,21 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+blake2b-wasm@^1.1.0:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/blake2b-wasm/-/blake2b-wasm-1.1.7.tgz#e4d075da10068e5d4c3ec1fb9accc4d186c55d81"
+  integrity sha512-oFIHvXhlz/DUgF0kq5B1CqxIDjIJwh9iDeUUGQUcvgiGz7Wdw03McEO7CfLBy7QKGdsydcMCgO9jFNBAFCtFcA==
+  dependencies:
+    nanoassert "^1.0.0"
+
+blake2b@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/blake2b/-/blake2b-2.1.3.tgz#f5388be424768e7c6327025dad0c3c6d83351bca"
+  integrity sha512-pkDss4xFVbMb4270aCyGD3qLv92314Et+FsKzilCLxDz5DuZ2/1g3w4nmBbu6nKApPspnjG7JcwTjGZnduB1yg==
+  dependencies:
+    blake2b-wasm "^1.1.0"
+    nanoassert "^1.0.0"
+
 bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.5.5"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
@@ -4238,6 +4260,11 @@ crypto-browserify@3.12.0, crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
+
+crypto-js@^3.1.9-1:
+  version "3.1.9-1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
+  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
 
 crypto@^1.0.1:
   version "1.0.1"
@@ -8733,6 +8760,11 @@ nano-json-stream-parser@^0.1.2:
   resolved "https://registry.yarnpkg.com/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz#0cc8f6d0e2b622b479c40d499c46d64b755c6f5f"
   integrity sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18=
 
+nanoassert@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/nanoassert/-/nanoassert-1.1.0.tgz#4f3152e09540fde28c76f44b19bbcd1d5a42478d"
+  integrity sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40=
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -10591,10 +10623,10 @@ react-redux@5:
     react-is "^16.6.0"
     react-lifecycles-compat "^3.0.0"
 
-react@16.9.0:
-  version "16.9.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.9.0.tgz#40ba2f9af13bc1a38d75dbf2f4359a5185c4f7aa"
-  integrity sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==
+react@16.11.0:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
+  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -11602,7 +11634,7 @@ setprototypeof@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
 
-sha.js@^2.4.0, sha.js@^2.4.8:
+sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   dependencies:


### PR DESCRIPTION
as titled
- looks like the call to ledger-live common returns diff payloads based on the device type
`this.transport.getDeviceInfo()`

- also updates ledger deps to latest release since [i noticed the version call fix on this release](https://github.com/LedgerHQ/ledger-live-common/releases/tag/v8.0.0) (happy to make that a separate PR if we are concerned about other breaking changes..