### PR TITLE
fix: better guards for is object

### DIFF
--- a/packages/hdwallet-core/package.json
+++ b/packages/hdwallet-core/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "eventemitter2": "^5.0.1",
+    "lodash": "^4.17.15",
     "rxjs": "^6.4.0"
   },
   "devDependencies": {

--- a/packages/hdwallet-core/src/wallet.test.ts
+++ b/packages/hdwallet-core/src/wallet.test.ts
@@ -3,7 +3,7 @@ import {
     infoETH,
     supportsBTC,
     supportsETH,
-    supportsDebugLink
+    supportsDebugLink, HDWallet
 } from './wallet'
 
 describe("wallet : guards", () => {
@@ -12,7 +12,8 @@ describe("wallet : guards", () => {
         infoETH,
         supportsBTC,
         supportsETH,
-        supportsDebugLink])
+        supportsDebugLink
+    ])
     (
         'should return falsy for `null`',
         (method) => {
@@ -20,5 +21,26 @@ describe("wallet : guards", () => {
             expect(method(null)).toBeFalsy()
             expect(method({})).toBeFalsy()
         }
+    )
+
+    it(
+        'infoBTC should be truthy',
+        () => expect(infoBTC(({ _supportsBTCInfo: true } as HDWallet))).toBeTruthy()
+    )
+    it(
+        'infoETH should be truthy',
+        () => expect(infoETH(({ _supportsETHInfo: true } as HDWallet))).toBeTruthy()
+    )
+    it(
+        'supportsBTC should be truthy',
+        () => expect(supportsBTC(({ _supportsBTC: true } as HDWallet))).toBeTruthy()
+    )
+    it(
+        'supportsETH should be truthy',
+        () => expect(supportsETH(({ _supportsETH: true } as HDWallet))).toBeTruthy()
+    )
+    it(
+        'supportsDebugLink should be truthy',
+        () => expect(supportsDebugLink(({ _supportsDebugLink: true } as HDWallet))).toBeTruthy()
     )
 })

--- a/packages/hdwallet-core/src/wallet.test.ts
+++ b/packages/hdwallet-core/src/wallet.test.ts
@@ -6,7 +6,7 @@ import {
     supportsDebugLink
 } from './wallet'
 
-describe("wallet : supportsETH", () => {
+describe("wallet : guards", () => {
     it("should return falsy for `null`", () => {
         [
             infoBTC,

--- a/packages/hdwallet-core/src/wallet.test.ts
+++ b/packages/hdwallet-core/src/wallet.test.ts
@@ -1,0 +1,23 @@
+import {
+    infoBTC,
+    infoETH,
+    supportsBTC,
+    supportsETH,
+    supportsDebugLink
+} from './wallet'
+
+describe("wallet : supportsETH", () => {
+    it("should return falsy for `null`", () => {
+        [
+            infoBTC,
+            infoETH,
+            supportsBTC,
+            supportsETH,
+            supportsDebugLink
+        ].forEach(method => {
+            expect(method(undefined)).toBeFalsy()
+            expect(method(null)).toBeFalsy()
+            expect(method({})).toBeFalsy()
+        })
+    })
+})

--- a/packages/hdwallet-core/src/wallet.test.ts
+++ b/packages/hdwallet-core/src/wallet.test.ts
@@ -7,17 +7,18 @@ import {
 } from './wallet'
 
 describe("wallet : guards", () => {
-    it("should return falsy for `null`", () => {
-        [
-            infoBTC,
-            infoETH,
-            supportsBTC,
-            supportsETH,
-            supportsDebugLink
-        ].forEach(method => {
+    it.each([
+        infoBTC,
+        infoETH,
+        supportsBTC,
+        supportsETH,
+        supportsDebugLink])
+    (
+        'should return falsy for `null`',
+        (method) => {
             expect(method(undefined)).toBeFalsy()
             expect(method(null)).toBeFalsy()
             expect(method({})).toBeFalsy()
-        })
-    })
+        }
+    )
 })

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -10,6 +10,7 @@ import {
 } from './ethereum'
 import { DebugLinkWallet } from './debuglink'
 import { Transport } from './transport';
+import { isObject } from 'lodash';
 
 export type BIP32Path = Array<number>
 
@@ -113,11 +114,11 @@ export type Coin = string
  ```
  */
 export function supportsBTC(wallet: any): wallet is BTCWallet {
-  return typeof wallet === 'object' && wallet._supportsBTC === true
+  return isObject(wallet) && wallet._supportsBTC === true
 }
 
 export function infoBTC(info: any): info is BTCWalletInfo {
-  return typeof info === 'object' && info._supportsBTCInfo === true
+  return isObject(info) && info._supportsBTCInfo === true
 }
 
 /**
@@ -131,15 +132,15 @@ export function infoBTC(info: any): info is BTCWalletInfo {
  ```
  */
 export function supportsETH(wallet: any): wallet is ETHWallet {
-  return typeof wallet === 'object' && wallet._supportsETH === true
+  return isObject(wallet) && wallet._supportsETH === true
 }
 
 export function infoETH(info: any): info is ETHWalletInfo {
-  return typeof info === 'object' && info._supportsETHInfo === true
+  return isObject(info) && info._supportsETHInfo === true
 }
 
 export function supportsDebugLink(wallet: any): wallet is DebugLinkWallet {
-  return typeof wallet === 'object' && wallet._supportsDebugLink === true
+  return isObject(wallet) && wallet._supportsDebugLink === true
 }
 
 export interface HDWalletInfo {

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -114,11 +114,11 @@ export type Coin = string
  ```
  */
 export function supportsBTC(wallet: any): wallet is BTCWallet {
-  return isObject(wallet) && wallet._supportsBTC === true
+  return isObject(wallet) && (wallet as HDWallet)._supportsBTC === true
 }
 
 export function infoBTC(info: any): info is BTCWalletInfo {
-  return isObject(info) && info._supportsBTCInfo === true
+  return isObject(info) && (info as HDWallet)._supportsBTCInfo === true
 }
 
 /**
@@ -132,15 +132,15 @@ export function infoBTC(info: any): info is BTCWalletInfo {
  ```
  */
 export function supportsETH(wallet: any): wallet is ETHWallet {
-  return isObject(wallet) && wallet._supportsETH === true
+  return isObject(wallet) && (wallet as HDWallet)._supportsETH === true
 }
 
 export function infoETH(info: any): info is ETHWalletInfo {
-  return isObject(info) && info._supportsETHInfo === true
+  return isObject(info) && (info as ETHWalletInfo)._supportsETHInfo === true
 }
 
 export function supportsDebugLink(wallet: any): wallet is DebugLinkWallet {
-  return isObject(wallet) && wallet._supportsDebugLink === true
+  return isObject(wallet) && (wallet as HDWallet)._supportsDebugLink === true
 }
 
 export interface HDWalletInfo {

--- a/packages/hdwallet-keepkey/package.json
+++ b/packages/hdwallet-keepkey/package.json
@@ -24,7 +24,8 @@
     "@types/eventemitter2": "^4.1.0",
     "eip55": "^1.0.3",
     "ethereumjs-tx": "^1.3.7",
-    "eventemitter2": "^5.0.1"
+    "eventemitter2": "^5.0.1",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@types/ethereumjs-tx": "^1.0.1",

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -50,7 +50,7 @@ import {
 } from "@shapeshiftoss/hdwallet-core";
 import * as Messages from "@keepkey/device-protocol/lib/messages_pb";
 import * as Types from "@keepkey/device-protocol/lib/types_pb";
-
+import { isObject } from 'lodash';
 import { messageTypeRegistry } from "./typeRegistry";
 import {
   protoFieldToSetMethod,
@@ -62,7 +62,7 @@ import * as Eth from "./ethereum"
 import { KeepKeyTransport } from "./transport";
 
 export function isKeepKey(wallet: HDWallet): wallet is KeepKeyHDWallet {
-  return typeof wallet === 'object' && (wallet as any)._isKeepKey === true
+  return isObject(wallet) && (wallet as any)._isKeepKey === true
 }
 
 function describeETHPath (path: BIP32Path): PathDescription {

--- a/packages/hdwallet-ledger/src/ledger.ts
+++ b/packages/hdwallet-ledger/src/ledger.ts
@@ -11,9 +11,10 @@ import {
   networksUtil,
   parseHexString
 } from './utils'
+import { isObject } from 'lodash'
 
 export function isLedger (wallet: core.HDWallet): wallet is LedgerHDWallet {
-  return typeof wallet === 'object' && (wallet as any)._isLedger === true
+  return isObject(wallet) && (wallet as any)._isLedger === true
 }
 
 function describeETHPath (path: core.BIP32Path): core.PathDescription {

--- a/packages/hdwallet-portis/package.json
+++ b/packages/hdwallet-portis/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@portis/web3": "^2.0.0-beta.45",
     "eventemitter2": "^5.0.1",
+    "lodash": "^4.17.15",
     "web3": "^1.2.1"
   }
 }

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -29,6 +29,7 @@ import {
   HDWalletInfo,
   ETHWalletInfo
 } from "@shapeshiftoss/hdwallet-core"
+import { isObject } from 'lodash';
 
 function describeETHPath (path: BIP32Path): PathDescription {
   let pathStr = addressNListToBIP32(path)
@@ -79,7 +80,7 @@ class PortisTransport extends Transport {
 }
 
 export function isPortis(wallet: HDWallet): wallet is PortisHDWallet {
-  return typeof wallet === 'object' && (wallet as any)._isPortis === true
+  return isObject(wallet) && (wallet as any)._isPortis === true
 }
 
 export class PortisHDWallet implements HDWallet, ETHWallet {
@@ -91,7 +92,7 @@ export class PortisHDWallet implements HDWallet, ETHWallet {
   _isPortis: boolean = true
 
   transport = new PortisTransport(new Keyring())
-  
+
   portis: any
   web3: any
   info: PortisHDWalletInfo & HDWalletInfo
@@ -278,7 +279,7 @@ export class PortisHDWallet implements HDWallet, ETHWallet {
         r: result.tx.r,
         s:  result.tx.s,
         serialized: result.raw
-    } 
+    }
   }
 
   public async ethSignMessage (msg: ETHSignMessage): Promise<ETHSignedMessage> {

--- a/packages/hdwallet-trezor/package.json
+++ b/packages/hdwallet-trezor/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "@shapeshiftoss/hdwallet-core": "^0.12.0",
     "ethereumjs-tx": "^1.3.7",
-    "eventemitter2": "^5.0.1"
+    "eventemitter2": "^5.0.1",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "@types/ethereumjs-tx": "^1.0.1",

--- a/packages/hdwallet-trezor/src/trezor.ts
+++ b/packages/hdwallet-trezor/src/trezor.ts
@@ -46,9 +46,10 @@ import { handleError } from './utils'
 import * as Btc from './bitcoin'
 import * as Eth from './ethereum'
 import { TrezorTransport } from './transport'
+import { isObject } from 'lodash';
 
 export function isTrezor(wallet: HDWallet): wallet is TrezorHDWallet {
-  return typeof wallet === 'object' && (wallet as any)._isTrezor === true
+  return isObject(wallet) && (wallet as any)._isTrezor === true
 }
 
 function describeETHPath (path: BIP32Path): PathDescription {


### PR DESCRIPTION
[use lodash.isObject for object checks](https://lodash.com/docs/4.17.15#isObject)
to prevent stuff like this
```
typeof null === 'object'
true
```
from happening

testing: 
`./node_modules/.bin/jest -t  'wallet : guards'`