### PR TITLE
Move common helper functions into core

### DIFF
--- a/packages/hdwallet-core/src/binance.ts
+++ b/packages/hdwallet-core/src/binance.ts
@@ -123,3 +123,26 @@ export function binanceDescribePath(path: BIP32Path): PathDescription {
     isPrefork: false,
   };
 }
+
+export function binanceNextAccountPath(msg: BinanceAccountPath): BinanceAccountPath | undefined {
+  let description = binanceDescribePath(msg.addressNList);
+  if (!description.isKnown) {
+    return undefined;
+  }
+
+  let addressNList = msg.addressNList;
+  addressNList[2] += 1;
+
+  return {
+    ...msg,
+    addressNList,
+  };
+}
+
+export function binanceGetAccountPaths(msg: BinanceGetAccountPaths): BinanceAccountPath[] {
+  return [
+    {
+      addressNList: [0x80000000 + 44, 0x80000000 + slip44ByCoin("Binance"), 0x80000000 + msg.accountIdx, 0, 0],
+    },
+  ];
+}

--- a/packages/hdwallet-core/src/cosmos.ts
+++ b/packages/hdwallet-core/src/cosmos.ts
@@ -130,3 +130,26 @@ export function cosmosDescribePath(path: BIP32Path): PathDescription {
     isPrefork: false,
   };
 }
+
+export function cosmosNextAccountPath(msg: CosmosAccountPath): CosmosAccountPath | undefined {
+  let description = cosmosDescribePath(msg.addressNList);
+  if (!description.isKnown) {
+    return undefined;
+  }
+
+  let addressNList = msg.addressNList;
+  addressNList[2] += 1;
+
+  return {
+    ...msg,
+    addressNList,
+  };
+}
+
+export function cosmosGetAccountPaths(msg: CosmosGetAccountPaths): CosmosAccountPath[] {
+  return [
+    {
+      addressNList: [0x80000000 + 44, 0x80000000 + slip44ByCoin("Atom"), 0x80000000 + msg.accountIdx, 0, 0],
+    },
+  ];
+}

--- a/packages/hdwallet-core/src/eos.ts
+++ b/packages/hdwallet-core/src/eos.ts
@@ -1,4 +1,5 @@
-import { BIP32Path } from "./wallet";
+import { addressNListToBIP32, slip44ByCoin } from "./utils";
+import { BIP32Path, PathDescription } from "./wallet";
 
 export interface EosGetPublicKey {
   addressNList: Array<number>;
@@ -90,4 +91,58 @@ export interface EosWallet extends EosWalletInfo {
 
   eosGetPublicKey(msg: EosGetPublicKey): Promise<string>;
   eosSignTx(msg: EosToSignTx): Promise<EosTxSigned>;
+}
+
+export function eosDescribePath(path: BIP32Path): PathDescription {
+  let pathStr = addressNListToBIP32(path);
+  let unknown: PathDescription = {
+    verbose: pathStr,
+    coin: "Eos",
+    isKnown: false,
+  };
+
+  if (path.length != 5) {
+    return unknown;
+  }
+
+  if (path[0] != 0x80000000 + 44) {
+    return unknown;
+  }
+
+  if (path[1] != 0x80000000 + slip44ByCoin("Eos")) {
+    return unknown;
+  }
+
+  if ((path[2] & 0x80000000) >>> 0 !== 0x80000000) {
+    return unknown;
+  }
+
+  if (path[3] !== 0 || path[4] !== 0) {
+    return unknown;
+  }
+
+  let index = path[2] & 0x7fffffff;
+  return {
+    verbose: `Eos Account #${index}`,
+    accountIdx: index,
+    wholeAccount: true,
+    coin: "Eos",
+    isKnown: true,
+    isPrefork: false,
+  };
+}
+
+export function eosNextAccountPath(msg: EosAccountPath): EosAccountPath | undefined {
+  let description = eosDescribePath(msg.addressNList);
+  if (!description.isKnown) {
+    return undefined;
+  }
+
+  let addressNList = msg.addressNList;
+  addressNList[2] += 1;
+
+  return {
+    ...msg,
+    addressNList,
+  };
 }

--- a/packages/hdwallet-keepkey/src/binance.ts
+++ b/packages/hdwallet-keepkey/src/binance.ts
@@ -1,31 +1,14 @@
-import * as Core from "@shapeshiftoss/hdwallet-core";
-
-import { KeepKeyTransport } from "./transport";
-
 import {
-  BinanceGetAddress,
   BinanceAddress,
-  BinanceSignTx,
+  BinanceGetAddress,
   BinanceSignedTx,
+  BinanceSignTx,
   BinanceTransferMsg,
 } from "@keepkey/device-protocol/lib/messages-binance_pb";
 import { MessageType } from "@keepkey/device-protocol/lib/messages_pb";
+import * as Core from "@shapeshiftoss/hdwallet-core";
 
-export function binanceGetAccountPaths(
-  msg: Core.BinanceGetAccountPaths
-): Array<Core.BinanceAccountPath> {
-  return [
-    {
-      addressNList: [
-        0x80000000 + 44,
-        0x80000000 + Core.slip44ByCoin("Binance"),
-        0x80000000 + msg.accountIdx,
-        0,
-        0,
-      ],
-    },
-  ];
-}
+import { KeepKeyTransport } from "./transport";
 
 export async function binanceSignTx(
   transport: KeepKeyTransport,
@@ -40,8 +23,7 @@ export async function binanceSignTx(
     if (msg.tx.memo !== undefined) signTx.setMemo(msg.tx.memo);
 
     //verify not a batch tx
-    if (msg.tx.msgs.length > 1)
-      throw new Error("Binance batch sending not supported!");
+    if (msg.tx.msgs.length > 1) throw new Error("Binance batch sending not supported!");
     let message = msg.tx.msgs[0];
     //tell device not a batch tx
     signTx.setMsgCount(1);
@@ -107,18 +89,11 @@ export async function binanceSignTx(
   });
 }
 
-export async function binanceGetAddress(
-  transport: KeepKeyTransport,
-  msg: Core.BinanceGetAddress
-): Promise<string> {
+export async function binanceGetAddress(transport: KeepKeyTransport, msg: Core.BinanceGetAddress): Promise<string> {
   const getAddr = new BinanceGetAddress();
   getAddr.setAddressNList(msg.addressNList);
   getAddr.setShowDisplay(msg.showDisplay !== false);
-  const response = await transport.call(
-    MessageType.MESSAGETYPE_BINANCEGETADDRESS,
-    getAddr,
-    Core.LONG_TIMEOUT
-  );
+  const response = await transport.call(MessageType.MESSAGETYPE_BINANCEGETADDRESS, getAddr, Core.LONG_TIMEOUT);
 
   if (response.message_type === Core.Events.FAILURE) throw response;
 

--- a/packages/hdwallet-keepkey/src/cosmos.ts
+++ b/packages/hdwallet-keepkey/src/cosmos.ts
@@ -14,14 +14,6 @@ import { MessageType } from "@keepkey/device-protocol/lib/messages_pb";
 
 import { cloneDeep } from "lodash";
 
-export function cosmosGetAccountPaths(msg: Core.CosmosGetAccountPaths): Array<Core.CosmosAccountPath> {
-  return [
-    {
-      addressNList: [0x80000000 + 44, 0x80000000 + Core.slip44ByCoin("Atom"), 0x80000000 + msg.accountIdx, 0, 0],
-    },
-  ];
-}
-
 export async function cosmosSignTx(transport: KeepKeyTransport, msg: Core.CosmosSignTx): Promise<any> {
   return transport.lockDuring(async () => {
     const signTx = new CosmosSignTx();

--- a/packages/hdwallet-keepkey/src/ethereum.ts
+++ b/packages/hdwallet-keepkey/src/ethereum.ts
@@ -1,51 +1,45 @@
+import { SignedExchangeResponse } from "@keepkey/device-protocol/lib/exchange_pb";
+
 import {
-  ETHWallet,
-  ETHGetAddress,
-  ETHSignTx,
-  ETHSignedTx,
-  ETHGetAccountPath,
-  ETHAccountPath,
-  ETHSignMessage,
-  ETHSignedMessage,
-  ETHVerifyMessage,
-  Constructor,
-  toHexString,
-  fromHexString,
+  EthereumAddress,
+  EthereumGetAddress,
+  EthereumMessageSignature,
+  EthereumSignMessage,
+  EthereumSignTx,
+  EthereumTxRequest,
+  EthereumVerifyMessage,
+  MessageType,
+  Success,
+} from "@keepkey/device-protocol/lib/messages_pb";
+import { ExchangeType, OutputAddressType } from "@keepkey/device-protocol/lib/types_pb";
+import {
   arrayify,
+  base64toHEX,
+  BTCInputScriptType,
+  ETHAccountPath,
+  ETHGetAccountPath,
+  ETHGetAddress,
+  ETHSignedMessage,
+  ETHSignedTx,
+  ETHSignMessage,
+  ETHSignTx,
+  ETHVerifyMessage,
   Event,
   Events,
   LONG_TIMEOUT,
-  base64toHEX,
   slip44ByCoin,
-  BTCInputScriptType,
+  toHexString,
 } from "@shapeshiftoss/hdwallet-core";
 
-import { KeepKeyTransport } from "./transport";
-
-import {
-  MessageType,
-  EthereumSignTx,
-  EthereumTxRequest,
-  EthereumGetAddress,
-  EthereumAddress,
-  EthereumSignMessage,
-  EthereumMessageSignature,
-  EthereumVerifyMessage,
-  Success,
-} from "@keepkey/device-protocol/lib/messages_pb";
-import { SignedExchangeResponse } from "@keepkey/device-protocol/lib/exchange_pb";
-import {
-  ExchangeType,
-  OutputAddressType,
-} from "@keepkey/device-protocol/lib/types_pb";
+import * as EIP55 from "eip55";
 
 // @ts-ignore
 import * as Ethereumjs from "ethereumjs-tx";
-const { default: EthereumTx } = Ethereumjs as any;
 
+import { KeepKeyTransport } from "./transport";
 import { toUTF8Array, translateInputScriptType } from "./utils";
 
-import * as EIP55 from "eip55";
+const { default: EthereumTx } = Ethereumjs as any;
 
 export async function ethSupportsNetwork(chain_id: number): Promise<boolean> {
   return true;
@@ -59,33 +53,7 @@ export function ethSupportsNativeShapeShift(): boolean {
   return true;
 }
 
-export function ethGetAccountPaths(
-  msg: ETHGetAccountPath
-): Array<ETHAccountPath> {
-  return [
-    {
-      addressNList: [
-        0x80000000 + 44,
-        0x80000000 + slip44ByCoin(msg.coin),
-        0x80000000 + msg.accountIdx,
-        0,
-        0,
-      ],
-      hardenedPath: [
-        0x80000000 + 44,
-        0x80000000 + slip44ByCoin(msg.coin),
-        0x80000000 + msg.accountIdx,
-      ],
-      relPath: [0, 0],
-      description: "KeepKey",
-    },
-  ];
-}
-
-export async function ethSignTx(
-  transport: KeepKeyTransport,
-  msg: ETHSignTx
-): Promise<ETHSignedTx> {
+export async function ethSignTx(transport: KeepKeyTransport, msg: ETHSignTx): Promise<ETHSignedTx> {
   return transport.lockDuring(async () => {
     const est: EthereumSignTx = new EthereumSignTx();
     est.setAddressNList(msg.addressNList);
@@ -103,26 +71,17 @@ export async function ethSignTx(
       est.setAddressType(OutputAddressType.EXCHANGE);
 
       const signedHex = base64toHEX(msg.exchangeType.signedExchangeResponse);
-      const signedExchangeOut = SignedExchangeResponse.deserializeBinary(
-        arrayify(signedHex)
-      );
+      const signedExchangeOut = SignedExchangeResponse.deserializeBinary(arrayify(signedHex));
       const exchangeType = new ExchangeType();
       exchangeType.setSignedExchangeResponse(signedExchangeOut);
       exchangeType.setWithdrawalCoinName(msg.exchangeType.withdrawalCoinName); // KeepKey firmware will complain if this doesn't match signed exchange response
-      exchangeType.setWithdrawalAddressNList(
-        msg.exchangeType.withdrawalAddressNList
-      );
+      exchangeType.setWithdrawalAddressNList(msg.exchangeType.withdrawalAddressNList);
       exchangeType.setWithdrawalScriptType(
-        translateInputScriptType(
-          msg.exchangeType.withdrawalScriptType ||
-            BTCInputScriptType.SpendAddress
-        )
+        translateInputScriptType(msg.exchangeType.withdrawalScriptType || BTCInputScriptType.SpendAddress)
       );
       exchangeType.setReturnAddressNList(msg.exchangeType.returnAddressNList);
       exchangeType.setReturnScriptType(
-        translateInputScriptType(
-          msg.exchangeType.returnScriptType || BTCInputScriptType.SpendAddress
-        )
+        translateInputScriptType(msg.exchangeType.returnScriptType || BTCInputScriptType.SpendAddress)
       );
       est.setExchangeType(exchangeType);
     } else {
@@ -210,43 +169,28 @@ export async function ethSignTx(
   });
 }
 
-export async function ethGetAddress(
-  transport: KeepKeyTransport,
-  msg: ETHGetAddress
-): Promise<string> {
+export async function ethGetAddress(transport: KeepKeyTransport, msg: ETHGetAddress): Promise<string> {
   const getAddr = new EthereumGetAddress();
   getAddr.setAddressNList(msg.addressNList);
   getAddr.setShowDisplay(msg.showDisplay !== false);
-  const response = await transport.call(
-    MessageType.MESSAGETYPE_ETHEREUMGETADDRESS,
-    getAddr,
-    LONG_TIMEOUT
-  );
+  const response = await transport.call(MessageType.MESSAGETYPE_ETHEREUMGETADDRESS, getAddr, LONG_TIMEOUT);
   const ethAddress = response.proto as EthereumAddress;
 
   if (response.message_type === Events.FAILURE) throw response;
 
   let address = null;
   if (ethAddress.hasAddressStr()) address = ethAddress.getAddressStr();
-  else if (ethAddress.hasAddress())
-    address = "0x" + toHexString(ethAddress.getAddress_asU8());
+  else if (ethAddress.hasAddress()) address = "0x" + toHexString(ethAddress.getAddress_asU8());
   else throw new Error("Unable to obtain ETH address from device.");
 
   return address;
 }
 
-export async function ethSignMessage(
-  transport: KeepKeyTransport,
-  msg: ETHSignMessage
-): Promise<ETHSignedMessage> {
+export async function ethSignMessage(transport: KeepKeyTransport, msg: ETHSignMessage): Promise<ETHSignedMessage> {
   const m = new EthereumSignMessage();
   m.setAddressNList(msg.addressNList);
   m.setMessage(toUTF8Array(msg.message));
-  const response = (await transport.call(
-    MessageType.MESSAGETYPE_ETHEREUMSIGNMESSAGE,
-    m,
-    LONG_TIMEOUT
-  )) as Event;
+  const response = (await transport.call(MessageType.MESSAGETYPE_ETHEREUMSIGNMESSAGE, m, LONG_TIMEOUT)) as Event;
   const sig = response.proto as EthereumMessageSignature;
   return {
     address: EIP55.encode("0x" + toHexString(sig.getAddress_asU8())), // FIXME: this should be done in the firmware
@@ -254,19 +198,12 @@ export async function ethSignMessage(
   };
 }
 
-export async function ethVerifyMessage(
-  transport: KeepKeyTransport,
-  msg: ETHVerifyMessage
-): Promise<boolean> {
+export async function ethVerifyMessage(transport: KeepKeyTransport, msg: ETHVerifyMessage): Promise<boolean> {
   const m = new EthereumVerifyMessage();
   m.setAddress(arrayify(msg.address));
   m.setSignature(arrayify(msg.signature));
   m.setMessage(toUTF8Array(msg.message));
-  const event = (await transport.call(
-    MessageType.MESSAGETYPE_ETHEREUMVERIFYMESSAGE,
-    m,
-    LONG_TIMEOUT
-  )) as Event;
+  const event = (await transport.call(MessageType.MESSAGETYPE_ETHEREUMVERIFYMESSAGE, m, LONG_TIMEOUT)) as Event;
   const success = event.proto as Success;
   return success.getMessage() === "Message verified";
 }

--- a/packages/hdwallet-keepkey/src/ripple.ts
+++ b/packages/hdwallet-keepkey/src/ripple.ts
@@ -13,26 +13,7 @@ import { MessageType } from "@keepkey/device-protocol/lib/messages_pb";
 
 import { cloneDeep } from "lodash";
 
-export function rippleGetAccountPaths(
-  msg: Core.RippleGetAccountPaths
-): Array<Core.RippleAccountPath> {
-  return [
-    {
-      addressNList: [
-        0x80000000 + 44,
-        0x80000000 + Core.slip44ByCoin("Ripple"),
-        0x80000000 + msg.accountIdx,
-        0,
-        0,
-      ],
-    },
-  ];
-}
-
-export async function rippleSignTx(
-  transport: KeepKeyTransport,
-  msg: Core.RippleSignTx
-): Promise<Core.RippleSignedTx> {
+export async function rippleSignTx(transport: KeepKeyTransport, msg: Core.RippleSignTx): Promise<Core.RippleSignedTx> {
   return transport.lockDuring(async () => {
     const signTx = new RippleSignTx();
     signTx.setAddressNList(msg.addressNList);
@@ -92,18 +73,11 @@ export async function rippleSignTx(
   });
 }
 
-export async function rippleGetAddress(
-  transport: KeepKeyTransport,
-  msg: Core.RippleGetAddress
-): Promise<string> {
+export async function rippleGetAddress(transport: KeepKeyTransport, msg: Core.RippleGetAddress): Promise<string> {
   const getAddr = new RippleGetAddress();
   getAddr.setAddressNList(msg.addressNList);
   getAddr.setShowDisplay(msg.showDisplay !== false);
-  const response = await transport.call(
-    MessageType.MESSAGETYPE_RIPPLEGETADDRESS,
-    getAddr,
-    Core.LONG_TIMEOUT
-  );
+  const response = await transport.call(MessageType.MESSAGETYPE_RIPPLEGETADDRESS, getAddr, Core.LONG_TIMEOUT);
 
   if (response.message_type === Core.Events.FAILURE) throw response;
 

--- a/packages/hdwallet-native/src/bitcoin.ts
+++ b/packages/hdwallet-native/src/bitcoin.ts
@@ -92,7 +92,7 @@ export function MixinNativeBTCWalletInfo<TBase extends core.Constructor>(Base: T
     }
 
     btcNextAccountPath(msg: core.BTCAccountPath): core.BTCAccountPath {
-      const description = core.describeUTXOPath(msg.addressNList, msg.coin, msg.scriptType);
+      const description = core.btcDescribePath(msg.addressNList, msg.coin, msg.scriptType);
 
       if (!description.isKnown) {
         return undefined;

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -97,9 +97,9 @@ class NativeHDWalletInfo
         if (!super.btcSupportsCoin(msg.coin)) return unknown;
         if (!super.btcSupportsScriptType(msg.coin, msg.scriptType)) return unknown;
 
-        return core.describeUTXOPath(msg.path, msg.coin, msg.scriptType);
+        return core.btcDescribePath(msg.path, msg.coin, msg.scriptType);
       case "ethereum":
-        return core.describeETHPath(msg.path);
+        return core.ethDescribePath(msg.path);
       case "atom":
         return core.cosmosDescribePath(msg.path);
       case "binance":

--- a/packages/hdwallet-native/src/util.ts
+++ b/packages/hdwallet-native/src/util.ts
@@ -1,0 +1,17 @@
+import { addressNListToBIP32 } from "@shapeshiftoss/hdwallet-core";
+import * as bitcoin from "bitcoinjs-lib";
+import { BIP32Interface, Network } from "bitcoinjs-lib";
+import { getNetwork } from "./networks";
+
+export function getKeyPair(
+  seed: BIP32Interface,
+  addressNList: number[],
+  network = "bitcoin"
+): { privateKey: string; publicKey: string } {
+  const path = addressNListToBIP32(addressNList);
+  const keypair = bitcoin.ECPair.fromWIF(seed.derivePath(path).toWIF(), getNetwork(network));
+  return {
+    privateKey: keypair.privateKey.toString("hex"),
+    publicKey: keypair.publicKey.toString("hex"),
+  };
+}

--- a/packages/hdwallet-portis/src/bitcoin.ts
+++ b/packages/hdwallet-portis/src/bitcoin.ts
@@ -1,138 +1,25 @@
 import {
-  PathDescription,
   addressNListToBIP32,
-  BIP32Path,
-  slip44ByCoin,
-  Coin,
-  BTCInputScriptType,
-  BTCGetAddress,
   BTCAccountPath,
   BTCGetAccountPaths,
-  BTCSignTx,
+  BTCGetAddress,
+  BTCInputScriptType,
   BTCSignedTx,
+  BTCSignTx,
   BTCVerifyMessage,
+  Coin,
   fromHexString,
   hardenedPath,
   relativePath,
+  slip44ByCoin,
 } from "@shapeshiftoss/hdwallet-core";
+import Base64 from "base64-js";
+import { fromBase58 } from "bip32";
+import { payments } from "bitcoinjs-lib";
 
 import { verify } from "bitcoinjs-message";
-import Base64 from "base64-js";
-import { payments } from "bitcoinjs-lib";
-import { fromBase58 } from "bip32";
 
-export function describeUTXOPath(
-  path: BIP32Path,
-  coin: Coin,
-  scriptType: BTCInputScriptType
-): PathDescription {
-  let pathStr = addressNListToBIP32(path);
-  let unknown: PathDescription = {
-    verbose: pathStr,
-    coin,
-    scriptType,
-    isKnown: false,
-  };
-
-  if (path.length !== 3 && path.length !== 5) return unknown;
-
-  if ((path[0] & 0x80000000) >>> 0 !== 0x80000000) return unknown;
-
-  let purpose = path[0] & 0x7fffffff;
-
-  if (![44, 49, 84].includes(purpose)) return unknown;
-
-  if (purpose === 44 && scriptType !== BTCInputScriptType.SpendAddress)
-    return unknown;
-
-  if (purpose === 49 && scriptType !== BTCInputScriptType.SpendP2SHWitness)
-    return unknown;
-
-  if (purpose === 84 && scriptType !== BTCInputScriptType.SpendWitness)
-    return unknown;
-
-  let wholeAccount = path.length === 3;
-
-  let script = {
-    [BTCInputScriptType.SpendAddress]: ["Legacy"],
-    [BTCInputScriptType.SpendP2SHWitness]: [],
-    [BTCInputScriptType.SpendWitness]: ["Segwit Native"],
-  }[scriptType];
-
-  let isPrefork = false;
-  if (path[1] !== 0x80000000 + slip44ByCoin(coin)) {
-    switch (coin) {
-      case "BitcoinCash":
-      case "BitcoinGold": {
-        if (path[1] === 0x80000000 + slip44ByCoin("Bitcoin")) {
-          isPrefork = true;
-          break;
-        }
-        return unknown;
-      }
-      case "BitcoinSV": {
-        if (
-          path[1] === 0x80000000 + slip44ByCoin("Bitcoin") ||
-          path[1] === 0x80000000 + slip44ByCoin("BitcoinCash")
-        ) {
-          isPrefork = true;
-          break;
-        }
-        return unknown;
-      }
-      default:
-        return unknown;
-    }
-  }
-
-  let attributes = isPrefork ? ["Prefork"] : [];
-  switch (coin) {
-    case "Bitcoin":
-    case "Litecoin":
-    case "BitcoinGold":
-    case "Testnet": {
-      attributes = attributes.concat(script);
-      break;
-    }
-    default:
-      break;
-  }
-
-  let attr = attributes.length ? ` (${attributes.join(", ")})` : "";
-
-  let accountIdx = path[2] & 0x7fffffff;
-
-  if (wholeAccount) {
-    return {
-      coin,
-      verbose: `${coin} Account #${accountIdx}${attr}`,
-      accountIdx,
-      wholeAccount: true,
-      isKnown: true,
-      scriptType,
-      isPrefork,
-    };
-  } else {
-    let change = path[3] === 1 ? "Change " : "";
-    let addressIdx = path[4];
-    return {
-      coin,
-      verbose: `${coin} Account #${accountIdx}, ${change}Address #${addressIdx}${attr}`,
-      accountIdx,
-      addressIdx,
-      wholeAccount: false,
-      isKnown: true,
-      isChange: path[3] === 1,
-      scriptType,
-      isPrefork,
-    };
-  }
-}
-
-export async function btcGetAddress(
-  msg: BTCGetAddress,
-  portis: any
-): Promise<string> {
+export async function btcGetAddress(msg: BTCGetAddress, portis: any): Promise<string> {
   if (!msg.addressNList.length) throw new Error("Empty addressNList");
 
   const scriptType = msg.scriptType;
@@ -141,10 +28,7 @@ export async function btcGetAddress(
   const hardPath = hardenedPath(msg.addressNList);
   const hardPathString = addressNListToBIP32(hardPath);
 
-  const { result: xpub } = await portis.getExtendedPublicKey(
-    hardPathString,
-    "Bitcoin"
-  );
+  const { result: xpub } = await portis.getExtendedPublicKey(hardPathString, "Bitcoin");
 
   const relPath = relativePath(msg.addressNList);
   const relPathString = addressNListToBIP32(relPath).substr(2);
@@ -170,9 +54,7 @@ export async function btcGetAddress(
 
   if (msg.showDisplay === true) {
     if (!verifyScriptTypePurpose(scriptType, purpose)) {
-      throw new Error(
-        `Invalid scriptType ${scriptType} for purpose ${purpose}`
-      );
+      throw new Error(`Invalid scriptType ${scriptType} for purpose ${purpose}`);
     }
 
     portis.showBitcoinWallet(addressNListToBIP32(msg.addressNList));
@@ -181,77 +63,43 @@ export async function btcGetAddress(
   return result.address;
 }
 
-export function verifyScriptTypePurpose(
-  scriptType: BTCInputScriptType,
-  purpose: number
-): boolean {
+export function verifyScriptTypePurpose(scriptType: BTCInputScriptType, purpose: number): boolean {
   return (
-    (purpose === 0x80000000 + 44 &&
-      scriptType === BTCInputScriptType.SpendAddress) ||
-    (purpose === 0x80000000 + 49 &&
-      scriptType === BTCInputScriptType.SpendP2SHWitness) ||
-    (purpose === 0x80000000 + 84 &&
-      scriptType === BTCInputScriptType.SpendWitness)
+    (purpose === 0x80000000 + 44 && scriptType === BTCInputScriptType.SpendAddress) ||
+    (purpose === 0x80000000 + 49 && scriptType === BTCInputScriptType.SpendP2SHWitness) ||
+    (purpose === 0x80000000 + 84 && scriptType === BTCInputScriptType.SpendWitness)
   );
 }
 
-export function legacyAccount(
-  coin: Coin,
-  slip44: number,
-  accountIdx: number
-): BTCAccountPath {
+export function legacyAccount(coin: Coin, slip44: number, accountIdx: number): BTCAccountPath {
   return {
     coin,
     scriptType: BTCInputScriptType.SpendAddress,
-    addressNList: [
-      0x80000000 + 44,
-      0x80000000 + slip44,
-      0x80000000 + accountIdx,
-    ],
+    addressNList: [0x80000000 + 44, 0x80000000 + slip44, 0x80000000 + accountIdx],
   };
 }
 
-export function segwitAccount(
-  coin: Coin,
-  slip44: number,
-  accountIdx: number
-): BTCAccountPath {
+export function segwitAccount(coin: Coin, slip44: number, accountIdx: number): BTCAccountPath {
   return {
     coin,
     scriptType: BTCInputScriptType.SpendP2SHWitness,
-    addressNList: [
-      0x80000000 + 49,
-      0x80000000 + slip44,
-      0x80000000 + accountIdx,
-    ],
+    addressNList: [0x80000000 + 49, 0x80000000 + slip44, 0x80000000 + accountIdx],
   };
 }
 
-export function segwitNativeAccount(
-  coin: Coin,
-  slip44: number,
-  accountIdx: number
-): BTCAccountPath {
+export function segwitNativeAccount(coin: Coin, slip44: number, accountIdx: number): BTCAccountPath {
   return {
     coin,
     scriptType: BTCInputScriptType.SpendWitness,
-    addressNList: [
-      0x80000000 + 84,
-      0x80000000 + slip44,
-      0x80000000 + accountIdx,
-    ],
+    addressNList: [0x80000000 + 84, 0x80000000 + slip44, 0x80000000 + accountIdx],
   };
 }
 
-export function btcNextAccountPath(
-  msg: BTCAccountPath
-): BTCAccountPath | undefined {
+export function btcNextAccountPath(msg: BTCAccountPath): BTCAccountPath | undefined {
   return undefined;
 }
 
-export function btcGetAccountPaths(
-  msg: BTCGetAccountPaths
-): Array<BTCAccountPath> {
+export function btcGetAccountPaths(msg: BTCGetAccountPaths): Array<BTCAccountPath> {
   const slip44 = slip44ByCoin(msg.coin);
   const bip44 = legacyAccount(msg.coin, slip44, msg.accountIdx);
   const bip49 = segwitAccount(msg.coin, slip44, msg.accountIdx);
@@ -270,10 +118,7 @@ export function btcGetAccountPaths(
   return paths;
 }
 
-export async function btcSupportsScriptType(
-  coin: Coin,
-  scriptType: BTCInputScriptType
-): Promise<boolean> {
+export async function btcSupportsScriptType(coin: Coin, scriptType: BTCInputScriptType): Promise<boolean> {
   if (coin !== "Bitcoin") return Promise.resolve(false);
 
   switch (scriptType) {
@@ -291,10 +136,7 @@ export async function btcSupportsCoin(coin: Coin): Promise<boolean> {
   else return false;
 }
 
-export async function btcSignTx(
-  msg: BTCSignTx,
-  portis: any
-): Promise<BTCSignedTx> {
+export async function btcSignTx(msg: BTCSignTx, portis: any): Promise<BTCSignedTx> {
   const { result } = await portis.signBitcoinTransaction(msg);
   return {
     signatures: ["signature1", "signature2", "signature3"],

--- a/packages/hdwallet-portis/src/ethereum.ts
+++ b/packages/hdwallet-portis/src/ethereum.ts
@@ -1,7 +1,4 @@
 import {
-  PathDescription,
-  addressNListToBIP32,
-  BIP32Path,
   slip44ByCoin,
   ETHVerifyMessage,
   ETHGetAccountPath,
@@ -12,76 +9,23 @@ import {
   ETHSignedMessage,
 } from "@shapeshiftoss/hdwallet-core";
 
-export function describeETHPath(path: BIP32Path): PathDescription {
-  let pathStr = addressNListToBIP32(path);
-  let unknown: PathDescription = {
-    verbose: pathStr,
-    coin: "Ethereum",
-    isKnown: false,
-  };
-
-  if (path.length !== 5) return unknown;
-
-  if (path[0] !== 0x80000000 + 44) return unknown;
-
-  if (path[1] !== 0x80000000 + slip44ByCoin("Ethereum")) return unknown;
-
-  if ((path[2] & 0x80000000) >>> 0 !== 0x80000000) return unknown;
-
-  if (path[3] !== 0) return unknown;
-
-  if (path[4] !== 0) return unknown;
-
-  let index = path[2] & 0x7fffffff;
-  return {
-    verbose: `Ethereum Account #${index}`,
-    accountIdx: index,
-    wholeAccount: true,
-    coin: "Ethereum",
-    isKnown: true,
-  };
-}
-
-export async function ethVerifyMessage(
-  msg: ETHVerifyMessage,
-  web3: any
-): Promise<boolean> {
-  const signingAddress = await web3.eth.accounts.recover(
-    msg.message,
-    "0x" + msg.signature,
-    false
-  );
+export async function ethVerifyMessage(msg: ETHVerifyMessage, web3: any): Promise<boolean> {
+  const signingAddress = await web3.eth.accounts.recover(msg.message, "0x" + msg.signature, false);
   return signingAddress === msg.address;
 }
 
-export function ethGetAccountPaths(
-  msg: ETHGetAccountPath
-): Array<ETHAccountPath> {
+export function ethGetAccountPaths(msg: ETHGetAccountPath): Array<ETHAccountPath> {
   return [
     {
-      addressNList: [
-        0x80000000 + 44,
-        0x80000000 + slip44ByCoin(msg.coin),
-        0x80000000 + msg.accountIdx,
-        0,
-        0,
-      ],
-      hardenedPath: [
-        0x80000000 + 44,
-        0x80000000 + slip44ByCoin(msg.coin),
-        0x80000000 + msg.accountIdx,
-      ],
+      addressNList: [0x80000000 + 44, 0x80000000 + slip44ByCoin(msg.coin), 0x80000000 + msg.accountIdx, 0, 0],
+      hardenedPath: [0x80000000 + 44, 0x80000000 + slip44ByCoin(msg.coin), 0x80000000 + msg.accountIdx],
       relPath: [0, 0],
       description: "Portis",
     },
   ];
 }
 
-export async function ethSignTx(
-  msg: ETHSignTx,
-  web3: any,
-  from: string
-): Promise<ETHSignedTx> {
+export async function ethSignTx(msg: ETHSignTx, web3: any, from: string): Promise<ETHSignedTx> {
   const result = await web3.eth.signTransaction({
     from,
     to: msg.to,
@@ -99,11 +43,7 @@ export async function ethSignTx(
   };
 }
 
-export async function ethSignMessage(
-  msg: ETHSignMessage,
-  web3: any,
-  address: string
-): Promise<ETHSignedMessage> {
+export async function ethSignMessage(msg: ETHSignMessage, web3: any, address: string): Promise<ETHSignedMessage> {
   const result = await web3.eth.sign(msg.message, address);
   return {
     address,

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -1,46 +1,49 @@
-import Web3 from "web3";
 import {
-  HDWallet,
+  addressNListToBIP32,
+  BTCAccountPath,
+  btcDescribePath,
+  BTCGetAccountPaths,
+  BTCGetAddress,
+  BTCInputScriptType,
+  BTCSignedMessage,
+  BTCSignedTx,
+  BTCSignMessage,
+  BTCSignTx,
+  BTCVerifyMessage,
+  BTCWallet,
+  BTCWalletInfo,
+  Coin,
+  DescribePath,
+  ETHAccountPath,
+  ethDescribePath,
+  ETHGetAccountPath,
+  ETHGetAddress,
+  ETHSignedMessage,
+  ETHSignedTx,
+  ETHSignMessage,
+  ETHSignTx,
+  ETHVerifyMessage,
+  ETHWallet,
+  ETHWalletInfo,
   GetPublicKey,
+  HDWallet,
+  HDWalletInfo,
+  Keyring,
+  LoadDevice,
+  PathDescription,
+  Ping,
+  Pong,
   PublicKey,
   RecoverDevice,
   ResetDevice,
-  Coin,
-  Ping,
-  Pong,
-  LoadDevice,
-  ETHWallet,
-  ETHGetAddress,
-  ETHSignTx,
-  ETHGetAccountPath,
-  ETHAccountPath,
-  ETHSignMessage,
-  ETHSignedMessage,
-  ETHVerifyMessage,
-  ETHSignedTx,
-  DescribePath,
-  PathDescription,
-  addressNListToBIP32,
-  Transport,
-  Keyring,
-  HDWalletInfo,
-  ETHWalletInfo,
-  BTCWallet,
-  BTCGetAddress,
-  BTCSignTx,
-  BTCSignedTx,
-  BTCSignMessage,
-  BTCSignedMessage,
-  BTCVerifyMessage,
-  BTCInputScriptType,
-  BTCGetAccountPaths,
-  BTCAccountPath,
-  BTCWalletInfo,
   slip44ByCoin,
+  Transport,
+  unknownUTXOPath,
 } from "@shapeshiftoss/hdwallet-core";
-import * as eth from "./ethereum";
-import * as btc from "./bitcoin";
 import { isObject } from "lodash";
+import Web3 from "web3";
+import * as btc from "./bitcoin";
+import * as eth from "./ethereum";
 
 // We might not need this. Leaving it for now to debug further
 class PortisTransport extends Transport {
@@ -360,9 +363,14 @@ export class PortisHDWalletInfo implements HDWalletInfo, ETHWalletInfo, BTCWalle
   public describePath(msg: DescribePath): PathDescription {
     switch (msg.coin) {
       case "Ethereum":
-        return eth.describeETHPath(msg.path);
+        return ethDescribePath(msg.path);
       case "Bitcoin":
-        return btc.describeUTXOPath(msg.path, msg.coin, msg.scriptType);
+        const unknown = unknownUTXOPath(msg.path, msg.coin, msg.scriptType);
+
+        if (!this.btcSupportsCoin(msg.coin)) return unknown;
+        if (!this.btcSupportsScriptType(msg.coin, msg.scriptType)) return unknown;
+
+        return btcDescribePath(msg.path, msg.coin, msg.scriptType);
       default:
         throw new Error("Unsupported path");
     }


### PR DESCRIPTION
Every wallet has copy/paste copies of the same coin helper functions.  This PR moves some of those helper functions into core and changes each wallet to just reference the version of the function in core.

I made an effort to compare the function in each wallet to uniqueness before pulling it out into core. All of these functions were exact duplicates, but it may be worth doing a quick double-check to see if you see anything different in any of the removed functions.

Prettier formatting was automatically applied on save, so there are some formatting changes.