### PR TITLE
Improve Native Wallet Initialization Performance

### DIFF
--- a/packages/hdwallet-native/src/bitcoin.ts
+++ b/packages/hdwallet-native/src/bitcoin.ts
@@ -182,8 +182,8 @@ export function MixinNativeBTCWallet<TBase extends core.Constructor>(Base: TBase
       };
     }
 
-    async btcInitializeWallet(mnemonic: string): Promise<void> {
-      this.seed = Buffer.from(await mnemonicToSeed(mnemonic));
+    async btcInitializeWallet(seed: Buffer): Promise<void> {
+      this.seed = seed;
     }
 
     async btcGetAddress(msg: core.BTCGetAddress): Promise<string> {

--- a/packages/hdwallet-native/src/ethereum.ts
+++ b/packages/hdwallet-native/src/ethereum.ts
@@ -1,7 +1,7 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
 import { Wallet, utils } from "ethers";
 import txDecoder from "ethereum-tx-decoder";
-import { HDNode, defaultPath } from "ethers/lib.esm/utils";
+import { HDNode, defaultPath } from "@ethersproject/hdnode";
 
 export function MixinNativeETHWalletInfo<TBase extends core.Constructor>(Base: TBase) {
   return class MixinNativeETHWalletInfo extends Base implements core.ETHWalletInfo {

--- a/packages/hdwallet-native/src/ethereum.ts
+++ b/packages/hdwallet-native/src/ethereum.ts
@@ -1,6 +1,7 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
 import { Wallet, utils } from "ethers";
 import txDecoder from "ethereum-tx-decoder";
+import { HDNode, defaultPath } from "ethers/lib.esm/utils";
 
 export function MixinNativeETHWalletInfo<TBase extends core.Constructor>(Base: TBase) {
   return class MixinNativeETHWalletInfo extends Base implements core.ETHWalletInfo {
@@ -43,8 +44,8 @@ export function MixinNativeETHWallet<TBase extends core.Constructor>(Base: TBase
 
     ethWallet: Wallet;
 
-    ethInitializeWallet(mnemonic: string): void {
-      this.ethWallet = Wallet.fromMnemonic(mnemonic);
+    ethInitializeWallet(seed: string): void {
+      this.ethWallet = new Wallet(HDNode.fromSeed(seed).derivePath(defaultPath));
     }
 
     async ethGetAddress(msg: core.ETHGetAddress): Promise<string> {

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -78,9 +78,8 @@ export class NativeHDWallet extends MixinNativeBTCWallet(MixinNativeETHWallet(Na
 
   private mnemonic: string;
 
-  constructor(mnemonic: string, deviceId: string, seed?: string) {
+  constructor(mnemonic: string, deviceId: string) {
     super();
-    console.log("constructing native wallet for device ", deviceId);
     this.mnemonic = mnemonic;
     this.deviceId = deviceId;
   }
@@ -132,17 +131,10 @@ export class NativeHDWallet extends MixinNativeBTCWallet(MixinNativeETHWallet(Na
   async clearSession(): Promise<void> {}
 
   async initialize(): Promise<any> {
-    const start = Date.now();
     const seed = await mnemonicToSeed(this.mnemonic);
-    console.log(`converted  mnemonicToSeed in ${Date.now() - start}ms`);
-    const estart = Date.now();
     super.ethInitializeWallet("0x" + seed.toString("hex"));
-    console.log(`initializedEthWallet in ${Date.now() - estart}ms`);
-    const bstart = Date.now();
     await super.btcInitializeWallet(seed);
-    console.log(`initializedBtcWallet in ${Date.now() - bstart}ms`);
     this.initialized = true;
-    console.log(`Native.initialize done in ${Date.now() - start}ms`);
   }
 
   async ping(msg: core.Ping): Promise<core.Pong> {


### PR DESCRIPTION
Derive seed once using bip39.js mnemonicToSeed. Use that seed to initialize each native wallet.