### PR TITLE
[native] Block all access to mnemonic outside of the class

### DIFF
--- a/packages/hdwallet-native/src/native.test.ts
+++ b/packages/hdwallet-native/src/native.test.ts
@@ -1,0 +1,11 @@
+import { NativeHDWallet } from "./native";
+
+describe("hdwallet-native", () => {
+  it("should keep mnemonic private", () => {
+    const wallet = new NativeHDWallet("all all all all", "deviceId");
+    const json = JSON.stringify(wallet);
+    expect(json).not.toMatch(/mnemonic|all/);
+    expect(Object.getOwnPropertyNames(wallet).filter((p) => p.includes("mnemonic")).length).toBe(0);
+    expect(require("util").inspect(wallet, { showHidden: true }).includes("mnemonic")).toBe(false);
+  });
+});

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -73,19 +73,18 @@ export class NativeHDWallet extends MixinNativeBTCWallet(MixinNativeETHWallet(Na
   _supportsDebugLink = false;
   _isNative = true;
 
-  deviceId: string;
-  initialized: boolean;
-
-  private mnemonic: string;
+  readonly #deviceId: string;
+  #initialized: boolean;
+  #mnemonic: string;
 
   constructor(mnemonic: string, deviceId: string) {
     super();
-    this.mnemonic = mnemonic;
-    this.deviceId = deviceId;
+    this.#mnemonic = mnemonic;
+    this.#deviceId = deviceId;
   }
 
   async getDeviceID(): Promise<string> {
-    return this.deviceId;
+    return this.#deviceId;
   }
 
   async getFirmwareVersion(): Promise<string> {
@@ -108,7 +107,7 @@ export class NativeHDWallet extends MixinNativeBTCWallet(MixinNativeETHWallet(Na
     return Promise.all(
       msg.map(async (getPublicKey) => {
         let { addressNList } = getPublicKey;
-        const seed = await mnemonicToSeed(this.mnemonic);
+        const seed = await mnemonicToSeed(this.#mnemonic);
         const network = getNetwork(getPublicKey.coin, getPublicKey.scriptType);
         const node = fromSeed(seed, network);
         const xpub = node
@@ -121,7 +120,7 @@ export class NativeHDWallet extends MixinNativeBTCWallet(MixinNativeETHWallet(Na
   }
 
   async isInitialized(): Promise<boolean> {
-    return this.initialized;
+    return this.#initialized;
   }
 
   async isLocked(): Promise<boolean> {
@@ -131,10 +130,10 @@ export class NativeHDWallet extends MixinNativeBTCWallet(MixinNativeETHWallet(Na
   async clearSession(): Promise<void> {}
 
   async initialize(): Promise<any> {
-    const seed = await mnemonicToSeed(this.mnemonic);
+    const seed = await mnemonicToSeed(this.#mnemonic);
     super.ethInitializeWallet("0x" + seed.toString("hex"));
     await super.btcInitializeWallet(seed);
-    this.initialized = true;
+    this.#initialized = true;
   }
 
   async ping(msg: core.Ping): Promise<core.Pong> {
@@ -158,8 +157,8 @@ export class NativeHDWallet extends MixinNativeBTCWallet(MixinNativeETHWallet(Na
   async recover(): Promise<void> {}
 
   async loadDevice(msg: core.LoadDevice): Promise<void> {
-    this.mnemonic = msg.mnemonic;
-    this.initialized = false;
+    this.#mnemonic = msg.mnemonic;
+    this.#initialized = false;
     await this.initialize();
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "esnext",
+    "target": "ES2016",
     "module": "commonjs",
     "lib": ["es2016", "dom", "es5"],
     "declaration": true,


### PR DESCRIPTION
[hdwallet-native]
* Use the private class field proposal to make mnemonic a truly private variable
* Add a test to verify that the mnemonic doesn't get leaked when using several different serialization methods
