### PR TITLE
Feature Fio-native

### DIFF
--- a/examples/sandbox/index.ts
+++ b/examples/sandbox/index.ts
@@ -9,6 +9,7 @@ import {
   supportsRipple,
   supportsBinance,
   supportsEos,
+  supportsFio,
   supportsDebugLink,
   bip32ToAddressNList,
   Events,
@@ -730,6 +731,92 @@ $eosTx.on("click", async (e) => {
   } else {
     let label = await wallet.getLabel();
     $eosResults.val(label + " does not support Eos");
+  }
+});
+
+/*
+ * Fio
+ */
+const $fioAddr = $("#fioAddr");
+const $fioTx = $("#fioTx");
+const $fioResults = $("#fioResults");
+
+$fioAddr.on("click", async (e) => {
+  e.preventDefault();
+  if (!wallet) {
+    $ethResults.val("No wallet?");
+    return;
+  }
+  if (supportsFio(wallet)) {
+    let { addressNList } = wallet.fioGetAccountPaths({ accountIdx: 0 })[0];
+    let result = await wallet.fioGetPublicKey({
+      addressNList,
+      showDisplay: false,
+      kind: 0,
+    });
+    result = await wallet.fioGetPublicKey({
+      addressNList,
+      showDisplay: true,
+      kind: 0,
+      address: result,
+    });
+    $fioResults.val(result);
+  } else {
+    let label = await wallet.getLabel();
+    $fioResults.val(label + " does not support ");
+  }
+});
+
+$fioTx.on("click", async (e) => {
+  e.preventDefault();
+  if (!wallet) {
+    $ethResults.val("No wallet?");
+    return;
+  }
+  if (supportsFio(wallet)) {
+    let unsigned_main = {
+      expiration: "2020-04-30T22:00:00.000",
+      ref_block_num: 54661,
+      ref_block_prefix: 2118672142,
+      max_net_usage_words: 0,
+      max_cpu_usage_ms: 0,
+      delay_sec: 0,
+      context_free_actions: [],
+      actions: [
+        {
+          account: "eosio.token",
+          name: "transfer",
+          authorization: [
+            {
+              actor: "xhackmebrosx",
+              permission: "active",
+            },
+          ],
+          data: {
+            from: "xhackmebrosx",
+            to: "xhighlanderx",
+            quantity: "0.0001 EOS",
+            memo: "testmemo",
+          },
+        },
+      ],
+    };
+
+    let chainid_main = "aca376f206b8fc25a6ed44dbdc66547c36c6c33e3a119ffbeaef943642f0e906";
+    let res = await wallet.fioSignTx({
+      addressNList: bip32ToAddressNList("m/44'/194'/0'/0/0"),
+      chain_id: chainid_main,
+      tx: unsigned_main,
+    });
+
+    console.log(res);
+    console.log("signature = %d", res.signature);
+    console.log("serialized = %s", toHexString(res.serialized));
+
+    $eosResults.val(res.fioFormSig);
+  } else {
+    let label = await wallet.getLabel();
+    $fioResults.val(label + " does not support Fio");
   }
 });
 

--- a/integration/src/fio/fio.ts
+++ b/integration/src/fio/fio.ts
@@ -28,7 +28,7 @@ export function fioTests(get: () => { wallet: HDWallet; info: HDWalletInfo }): v
       });
     }, TIMEOUT);
 
-    test.only(
+    test(
       "fioGetAddress()",
       async () => {
         if (!wallet) return;
@@ -42,7 +42,7 @@ export function fioTests(get: () => { wallet: HDWallet; info: HDWalletInfo }): v
       TIMEOUT
     );
 
-    test.only(
+    test(
       "fioSignTx()",
       async () => {
         if (!wallet) return;

--- a/integration/src/fio/fio.ts
+++ b/integration/src/fio/fio.ts
@@ -1,0 +1,74 @@
+import { bip32ToAddressNList, HDWallet, FioWallet, supportsFio } from "@shapeshiftoss/hdwallet-core";
+
+import { HDWalletInfo } from "@shapeshiftoss/hdwallet-core/src/wallet";
+
+import * as tx01_unsigned from "./tx01.unsigned.json";
+import * as tx02_unsigned from "./tx02.unsigned.json";
+
+const MNEMONIC12_NOPIN_NOPASSPHRASE = "alcohol woman abuse must during monitor noble actual mixed trade anger aisle";
+
+const TIMEOUT = 60 * 1000;
+
+export function fioTests(get: () => { wallet: HDWallet; info: HDWalletInfo }): void {
+  let wallet: FioWallet & HDWallet;
+
+  describe("Fio", () => {
+    beforeAll(async () => {
+      const { wallet: w } = get();
+      if (supportsFio(w)) wallet = w;
+    });
+
+    beforeEach(async () => {
+      if (!wallet) return;
+      await wallet.wipe();
+      await wallet.loadDevice({
+        mnemonic: MNEMONIC12_NOPIN_NOPASSPHRASE,
+        label: "test",
+        skipChecksum: true,
+      });
+    }, TIMEOUT);
+
+    test.only(
+      "fioGetAddress()",
+      async () => {
+        if (!wallet) return;
+        expect(
+          await wallet.fioGetAddress({
+            addressNList: bip32ToAddressNList("m/44'/235'/0'/0/0"),
+            showDisplay: false,
+          })
+        ).toEqual("FIO6iLE1J4zb2SyDGTH9d6UL9Qm6hhqRce27QvP8AKxVLASGhtm7z");
+      },
+      TIMEOUT
+    );
+
+    test.only(
+      "fioSignTx()",
+      async () => {
+        if (!wallet) return;
+        let res = await wallet.fioSignTx({
+          actions: [
+            {
+              account: "fio.token",
+              name: "trnsfiopubky",
+              data: {
+                payee_public_key: "FIO7MpYCsLfjPGgXg8Sv7usGAw6RnFV3W6HTz1UP6HvodNXSAZiDp",
+                amount: "1000000000",
+                max_fee: 800000000000,
+                tpid: "",
+              },
+            },
+          ],
+        });
+        expect(res).toHaveProperty(
+          "signatures",
+          "SIG_K1_KZQX5nQDier8wtNRCQakgVRLVoZuRBFqGz8H7qxzDX2v2XJcaEVfa7xuZ9yX9CVqkpHaHVMBF4P2sp1GnZDYE15kJNK3aN"
+        );
+        expect(res).toHaveProperty("compression", 0);
+        expect(res).toHaveProperty("packed_context_free_data", "");
+        expect(res).toHaveProperty("packed_trx");
+      },
+      TIMEOUT
+    );
+  });
+}

--- a/integration/src/fio/index.ts
+++ b/integration/src/fio/index.ts
@@ -1,0 +1,7 @@
+import { HDWallet, HDWalletInfo } from "@shapeshiftoss/hdwallet-core";
+
+import { fioTests as tests } from "./fio";
+
+export function fioTests(get: () => { wallet: HDWallet; info: HDWalletInfo }): void {
+  tests(get);
+}

--- a/integration/src/fio/index.ts
+++ b/integration/src/fio/index.ts
@@ -1,4 +1,4 @@
-import { HDWallet, HDWalletInfo } from "@shapeshiftoss/hdwallet-core";
+import { HDWallet, HDWalletInfo, FioWallet } from "@shapeshiftoss/hdwallet-core";
 
 import { fioTests as tests } from "./fio";
 

--- a/integration/src/fio/tx01.unsigned.json
+++ b/integration/src/fio/tx01.unsigned.json
@@ -1,0 +1,35 @@
+{
+  "expiration": "2018-07-14T07:43:28",
+  "ref_block_num": "blockInfo.block_num & 0xffff",
+  "ref_block_prefix": "blockInfo.ref_block_prefix",
+  "actions": [
+    {
+      "account": "fio.address",
+      "name": "addaddress",
+      "authorization": [
+        {
+          "actor": "user.account",
+          "permission": "active"
+        }
+      ],
+      "data": {
+        "fio_address": "user.address",
+        "public_addresses": [
+          {
+            "chain_code": "BCH",
+            "token_code": "BCH",
+            "public_address": "bitcoincash:qzf8zha74ahdh9j0xnwlffdn0zuyaslx3c90q7n9g9"
+          },
+          {
+            "chain_code": "DASH",
+            "token_code": "DASH",
+            "public_address": "XyCyPKzTWvW2XdcYjPaPXGQDCGk946ywEv"
+          }
+        ],
+        "max_fee": 600000000,
+        "tpid": "rewards@wallet",
+        "actor": "user.account"
+      }
+    }
+  ]
+}

--- a/integration/src/integration.ts
+++ b/integration/src/integration.ts
@@ -11,6 +11,7 @@ import { cosmosTests } from "./cosmos";
 import { binanceTests } from "./binance";
 import { rippleTests } from "./ripple";
 import { eosTests } from "./eos";
+import { fioTests } from "./fio";
 import { WalletSuite } from "./wallets/suite";
 
 /**
@@ -72,6 +73,15 @@ export function integration(suite: WalletSuite): void {
 
       eosTests(() => ({ wallet, info }));
     });
+
+    describe("FioWallet", () => {
+      beforeAll(async () => {
+        wallet = await suite.createWallet("Fio");
+      });
+
+      eosTests(() => ({ wallet, info }));
+    });
+
 
     describe("CosmosWallet", () => {
       beforeAll(async () => {

--- a/integration/src/integration.ts
+++ b/integration/src/integration.ts
@@ -79,7 +79,7 @@ export function integration(suite: WalletSuite): void {
         wallet = await suite.createWallet("Fio");
       });
 
-      eosTests(() => ({ wallet, info }));
+      fioTests(() => ({ wallet, info }));
     });
 
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     ]
   },
   "scripts": {
+    "yarn": "yarn",
     "pre-reqs": "npm install -g typescript prettier",
     "clean": "lerna run clean --scope @shapeshiftoss/* && rm -rf coverage test-report node_modules && yarn cache clean",
     "lint:ts": "tsc --noEmit",

--- a/packages/hdwallet-core/src/fio.ts
+++ b/packages/hdwallet-core/src/fio.ts
@@ -1,11 +1,5 @@
-import { BIP32Path } from "./wallet";
-
-export interface FioGetPublicKey {
-  addressNList: BIP32Path;
-  showDisplay?: boolean;
-  /** Optional. Required for showDisplay == true. */
-  address?: string;
-}
+import { BIP32Path, PathDescription } from "./wallet";
+import { addressNListToBIP32, slip44ByCoin } from "./utils";
 
 export interface FioGetAddress {
   addressNList: BIP32Path;
@@ -32,18 +26,11 @@ export namespace Fio {
     permission?: string;
   }
 
-  export interface FioPublicAddress {
-    chain_code?: string;
-    token_code?: string;
-    public_address?: string;
-  }
 
   export interface FioTxActionData {
-    fio_address?: string;
-    public_addresses: Array<Fio.FioPublicAddress>;
-    max_fee?: number;
     tpid?: string;
     actor?: string;
+    [x: string]: any;
   }
 
   /* add action acks here as they are added to the wallet */
@@ -55,7 +42,7 @@ export namespace Fio {
   }
 }
 
-export interface FioTx {
+export interface FioSignTx {
   expiration?: string;
   ref_block_num?: number;
   ref_block_prefix?: number;
@@ -84,7 +71,45 @@ export interface FioWalletInfo {
 
 export interface FioWallet extends FioWalletInfo {
   _supportsFio: boolean;
+  fioGetAddress(msg: FioGetAddress): Promise<string>;
+  fioSignTx(msg: FioSignTx): Promise<FioSignedTx>;
+}
 
-  fioGetPublicKey(msg: FioGetPublicKey): Promise<string>;
-  fioSignTx(msg: FioTx): Promise<FioSignedTx>;
+export function fioDescribePath(path: BIP32Path): PathDescription {
+  let pathStr = addressNListToBIP32(path);
+  let unknown: PathDescription = {
+    verbose: pathStr,
+    coin: "Binance",
+    isKnown: false,
+  };
+
+  if (path.length != 5) {
+    return unknown;
+  }
+
+  if (path[0] != 0x80000000 + 44) {
+    return unknown;
+  }
+
+  if (path[1] != 0x80000000 + slip44ByCoin("fio")) {
+    return unknown;
+  }
+
+  if ((path[2] & 0x80000000) >>> 0 !== 0x80000000) {
+    return unknown;
+  }
+
+  if (path[3] !== 0 || path[4] !== 0) {
+    return unknown;
+  }
+
+  let index = path[2] & 0x7fffffff;
+  return {
+    verbose: `Binance Account #${index}`,
+    accountIdx: index,
+    wholeAccount: true,
+    coin: "Binance",
+    isKnown: true,
+    isPrefork: false,
+  };
 }

--- a/packages/hdwallet-core/src/fio.ts
+++ b/packages/hdwallet-core/src/fio.ts
@@ -1,0 +1,90 @@
+import { BIP32Path } from "./wallet";
+
+export interface FioGetPublicKey {
+  addressNList: BIP32Path;
+  showDisplay?: boolean;
+  /** Optional. Required for showDisplay == true. */
+  address?: string;
+}
+
+export interface FioGetAddress {
+  addressNList: BIP32Path;
+  showDisplay?: boolean;
+  /** Optional. Required for showDisplay == true. */
+  address?: string;
+}
+
+export interface FioGetAccountPaths {
+  accountIdx: number;
+}
+
+export interface FioAccountPath {
+  addressNList: BIP32Path;
+}
+
+export interface FioNextAccountPath {
+  accountIdx: number;
+}
+
+export namespace Fio {
+  export interface FioPermissionLevel {
+    actor?: string;
+    permission?: string;
+  }
+
+  export interface FioPublicAddress {
+    chain_code?: string;
+    token_code?: string;
+    public_address?: string;
+  }
+
+  export interface FioTxActionData {
+    fio_address?: string;
+    public_addresses: Array<Fio.FioPublicAddress>;
+    max_fee?: number;
+    tpid?: string;
+    actor?: string;
+  }
+
+  /* add action acks here as they are added to the wallet */
+  export interface FioTxActionAck {
+    account?: string;
+    name?: string;
+    authorization?: Array<Fio.FioPermissionLevel>;
+    data?: Fio.FioTxActionData;
+  }
+}
+
+export interface FioTx {
+  expiration?: string;
+  ref_block_num?: number;
+  ref_block_prefix?: number;
+  actions: Array<Fio.FioTxActionAck>;
+}
+
+export interface FioSignedTx {
+  serialized: string;
+  signature: string;
+}
+
+export interface FioWalletInfo {
+  _supportsFioInfo: boolean;
+
+  /**
+   * Returns a list of bip32 paths for a given account index in preferred order
+   * from most to least preferred.
+   */
+  fioGetAccountPaths(msg: FioGetAccountPaths): Array<FioAccountPath>;
+
+  /**
+   * Returns the "next" account path, if any.
+   */
+  fioNextAccountPath(msg: FioAccountPath): FioAccountPath | undefined;
+}
+
+export interface FioWallet extends FioWalletInfo {
+  _supportsFio: boolean;
+
+  fioGetPublicKey(msg: FioGetPublicKey): Promise<string>;
+  fioSignTx(msg: FioTx): Promise<FioSignedTx>;
+}

--- a/packages/hdwallet-core/src/fio.ts
+++ b/packages/hdwallet-core/src/fio.ts
@@ -1,6 +1,4 @@
-import { BIP32Path, PathDescription } from "./wallet";
-import { addressNListToBIP32, slip44ByCoin } from "./utils";
-
+import { BIP32Path } from "./wallet";
 export interface FioGetAddress {
   addressNList: BIP32Path;
   showDisplay?: boolean;
@@ -25,7 +23,6 @@ export namespace Fio {
     actor?: string;
     permission?: string;
   }
-
 
   export interface FioTxActionData {
     tpid?: string;
@@ -73,43 +70,4 @@ export interface FioWallet extends FioWalletInfo {
   _supportsFio: boolean;
   fioGetAddress(msg: FioGetAddress): Promise<string>;
   fioSignTx(msg: FioSignTx): Promise<FioSignedTx>;
-}
-
-export function fioDescribePath(path: BIP32Path): PathDescription {
-  let pathStr = addressNListToBIP32(path);
-  let unknown: PathDescription = {
-    verbose: pathStr,
-    coin: "Binance",
-    isKnown: false,
-  };
-
-  if (path.length != 5) {
-    return unknown;
-  }
-
-  if (path[0] != 0x80000000 + 44) {
-    return unknown;
-  }
-
-  if (path[1] != 0x80000000 + slip44ByCoin("fio")) {
-    return unknown;
-  }
-
-  if ((path[2] & 0x80000000) >>> 0 !== 0x80000000) {
-    return unknown;
-  }
-
-  if (path[3] !== 0 || path[4] !== 0) {
-    return unknown;
-  }
-
-  let index = path[2] & 0x7fffffff;
-  return {
-    verbose: `Binance Account #${index}`,
-    accountIdx: index,
-    wholeAccount: true,
-    coin: "Binance",
-    isKnown: true,
-    isPrefork: false,
-  };
 }

--- a/packages/hdwallet-core/src/index.ts
+++ b/packages/hdwallet-core/src/index.ts
@@ -11,3 +11,4 @@ export * from "./keyring";
 export * from "./exceptions";
 export * from "./ripple";
 export * from "./eos";
+export * from "./fio";

--- a/packages/hdwallet-core/src/utils.ts
+++ b/packages/hdwallet-core/src/utils.ts
@@ -148,6 +148,7 @@ export function slip44ByCoin(coin: Coin): number {
     Binance: 714,
     Ripple: 144,
     Eos: 194,
+    Fio: 235,
   }[coin];
 }
 

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -103,6 +103,16 @@ export interface PathDescription {
   isPrefork?: boolean;
 }
 
+type CoinWallets =
+  | BTCWallet
+  | ETHWallet
+  | CosmosWallet
+  | BinanceWallet
+  | RippleWallet
+  | EosWallet
+  | FioWallet
+  | DebugLinkWallet;
+
 export type Coin = string;
 export type Symbol = string;
 
@@ -154,16 +164,16 @@ export function supportsEos(wallet: any): wallet is EosWallet {
   return isObject(wallet) && (wallet as any)._supportsEos;
 }
 
+export function infoEos(info: any): info is EosWalletInfo {
+  return isObject(info) && (info as any)._supportsEosInfo;
+}
+
 export function supportsFio(wallet: any): wallet is FioWallet {
   return isObject(wallet) && (wallet as any)._supportsFio;
 }
 
 export function infoFio(info: any): info is FioWalletInfo {
   return isObject(info) && (info as any)._supportsFioInfo;
-}
-
-export function infoEos(info: any): info is EosWalletInfo {
-  return isObject(info) && (info as any)._supportsEosInfo;
 }
 
 /**
@@ -261,10 +271,6 @@ export interface HDWallet extends HDWalletInfo {
    */
   getDeviceID(): Promise<string>;
 
-  /**
-   * Get device specific features
-   */
-  getFeatures(): Promise<Record<string, any>>;
   /**
    * Retrieve the wallet's firmware version
    */

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -152,6 +152,10 @@ export function supportsEos(wallet: any): wallet is EosWallet {
   return isObject(wallet) && (wallet as any)._supportsEos;
 }
 
+export function supportsFio(wallet: any): wallet is EosWallet {
+  return isObject(wallet) && (wallet as any)._supportsFio;
+}
+
 export function infoEos(info: any): info is EosWalletInfo {
   return isObject(info) && (info as any)._supportsEosInfo;
 }

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -154,8 +154,12 @@ export function supportsEos(wallet: any): wallet is EosWallet {
   return isObject(wallet) && (wallet as any)._supportsEos;
 }
 
-export function supportsFio(wallet: any): wallet is EosWallet {
+export function supportsFio(wallet: any): wallet is FioWallet {
   return isObject(wallet) && (wallet as any)._supportsFio;
+}
+
+export function infoFio(info: any): info is FioWalletInfo {
+  return isObject(info) && (info as any)._supportsFioInfo;
 }
 
 export function infoEos(info: any): info is EosWalletInfo {

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -103,16 +103,6 @@ export interface PathDescription {
   isPrefork?: boolean;
 }
 
-type CoinWallets =
-  | BTCWallet
-  | ETHWallet
-  | CosmosWallet
-  | BinanceWallet
-  | RippleWallet
-  | EosWallet
-  | FioWallet
-  | DebugLinkWallet;
-
 export type Coin = string;
 export type Symbol = string;
 
@@ -164,16 +154,12 @@ export function supportsEos(wallet: any): wallet is EosWallet {
   return isObject(wallet) && (wallet as any)._supportsEos;
 }
 
-export function infoEos(info: any): info is EosWalletInfo {
-  return isObject(info) && (info as any)._supportsEosInfo;
-}
-
 export function supportsFio(wallet: any): wallet is FioWallet {
   return isObject(wallet) && (wallet as any)._supportsFio;
 }
 
-export function infoFio(info: any): info is FioWalletInfo {
-  return isObject(info) && (info as any)._supportsFioInfo;
+export function infoEos(info: any): info is EosWalletInfo {
+  return isObject(info) && (info as any)._supportsEosInfo;
 }
 
 /**
@@ -213,7 +199,6 @@ export interface HDWalletInfo {
   _supportsRippleInfo: boolean;
   _supportsBinanceInfo: boolean;
   _supportsEosInfo: boolean;
-  _supportsFioInfo: boolean;
   /**
    * Retrieve the wallet's vendor string.
    */
@@ -261,7 +246,6 @@ export interface HDWallet extends HDWalletInfo {
   _supportsBinance: boolean;
   _supportsRipple: boolean;
   _supportsEos: boolean;
-  _supportsFio: boolean;
   _supportsDebugLink: boolean;
 
   transport?: Transport;
@@ -271,6 +255,10 @@ export interface HDWallet extends HDWalletInfo {
    */
   getDeviceID(): Promise<string>;
 
+  /**
+   * Get device specific features
+   */
+  getFeatures(): Promise<Record<string, any>>;
   /**
    * Retrieve the wallet's firmware version
    */

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -10,6 +10,8 @@ import { RippleWallet, RippleWalletInfo } from "./ripple";
 
 import { EosWallet, EosWalletInfo } from "./eos";
 
+import { FioWallet, FioWalletInfo } from "./fio";
+
 import { DebugLinkWallet } from "./debuglink";
 import { Transport } from "./transport";
 import { isObject } from "lodash";

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -199,6 +199,7 @@ export interface HDWalletInfo {
   _supportsRippleInfo: boolean;
   _supportsBinanceInfo: boolean;
   _supportsEosInfo: boolean;
+  _supportsFioInfo: boolean;
   /**
    * Retrieve the wallet's vendor string.
    */
@@ -246,6 +247,7 @@ export interface HDWallet extends HDWalletInfo {
   _supportsBinance: boolean;
   _supportsRipple: boolean;
   _supportsEos: boolean;
+  _supportsFio: boolean;
   _supportsDebugLink: boolean;
 
   transport?: Transport;

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -402,6 +402,7 @@ export class KeepKeyHDWalletInfo
   _supportsRippleInfo: boolean = true;
   _supportsBinanceInfo: boolean = true;
   _supportsEosInfo: boolean = true;
+  _supportsFioInfo: boolean = false;
 
   public getVendor(): string {
     return "KeepKey";

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -84,6 +84,7 @@ import { KeepKeyTransport } from "./transport";
 
 import Semver from "semver";
 
+// @ts-ignore
 export function isKeepKey(wallet: HDWallet): wallet is KeepKeyHDWallet {
   return isObject(wallet) && (wallet as any)._isKeepKey;
 }
@@ -119,11 +120,7 @@ function describeETHPath(path: BIP32Path): PathDescription {
   };
 }
 
-function describeUTXOPath(
-  path: BIP32Path,
-  coin: Coin,
-  scriptType: BTCInputScriptType
-): PathDescription {
+function describeUTXOPath(path: BIP32Path, coin: Coin, scriptType: BTCInputScriptType): PathDescription {
   let pathStr = addressNListToBIP32(path);
   let unknown: PathDescription = {
     verbose: pathStr,
@@ -144,14 +141,11 @@ function describeUTXOPath(
 
   if (![44, 49, 84].includes(purpose)) return unknown;
 
-  if (purpose === 44 && scriptType !== BTCInputScriptType.SpendAddress)
-    return unknown;
+  if (purpose === 44 && scriptType !== BTCInputScriptType.SpendAddress) return unknown;
 
-  if (purpose === 49 && scriptType !== BTCInputScriptType.SpendP2SHWitness)
-    return unknown;
+  if (purpose === 49 && scriptType !== BTCInputScriptType.SpendP2SHWitness) return unknown;
 
-  if (purpose === 84 && scriptType !== BTCInputScriptType.SpendWitness)
-    return unknown;
+  if (purpose === 84 && scriptType !== BTCInputScriptType.SpendWitness) return unknown;
 
   let wholeAccount = path.length === 3;
 
@@ -173,10 +167,7 @@ function describeUTXOPath(
         return unknown;
       }
       case "BitcoinSV": {
-        if (
-          path[1] === 0x80000000 + slip44ByCoin("Bitcoin") ||
-          path[1] === 0x80000000 + slip44ByCoin("BitcoinCash")
-        ) {
+        if (path[1] === 0x80000000 + slip44ByCoin("Bitcoin") || path[1] === 0x80000000 + slip44ByCoin("BitcoinCash")) {
           isPrefork = true;
           break;
         }
@@ -412,10 +403,7 @@ export class KeepKeyHDWalletInfo
     return Btc.btcSupportsCoin(coin);
   }
 
-  public async btcSupportsScriptType(
-    coin: Coin,
-    scriptType: BTCInputScriptType
-  ): Promise<boolean> {
+  public async btcSupportsScriptType(coin: Coin, scriptType: BTCInputScriptType): Promise<boolean> {
     return Btc.btcSupportsScriptType(coin, scriptType);
   }
 
@@ -451,21 +439,15 @@ export class KeepKeyHDWalletInfo
     return Eth.ethGetAccountPaths(msg);
   }
 
-  public cosmosGetAccountPaths(
-    msg: CosmosGetAccountPaths
-  ): Array<CosmosAccountPath> {
+  public cosmosGetAccountPaths(msg: CosmosGetAccountPaths): Array<CosmosAccountPath> {
     return Cosmos.cosmosGetAccountPaths(msg);
   }
 
-  public rippleGetAccountPaths(
-    msg: RippleGetAccountPaths
-  ): Array<RippleAccountPath> {
+  public rippleGetAccountPaths(msg: RippleGetAccountPaths): Array<RippleAccountPath> {
     return Ripple.rippleGetAccountPaths(msg);
   }
 
-  public binanceGetAccountPaths(
-    msg: BinanceGetAccountPaths
-  ): Array<BinanceAccountPath> {
+  public binanceGetAccountPaths(msg: BinanceGetAccountPaths): Array<BinanceAccountPath> {
     return Binance.binanceGetAccountPaths(msg);
   }
 
@@ -512,11 +494,7 @@ export class KeepKeyHDWalletInfo
   }
 
   public btcNextAccountPath(msg: BTCAccountPath): BTCAccountPath | undefined {
-    let description = describeUTXOPath(
-      msg.addressNList,
-      msg.coin,
-      msg.scriptType
-    );
+    let description = describeUTXOPath(msg.addressNList, msg.coin, msg.scriptType);
     if (!description.isKnown) {
       return undefined;
     }
@@ -558,9 +536,7 @@ export class KeepKeyHDWalletInfo
     return undefined;
   }
 
-  public cosmosNextAccountPath(
-    msg: CosmosAccountPath
-  ): CosmosAccountPath | undefined {
+  public cosmosNextAccountPath(msg: CosmosAccountPath): CosmosAccountPath | undefined {
     let description = describeCosmosPath(msg.addressNList);
     if (!description.isKnown) {
       return undefined;
@@ -575,9 +551,7 @@ export class KeepKeyHDWalletInfo
     };
   }
 
-  public rippleNextAccountPath(
-    msg: RippleAccountPath
-  ): RippleAccountPath | undefined {
+  public rippleNextAccountPath(msg: RippleAccountPath): RippleAccountPath | undefined {
     let description = describeRipplePath(msg.addressNList);
     if (!description.isKnown) {
       return undefined;
@@ -591,9 +565,7 @@ export class KeepKeyHDWalletInfo
     };
   }
 
-  public binanceNextAccountPath(
-    msg: BinanceAccountPath
-  ): BinanceAccountPath | undefined {
+  public binanceNextAccountPath(msg: BinanceAccountPath): BinanceAccountPath | undefined {
     let description = describeBinancePath(msg.addressNList);
     if (!description.isKnown) {
       return undefined;
@@ -624,13 +596,13 @@ export class KeepKeyHDWalletInfo
   }
 }
 
-export class KeepKeyHDWallet
-  implements HDWallet, BTCWallet, ETHWallet, DebugLinkWallet {
+export class KeepKeyHDWallet implements HDWallet, BTCWallet, ETHWallet, DebugLinkWallet {
   _supportsETHInfo: boolean = true;
   _supportsBTCInfo: boolean = true;
   _supportsCosmosInfo: boolean = true;
   _supportsRippleInfo: boolean = true;
   _supportsBinanceInfo: boolean = true;
+  _supportsFioInfo: boolean = true;
   _supportsEosInfo: boolean = true;
   _supportsDebugLink: boolean;
   _isKeepKey: boolean = true;
@@ -640,6 +612,7 @@ export class KeepKeyHDWallet
   _supportsRipple: boolean = true;
   _supportsBinance: boolean = true;
   _supportsEos: boolean = true;
+  _supportsFio: boolean = true;
 
   transport: KeepKeyTransport;
   features?: Messages.Features.AsObject;
@@ -688,31 +661,20 @@ export class KeepKeyHDWallet
   public async isLocked(): Promise<boolean> {
     const features = await this.getFeatures();
     if (features.pinProtection && !features.pinProtection) return true;
-    if (features.passphraseProtection && !features.passphraseCached)
-      return true;
+    if (features.passphraseProtection && !features.passphraseCached) return true;
     return false;
   }
 
-  public async getPublicKeys(
-    getPublicKeys: Array<GetPublicKey>
-  ): Promise<Array<PublicKey | null>> {
+  public async getPublicKeys(getPublicKeys: Array<GetPublicKey>): Promise<Array<PublicKey | null>> {
     const publicKeys = [];
     for (let i = 0; i < getPublicKeys.length; i++) {
-      const {
-        coin,
-        addressNList,
-        curve,
-        showDisplay,
-        scriptType,
-      } = getPublicKeys[i];
+      const { coin, addressNList, curve, showDisplay, scriptType } = getPublicKeys[i];
       const GPK = new Messages.GetPublicKey();
       if (coin) GPK.setCoinName(coin);
       GPK.setAddressNList(addressNList);
       GPK.setShowDisplay(showDisplay || false);
       GPK.setEcdsaCurveName(curve || "secp256k1");
-      GPK.setScriptType(
-        translateInputScriptType(scriptType || BTCInputScriptType.SpendAddress)
-      );
+      GPK.setScriptType(translateInputScriptType(scriptType || BTCInputScriptType.SpendAddress));
 
       const event = (await this.transport.call(
         Messages.MessageType.MESSAGETYPE_GETPUBLICKEY,
@@ -756,11 +718,7 @@ export class KeepKeyHDWallet
     resetDevice.setU2fCounter(msg.u2fCounter || Math.floor(+new Date() / 1000));
     // resetDevice.setWordsPerGape(wordsPerScreen) // Re-enable when patch gets in
     // Send
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_RESETDEVICE,
-      resetDevice,
-      LONG_TIMEOUT
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_RESETDEVICE, resetDevice, LONG_TIMEOUT);
     this.cacheFeatures(undefined);
   }
 
@@ -777,11 +735,7 @@ export class KeepKeyHDWallet
       msg.setAutoLockDelayMs(r.autoLockDelayMs);
     }
     msg.setU2fCounter(r.u2fCounter || Math.floor(+new Date() / 1000));
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_RECOVERYDEVICE,
-      msg,
-      LONG_TIMEOUT
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_RECOVERYDEVICE, msg, LONG_TIMEOUT);
     this.cacheFeatures(undefined);
   }
 
@@ -872,11 +826,7 @@ export class KeepKeyHDWallet
     throw new Error("Not Yet Implemented :(");
   }
 
-  public async sendCharacterProto(
-    character: string,
-    _delete: boolean,
-    _done: boolean
-  ): Promise<any> {
+  public async sendCharacterProto(character: string, _delete: boolean, _done: boolean): Promise<any> {
     const characterAck = new Messages.CharacterAck();
     if (character !== "") {
       characterAck.setCharacter(character);
@@ -904,19 +854,13 @@ export class KeepKeyHDWallet
     policy.setEnabled(p.enabled);
     const applyPolicies = new Messages.ApplyPolicies();
     applyPolicies.setPolicyList([policy]);
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_APPLYPOLICIES,
-      applyPolicies,
-      LONG_TIMEOUT
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_APPLYPOLICIES, applyPolicies, LONG_TIMEOUT);
     this.cacheFeatures(undefined);
   }
 
   // ApplySettings changes the label, language, and enabling/disabling the passphrase
   // The default language is english
-  public async applySettings(
-    s: Messages.ApplySettings.AsObject
-  ): Promise<void> {
+  public async applySettings(s: Messages.ApplySettings.AsObject): Promise<void> {
     const applySettings = new Messages.ApplySettings();
     if (s.label) {
       applySettings.setLabel(s.label);
@@ -933,10 +877,7 @@ export class KeepKeyHDWallet
     if (s.u2fCounter) {
       applySettings.setU2fCounter(s.u2fCounter);
     }
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_APPLYSETTINGS,
-      applySettings
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_APPLYSETTINGS, applySettings);
     this.cacheFeatures(undefined);
   }
 
@@ -950,20 +891,14 @@ export class KeepKeyHDWallet
   public async changePin(): Promise<void> {
     const changePin = new Messages.ChangePin();
     // User may be propmpted for button press up to 2 times
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_CHANGEPIN,
-      changePin,
-      LONG_TIMEOUT
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_CHANGEPIN, changePin, LONG_TIMEOUT);
   }
 
   // CipherKeyValue encrypts or decrypts a value with a given key, nodepath, and initializationVector
   // This method encrypts if encrypt is true and decrypts if false, the confirm paramater determines wether
   // the user is prompted on the device. See EncryptKeyValue() and DecryptKeyValue() for convenience methods
   // NOTE: If the length of the value in bytes is not divisible by 16 it will be zero padded
-  public async cipherKeyValue(
-    v: Messages.CipherKeyValue.AsObject
-  ): Promise<string | Uint8Array> {
+  public async cipherKeyValue(v: Messages.CipherKeyValue.AsObject): Promise<string | Uint8Array> {
     // if(val.length % 16 !== 0) val = val.concat() TODO THIS
     const cipherKeyValue = new Messages.CipherKeyValue();
     cipherKeyValue.setAddressNList(v.addressNList);
@@ -985,18 +920,13 @@ export class KeepKeyHDWallet
   // ClearSession clears cached session values such as the pin and passphrase
   public async clearSession(): Promise<void> {
     const clearSession = new Messages.ClearSession();
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_CLEARSESSION,
-      clearSession
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_CLEARSESSION, clearSession);
     this.cacheFeatures(undefined);
   }
 
   // DecryptKeyValue is a convenience method around decrypting with CipherKeyValue().
   // For more granular control of the process use CipherKeyValue()
-  public async decryptKeyValue(
-    v: Messages.CipherKeyValue.AsObject
-  ): Promise<string | Uint8Array> {
+  public async decryptKeyValue(v: Messages.CipherKeyValue.AsObject): Promise<string | Uint8Array> {
     return this.cipherKeyValue(v);
   }
 
@@ -1004,10 +934,7 @@ export class KeepKeyHDWallet
   public async firmwareErase(): Promise<void> {
     const firmwareErase = new Messages.FirmwareErase();
     // send
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_FIRMWAREERASE,
-      firmwareErase
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_FIRMWAREERASE, firmwareErase);
     this.cacheFeatures(undefined);
   }
 
@@ -1016,20 +943,14 @@ export class KeepKeyHDWallet
     const hash = await this.transport.getFirmwareHash(firmware);
     firmwareUpload.setPayload(firmware);
     firmwareUpload.setPayloadHash(hash);
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_FIRMWAREUPLOAD,
-      firmwareUpload
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_FIRMWAREUPLOAD, firmwareUpload);
     this.cacheFeatures(undefined);
   }
 
   // Initialize assigns a hid connection to this KeepKey and send initialize message to device
   public async initialize(): Promise<Messages.Features.AsObject> {
     const initialize = new Messages.Initialize();
-    const event = (await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_INITIALIZE,
-      initialize
-    )) as Event;
+    const event = (await this.transport.call(Messages.MessageType.MESSAGETYPE_INITIALIZE, initialize)) as Event;
     if (event.message_type === Events.FAILURE) throw event;
     this.features = event.message;
 
@@ -1037,10 +958,7 @@ export class KeepKeyHDWallet
     // If the deviceId in the features table doesn't match, then we need to
     // add another k-v pair to the keyring so it can be looked up either way.
     if (this.transport.getDeviceID() !== this.features.deviceId) {
-      this.transport.keyring.addAlias(
-        this.transport.getDeviceID(),
-        this.features.deviceId
-      );
+      this.transport.keyring.addAlias(this.transport.getDeviceID(), this.features.deviceId);
     }
 
     // Cosmos isn't supported until v6.3.0
@@ -1055,15 +973,10 @@ export class KeepKeyHDWallet
   }
 
   // GetFeatures returns the features and other device information such as the version, label, and supported coins
-  public async getFeatures(
-    cached: boolean = false
-  ): Promise<Messages.Features.AsObject> {
+  public async getFeatures(cached: boolean = false): Promise<Messages.Features.AsObject> {
     if (cached && this.featuresCache) return this.featuresCache;
     const features = new Messages.GetFeatures();
-    const event = (await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_GETFEATURES,
-      features
-    )) as Event;
+    const event = (await this.transport.call(Messages.MessageType.MESSAGETYPE_GETFEATURES, features)) as Event;
     if (event.message_type === Events.FAILURE) throw event;
     this.cacheFeatures(event.message);
     return event.message as Messages.Features.AsObject;
@@ -1078,11 +991,7 @@ export class KeepKeyHDWallet
     const getEntropy = new Messages.GetEntropy();
     getEntropy.setSize(size);
     // send
-    const event = await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_GETENTROPY,
-      getEntropy,
-      LONG_TIMEOUT
-    );
+    const event = await this.transport.call(Messages.MessageType.MESSAGETYPE_GETENTROPY, getEntropy, LONG_TIMEOUT);
     if (event.message_type === Events.FAILURE) throw event;
     return (event.proto as Messages.Entropy).getEntropy_asU8();
   }
@@ -1090,27 +999,18 @@ export class KeepKeyHDWallet
   // GetNumCoins returns the number of coins supported by the device regardless of if the hanve funds.
   public async getNumCoins(): Promise<number> {
     const getCoinTable = new Messages.GetCoinTable();
-    const response = (await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_GETCOINTABLE,
-      getCoinTable
-    )) as Event;
+    const response = (await this.transport.call(Messages.MessageType.MESSAGETYPE_GETCOINTABLE, getCoinTable)) as Event;
     if (response.message_type === Events.FAILURE) throw event;
     return (response.proto as Messages.CoinTable).getNumCoins();
   }
 
   // GetCoinTable returns an array of Types.CoinTypes, with start and end arguments for paging.
   // You cannot request more than 10 at a time.
-  public async getCoinTable(
-    start: number = 0,
-    end: number = start + 10
-  ): Promise<Types.CoinType.AsObject[]> {
+  public async getCoinTable(start: number = 0, end: number = start + 10): Promise<Types.CoinType.AsObject[]> {
     const getCoinTable = new Messages.GetCoinTable();
     getCoinTable.setStart(start);
     getCoinTable.setEnd(end);
-    const response = (await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_GETCOINTABLE,
-      getCoinTable
-    )) as Event;
+    const response = (await this.transport.call(Messages.MessageType.MESSAGETYPE_GETCOINTABLE, getCoinTable)) as Event;
     if (response.message_type === Events.FAILURE) throw event;
     const coinTable = response.message as Messages.CoinTable.AsObject;
     return coinTable.tableList;
@@ -1127,11 +1027,7 @@ export class KeepKeyHDWallet
     if (msg.pin) loadDevice.setPin(msg.pin);
     if (msg.label) loadDevice.setLabel(msg.label);
     // send
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_LOADDEVICE,
-      loadDevice,
-      LONG_TIMEOUT
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_LOADDEVICE, loadDevice, LONG_TIMEOUT);
     this.cacheFeatures(undefined);
   }
 
@@ -1141,10 +1037,7 @@ export class KeepKeyHDWallet
     const changePin = new Messages.ChangePin();
     changePin.setRemove(true);
     // send
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_CHANGEPIN,
-      changePin
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_CHANGEPIN, changePin);
     this.cacheFeatures(undefined);
   }
 
@@ -1169,10 +1062,7 @@ export class KeepKeyHDWallet
   public async softReset(): Promise<void> {
     const softReset = new Messages.SoftReset();
     // send
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_SOFTRESET,
-      softReset
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_SOFTRESET, softReset);
     this.cacheFeatures(undefined);
   }
 
@@ -1180,10 +1070,7 @@ export class KeepKeyHDWallet
   public async wipe(): Promise<void> {
     const wipeDevice = new Messages.WipeDevice();
     // send
-    await this.transport.call(
-      Messages.MessageType.MESSAGETYPE_WIPEDEVICE,
-      wipeDevice
-    );
+    await this.transport.call(Messages.MessageType.MESSAGETYPE_WIPEDEVICE, wipeDevice);
     this.cacheFeatures(undefined);
   }
 
@@ -1191,10 +1078,7 @@ export class KeepKeyHDWallet
     return this.info.btcSupportsCoin(coin);
   }
 
-  public async btcSupportsScriptType(
-    coin: Coin,
-    scriptType: BTCInputScriptType
-  ): Promise<boolean> {
+  public async btcSupportsScriptType(coin: Coin, scriptType: BTCInputScriptType): Promise<boolean> {
     return this.info.btcSupportsScriptType(coin, scriptType);
   }
 
@@ -1267,9 +1151,7 @@ export class KeepKeyHDWallet
     return this.info.ethGetAccountPaths(msg);
   }
 
-  public rippleGetAccountPaths(
-    msg: RippleGetAccountPaths
-  ): Array<RippleAccountPath> {
+  public rippleGetAccountPaths(msg: RippleGetAccountPaths): Array<RippleAccountPath> {
     return this.info.rippleGetAccountPaths(msg);
   }
 
@@ -1281,9 +1163,7 @@ export class KeepKeyHDWallet
     return Ripple.rippleSignTx(this.transport, msg);
   }
 
-  public cosmosGetAccountPaths(
-    msg: CosmosGetAccountPaths
-  ): Array<CosmosAccountPath> {
+  public cosmosGetAccountPaths(msg: CosmosGetAccountPaths): Array<CosmosAccountPath> {
     return this.info.cosmosGetAccountPaths(msg);
   }
 
@@ -1295,9 +1175,7 @@ export class KeepKeyHDWallet
     return Cosmos.cosmosSignTx(this.transport, msg);
   }
 
-  public binanceGetAccountPaths(
-    msg: BinanceGetAccountPaths
-  ): Array<BinanceAccountPath> {
+  public binanceGetAccountPaths(msg: BinanceGetAccountPaths): Array<BinanceAccountPath> {
     return this.info.binanceGetAccountPaths(msg);
   }
 
@@ -1341,21 +1219,15 @@ export class KeepKeyHDWallet
     return this.info.eosNextAccountPath(msg);
   }
 
-  public cosmosNextAccountPath(
-    msg: CosmosAccountPath
-  ): CosmosAccountPath | undefined {
+  public cosmosNextAccountPath(msg: CosmosAccountPath): CosmosAccountPath | undefined {
     return this.info.cosmosNextAccountPath(msg);
   }
 
-  public rippleNextAccountPath(
-    msg: RippleAccountPath
-  ): RippleAccountPath | undefined {
+  public rippleNextAccountPath(msg: RippleAccountPath): RippleAccountPath | undefined {
     return this.info.rippleNextAccountPath(msg);
   }
 
-  public binanceNextAccountPath(
-    msg: BinanceAccountPath
-  ): BinanceAccountPath | undefined {
+  public binanceNextAccountPath(msg: BinanceAccountPath): BinanceAccountPath | undefined {
     return this.info.binanceNextAccountPath(msg);
   }
 }

--- a/packages/hdwallet-ledger/src/ledger.ts
+++ b/packages/hdwallet-ledger/src/ledger.ts
@@ -52,11 +52,7 @@ function describeETHPath(path: core.BIP32Path): core.PathDescription {
   };
 }
 
-function describeUTXOPath(
-  path: core.BIP32Path,
-  coin: core.Coin,
-  scriptType: core.BTCInputScriptType
-) {
+function describeUTXOPath(path: core.BIP32Path, coin: core.Coin, scriptType: core.BTCInputScriptType) {
   let pathStr = core.addressNListToBIP32(path);
   let unknown: core.PathDescription = {
     verbose: pathStr,
@@ -77,14 +73,11 @@ function describeUTXOPath(
 
   if (![44, 49, 84].includes(purpose)) return unknown;
 
-  if (purpose === 44 && scriptType !== core.BTCInputScriptType.SpendAddress)
-    return unknown;
+  if (purpose === 44 && scriptType !== core.BTCInputScriptType.SpendAddress) return unknown;
 
-  if (purpose === 49 && scriptType !== core.BTCInputScriptType.SpendP2SHWitness)
-    return unknown;
+  if (purpose === 49 && scriptType !== core.BTCInputScriptType.SpendP2SHWitness) return unknown;
 
-  if (purpose === 84 && scriptType !== core.BTCInputScriptType.SpendWitness)
-    return unknown;
+  if (purpose === 84 && scriptType !== core.BTCInputScriptType.SpendWitness) return unknown;
 
   if (path[1] !== 0x80000000 + core.slip44ByCoin(coin)) return unknown;
 
@@ -135,8 +128,7 @@ function describeUTXOPath(
   }
 }
 
-export class LedgerHDWalletInfo
-  implements core.HDWalletInfo, core.BTCWalletInfo, core.ETHWalletInfo {
+export class LedgerHDWalletInfo implements core.HDWalletInfo, core.BTCWalletInfo, core.ETHWalletInfo {
   _supportsBTCInfo: boolean = true;
   _supportsETHInfo: boolean = true;
   _supportsCosmosInfo: boolean = false; // TODO ledger supports cosmos
@@ -153,10 +145,7 @@ export class LedgerHDWalletInfo
     return btc.btcSupportsCoin(coin);
   }
 
-  public async btcSupportsScriptType(
-    coin: core.Coin,
-    scriptType: core.BTCInputScriptType
-  ): Promise<boolean> {
+  public async btcSupportsScriptType(coin: core.Coin, scriptType: core.BTCInputScriptType): Promise<boolean> {
     return btc.btcSupportsScriptType(coin, scriptType);
   }
 
@@ -168,9 +157,7 @@ export class LedgerHDWalletInfo
     return btc.btcSupportsNativeShapeShift();
   }
 
-  public btcGetAccountPaths(
-    msg: core.BTCGetAccountPaths
-  ): Array<core.BTCAccountPath> {
+  public btcGetAccountPaths(msg: core.BTCGetAccountPaths): Array<core.BTCAccountPath> {
     return btc.btcGetAccountPaths(msg);
   }
 
@@ -190,9 +177,7 @@ export class LedgerHDWalletInfo
     return eth.ethSupportsNativeShapeShift();
   }
 
-  public ethGetAccountPaths(
-    msg: core.ETHGetAccountPath
-  ): Array<core.ETHAccountPath> {
+  public ethGetAccountPaths(msg: core.ETHGetAccountPath): Array<core.ETHAccountPath> {
     return eth.ethGetAccountPaths(msg);
   }
 
@@ -225,14 +210,8 @@ export class LedgerHDWalletInfo
     }
   }
 
-  public btcNextAccountPath(
-    msg: core.BTCAccountPath
-  ): core.BTCAccountPath | undefined {
-    let description = describeUTXOPath(
-      msg.addressNList,
-      msg.coin,
-      msg.scriptType
-    );
+  public btcNextAccountPath(msg: core.BTCAccountPath): core.BTCAccountPath | undefined {
+    let description = describeUTXOPath(msg.addressNList, msg.coin, msg.scriptType);
     if (!description.isKnown) {
       return undefined;
     }
@@ -254,9 +233,7 @@ export class LedgerHDWalletInfo
     return undefined;
   }
 
-  public ethNextAccountPath(
-    msg: core.ETHAccountPath
-  ): core.ETHAccountPath | undefined {
+  public ethNextAccountPath(msg: core.ETHAccountPath): core.ETHAccountPath | undefined {
     let addressNList = msg.hardenedPath.concat(msg.relPath);
     let description = describeETHPath(addressNList);
     if (!description.isKnown) {
@@ -295,8 +272,7 @@ export class LedgerHDWalletInfo
   }
 }
 
-export class LedgerHDWallet
-  implements core.HDWallet, core.BTCWallet, core.ETHWallet {
+export class LedgerHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWallet {
   _supportsETHInfo: boolean = true;
   _supportsBTCInfo: boolean = true;
   _supportsDebugLink: boolean = false;
@@ -308,10 +284,10 @@ export class LedgerHDWallet
   _supportsRipple: boolean = false;
   _supportsCosmosInfo: boolean = false;
   _supportsCosmos: boolean = false;
-  _supportsEosInfo: boolean = false;
   _supportsEos: boolean = false;
+  _supportsEosInfo: boolean = false;
   _supportsFio: boolean = false;
-
+  _supportsFioInfo: boolean = false;
   _isLedger: boolean = true;
 
   transport: LedgerTransport;
@@ -409,9 +385,7 @@ export class LedgerHDWallet
     return;
   }
 
-  public async getPublicKeys(
-    msg: Array<core.GetPublicKey>
-  ): Promise<Array<core.PublicKey | null>> {
+  public async getPublicKeys(msg: Array<core.GetPublicKey>): Promise<Array<core.PublicKey | null>> {
     const res = await this.transport.call(null, "getAppAndVersion");
     handleError(res, this.transport);
 
@@ -494,10 +468,7 @@ export class LedgerHDWallet
     return this.info.btcSupportsCoin(coin);
   }
 
-  public async btcSupportsScriptType(
-    coin: core.Coin,
-    scriptType: core.BTCInputScriptType
-  ): Promise<boolean> {
+  public async btcSupportsScriptType(coin: core.Coin, scriptType: core.BTCInputScriptType): Promise<boolean> {
     return this.info.btcSupportsScriptType(coin, scriptType);
   }
 
@@ -519,9 +490,7 @@ export class LedgerHDWallet
     return this.info.btcSupportsNativeShapeShift();
   }
 
-  public async btcSignMessage(
-    msg: core.BTCSignMessage
-  ): Promise<core.BTCSignedMessage> {
+  public async btcSignMessage(msg: core.BTCSignMessage): Promise<core.BTCSignedMessage> {
     await this.validateCurrentApp(msg.coin);
     return btc.btcSignMessage(this, this.transport, msg);
   }
@@ -530,9 +499,7 @@ export class LedgerHDWallet
     return btc.btcVerifyMessage(msg);
   }
 
-  public btcGetAccountPaths(
-    msg: core.BTCGetAccountPaths
-  ): Array<core.BTCAccountPath> {
+  public btcGetAccountPaths(msg: core.BTCGetAccountPaths): Array<core.BTCAccountPath> {
     return this.info.btcGetAccountPaths(msg);
   }
 
@@ -550,9 +517,7 @@ export class LedgerHDWallet
     return eth.ethGetAddress(this.transport, msg);
   }
 
-  public async ethSignMessage(
-    msg: core.ETHSignMessage
-  ): Promise<core.ETHSignedMessage> {
+  public async ethSignMessage(msg: core.ETHSignMessage): Promise<core.ETHSignedMessage> {
     await this.validateCurrentApp("Ethereum");
     return eth.ethSignMessage(this.transport, msg);
   }
@@ -573,9 +538,7 @@ export class LedgerHDWallet
     return this.info.ethSupportsNativeShapeShift();
   }
 
-  public ethGetAccountPaths(
-    msg: core.ETHGetAccountPath
-  ): Array<core.ETHAccountPath> {
+  public ethGetAccountPaths(msg: core.ETHGetAccountPath): Array<core.ETHAccountPath> {
     return this.info.ethGetAccountPaths(msg);
   }
 
@@ -587,15 +550,11 @@ export class LedgerHDWallet
     return this.transport.disconnect();
   }
 
-  public btcNextAccountPath(
-    msg: core.BTCAccountPath
-  ): core.BTCAccountPath | undefined {
+  public btcNextAccountPath(msg: core.BTCAccountPath): core.BTCAccountPath | undefined {
     return this.info.btcNextAccountPath(msg);
   }
 
-  public ethNextAccountPath(
-    msg: core.ETHAccountPath
-  ): core.ETHAccountPath | undefined {
+  public ethNextAccountPath(msg: core.ETHAccountPath): core.ETHAccountPath | undefined {
     return this.info.ethNextAccountPath(msg);
   }
 }

--- a/packages/hdwallet-ledger/src/ledger.ts
+++ b/packages/hdwallet-ledger/src/ledger.ts
@@ -142,7 +142,8 @@ export class LedgerHDWalletInfo
   _supportsCosmosInfo: boolean = false; // TODO ledger supports cosmos
   _supportsBinanceInfo: boolean = false; // TODO ledger supports bnb
   _supportsRippleInfo: boolean = false; // TODO ledger supports XRP
-  _supportsEosInfo: boolean = false;
+  _supportsEosInfo: boolean = false; // TODO ledger supports EOS
+  _supportsFioInfo: boolean = false; // TODO ledger supports Fio
 
   public getVendor(): string {
     return "Ledger";
@@ -309,6 +310,7 @@ export class LedgerHDWallet
   _supportsCosmos: boolean = false;
   _supportsEosInfo: boolean = false;
   _supportsEos: boolean = false;
+  _supportsFio: boolean = false;
 
   _isLedger: boolean = true;
 

--- a/packages/hdwallet-native/package.json
+++ b/packages/hdwallet-native/package.json
@@ -24,6 +24,7 @@
     "crypto-js": "^3.1.9-1",
     "ethereum-tx-decoder": "^3.0.0",
     "ethers": "^5.0.2",
+    "fiosdk-offline": "^1.1.4",
     "lodash": "^4.17.15"
   },
   "devDependencies": {

--- a/packages/hdwallet-native/src/fio.ts
+++ b/packages/hdwallet-native/src/fio.ts
@@ -6,7 +6,7 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
 import { NativeHDWalletBase } from "./native";
 
-const fio = require("@fioprotocol/fiosdk");
+const fio = require("fiosdk-offline");
 const fetch = require("node-fetch");
 
 const fetchJson = async (uri, opts = {}) => {

--- a/packages/hdwallet-native/src/fio.ts
+++ b/packages/hdwallet-native/src/fio.ts
@@ -1,6 +1,6 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
-//import * as fio from "fiosdk-offline";
-const fio = require("fiosdk-offline");
+import * as fio from "fiosdk-offline";
+//const fio = require("fiosdk-offline");
 const fetch = require("node-fetch");
 
 const fetchJson = async (uri, opts = {}) => {
@@ -50,7 +50,7 @@ export function MixinNativeFioWallet<TBase extends core.Constructor>(Base: TBase
 
     async fioInitializeWallet(seed: string): Promise<void> {
       this.#seed = seed;
-      //await this.fioSDKInit(seed);
+      await this.fioSDKInit(seed);
     }
 
     async fioGetAddress(msg: core.FioGetAddress): Promise<string> {
@@ -60,16 +60,9 @@ export function MixinNativeFioWallet<TBase extends core.Constructor>(Base: TBase
     }
 
     async fioSignTx(msg: core.FioSignTx): Promise<core.FioSignedTx> {
-
-      await this.fioSDKInit(this.#seed);
-
-
       const account: string = msg.actions[0].account;
       const action: string = msg.actions[0].name;
       const data: core.Fio.FioTxActionData = msg.actions[0].data;
-      console.log("**ACCOUNT**", account);
-      console.log("**ACTION**", action);
-      console.log("**DATA**", data);
       if (!this.#fioSdk) {
         // Throw error. fioInitializeWallet has not been called.
       }
@@ -77,7 +70,6 @@ export function MixinNativeFioWallet<TBase extends core.Constructor>(Base: TBase
       if (!res.signatures || !res.packed_trx) {
         // Throw error. Transaction is invalid.
       }
-      console.log("**RES**", res);
       const sig = {
         serialized: res.packed_trx, // Serialized hexadecimal transaction
         signature: res.signatures[0], //
@@ -92,6 +84,8 @@ export function MixinNativeFioWallet<TBase extends core.Constructor>(Base: TBase
       const publicKeyRes = fio.FIOSDK.derivedPublicKey(this.#privateKey);
       this.#publicKey = publicKeyRes.publicKey;
       this.#fioSdk = new fio.FIOSDK(this.#privateKey, this.#publicKey, this.baseUrl, fetchJson);
+      //console.log("privKey", this.#privateKey);
+      //console.log("pubKey", this.#publicKey);
     }
   };
 }

--- a/packages/hdwallet-native/src/fio.ts
+++ b/packages/hdwallet-native/src/fio.ts
@@ -1,0 +1,100 @@
+/*
+
+
+ */
+
+import * as core from "@shapeshiftoss/hdwallet-core";
+import { NativeHDWalletBase } from "./native";
+
+const fio = require("@fioprotocol/fiosdk");
+const fetch = require("node-fetch");
+
+const fetchJson = async (uri, opts = {}) => {
+  return fetch(uri, opts);
+};
+
+export function MixinNativeFioWalletInfo<TBase extends core.Constructor>(Base: TBase) {
+  return class MixinNativeFioWalletInfo extends Base implements core.FioWalletInfo {
+    _supportsFioInfo = true;
+
+    async fioSupportsNetwork(): Promise<boolean> {
+      return true;
+    }
+
+    async fioSupportsSecureTransfer(): Promise<boolean> {
+      return false;
+    }
+
+    fioSupportsNativeShapeShift(): boolean {
+      return false;
+    }
+
+    fioGetAccountPaths(msg: any): Array<core.FioAccountPath> {
+      return [
+        {
+          addressNList: [0x80000000 + 44, 0x80000000 + 235, 0x80000000 + msg.accountIdx, 0, 0],
+        },
+      ];
+    }
+
+    fioNextAccountPath(msg: core.FioAccountPath): core.FioAccountPath {
+      // Only support one account for now (like portis).
+      // the fioers library supports paths so it shouldnt be too hard if we decide multiple accounts are needed
+      return undefined;
+    }
+  };
+}
+
+export function MixinNativeFioWallet<TBase extends core.Constructor<NativeHDWalletBase>>(Base: TBase) {
+  return class MixinNativeFioWallet extends Base {
+    _supportsFio = true;
+    baseUrl = "https://fio.eu.eosamsterdam.net/v1/"; //TODO fork/stop using network in sdk
+    #seed = "";
+    #privateKey = "";
+    #publicKey = "";
+    #fioSdk;
+
+    async fioInitializeWallet(seed: string): Promise<boolean> {
+      this.#seed = seed;
+      const privateKeyRes = await fio.FIOSDK.createPrivateKeyMnemonic(this.#seed);
+      const publicKeyRes = fio.FIOSDK.derivedPublicKey(privateKeyRes.fioKey);
+      return true;
+    }
+
+    async fioGetAddress(msg: any): Promise<string> {
+      const privateKeyRes = await fio.FIOSDK.createPrivateKeyMnemonic(this.#seed);
+      const publicKeyRes = fio.FIOSDK.derivedPublicKey(privateKeyRes.fioKey);
+      return publicKeyRes.publicKey;
+    }
+
+    async fioGetPublicKey(msg: any): Promise<string> {
+      const privateKeyRes = await fio.FIOSDK.createPrivateKeyMnemonic(this.#seed);
+      const publicKeyRes = fio.FIOSDK.derivedPublicKey(privateKeyRes.fioKey);
+      return publicKeyRes.publicKey;
+    }
+
+    async fioSignTx(msg: core.FioTx): Promise<any> {
+      this.#privateKey = fio.FIOSDK.createPrivateKeyMnemonic(this.#seed).fioKey;
+      this.#publicKey = fio.FIOSDK.derivedPublicKey(this.#privateKey);
+      this.#fioSdk = new fio.FIOSDK(this.#privateKey, this.#publicKey, this.baseUrl, fetchJson);
+
+      const account: string = msg.actions[0].account || "fio.token";
+      const action: string = msg.actions[0].name || "fiotrnspubky";
+
+      const data: core.Fio.FioTxActionData = msg.actions[0].data;
+      if (!this.#fioSdk) {
+        // Throw error. fioInitializeWallet has not been called.
+      }
+      const res = this.#fioSdk.prepareTransaction(account, action, data);
+      if (!res.signatures || !res.packed_trx) {
+        // Throw error. Transaction is invalid.
+      }
+      let sig = {
+        serialized: res.packed_trx, // Serialized hexadecimal transaction
+        signature: res.signatures[0], //
+      };
+
+      return sig;
+    }
+  };
+}

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -8,6 +8,7 @@ import { MixinNativeBTCWallet, MixinNativeBTCWalletInfo } from "./bitcoin";
 import { MixinNativeETHWalletInfo, MixinNativeETHWallet } from "./ethereum";
 import { MixinNativeCosmosWalletInfo, MixinNativeCosmosWallet } from "./cosmos";
 import { MixinNativeBinanceWalletInfo, MixinNativeBinanceWallet } from "./binance";
+import { MixinNativeFioWalletInfo, MixinNativeFioWallet } from "./fio";
 import type { NativeAdapterArgs } from "./adapter";
 
 export enum NativeEvents {
@@ -49,7 +50,9 @@ export class NativeHDWalletBase {
 
 class NativeHDWalletInfo
   extends MixinNativeBTCWalletInfo(
-    MixinNativeETHWalletInfo(MixinNativeCosmosWalletInfo(MixinNativeBinanceWalletInfo(NativeHDWalletBase)))
+    MixinNativeETHWalletInfo(
+      MixinNativeCosmosWalletInfo(MixinNativeFioWalletInfo(MixinNativeBinanceWalletInfo(NativeHDWalletBase)))
+    )
   )
   implements core.HDWalletInfo {
   _supportsBTCInfo: boolean = true;
@@ -58,6 +61,7 @@ class NativeHDWalletInfo
   _supportsBinanceInfo: boolean = true;
   _supportsRippleInfo: boolean = false;
   _supportsEosInfo: boolean = false;
+  _supportsFioInfo: boolean = true;
 
   getVendor(): string {
     return "Native";
@@ -112,7 +116,7 @@ class NativeHDWalletInfo
 
 export class NativeHDWallet
   extends MixinNativeBTCWallet(
-    MixinNativeETHWallet(MixinNativeCosmosWallet(MixinNativeBinanceWallet(NativeHDWalletInfo)))
+    MixinNativeETHWallet(MixinNativeCosmosWallet(MixinNativeFioWallet(MixinNativeBinanceWallet(NativeHDWalletInfo))))
   )
   implements core.HDWallet, core.BTCWallet, core.ETHWallet, core.CosmosWallet {
   _supportsBTC = true;
@@ -121,6 +125,7 @@ export class NativeHDWallet
   _supportsBinance = true;
   _supportsRipple = false;
   _supportsEos = false;
+  _supportsFio = true;
   _supportsDebugLink = false;
   _isNative = true;
 

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -1,5 +1,4 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
-import { EventEmitter2 } from "eventemitter2";
 import { mnemonicToSeed } from "bip39";
 import { fromSeed } from "bip32";
 import { isObject } from "lodash";
@@ -9,49 +8,11 @@ import { MixinNativeETHWalletInfo, MixinNativeETHWallet } from "./ethereum";
 import { MixinNativeCosmosWalletInfo, MixinNativeCosmosWallet } from "./cosmos";
 import { MixinNativeBinanceWalletInfo, MixinNativeBinanceWallet } from "./binance";
 import { MixinNativeFioWalletInfo, MixinNativeFioWallet } from "./fio";
-import type { NativeAdapterArgs } from "./adapter";
-
-export enum NativeEvents {
-  MNEMONIC_REQUIRED = "MNEMONIC_REQUIRED",
-  READY = "READY",
-}
-
-export class NativeHDWalletBase {
-  readonly #events: EventEmitter2;
-
-  constructor() {
-    this.#events = new EventEmitter2();
-  }
-
-  get events() {
-    return this.#events;
-  }
-
-  /**
-   * Wrap a function call that needs a mnemonic seed
-   * Raise an event if the wallet hasn't been initialized with a mnemonic seed
-   */
-  needsMnemonic<T>(hasMnemonic: boolean, callback: () => T): T | null {
-    if (hasMnemonic) {
-      return callback();
-    }
-
-    this.#events.emit(
-      NativeEvents.MNEMONIC_REQUIRED,
-      core.makeEvent({
-        message_type: NativeEvents.MNEMONIC_REQUIRED,
-        from_wallet: true,
-      })
-    );
-
-    return null;
-  }
-}
 
 class NativeHDWalletInfo
   extends MixinNativeBTCWalletInfo(
     MixinNativeETHWalletInfo(
-      MixinNativeCosmosWalletInfo(MixinNativeFioWalletInfo(MixinNativeBinanceWalletInfo(NativeHDWalletBase)))
+      MixinNativeCosmosWalletInfo(MixinNativeBinanceWalletInfo(MixinNativeFioWalletInfo(class Base {})))
     )
   )
   implements core.HDWalletInfo {
@@ -104,12 +65,6 @@ class NativeHDWalletInfo
         return core.describeUTXOPath(msg.path, msg.coin, msg.scriptType);
       case "ethereum":
         return core.describeETHPath(msg.path);
-      case "atom":
-        return core.cosmosDescribePath(msg.path);
-      case "binance":
-        return core.binanceDescribePath(msg.path);
-      case "fio":
-        return core.fioDescribePath(msg.path);
       default:
         throw new Error("Unsupported path");
     }
@@ -118,7 +73,7 @@ class NativeHDWalletInfo
 
 export class NativeHDWallet
   extends MixinNativeBTCWallet(
-    MixinNativeETHWallet(MixinNativeCosmosWallet(MixinNativeFioWallet(MixinNativeBinanceWallet(NativeHDWalletInfo))))
+    MixinNativeETHWallet(MixinNativeCosmosWallet(MixinNativeBinanceWallet(MixinNativeFioWallet(NativeHDWalletInfo))))
   )
   implements core.HDWallet, core.BTCWallet, core.ETHWallet, core.CosmosWallet, core.FioWallet {
   _supportsBTC = true;
@@ -127,7 +82,7 @@ export class NativeHDWallet
   _supportsBinance = true;
   _supportsRipple = false;
   _supportsEos = false;
-  _supportsFio = false;
+  _supportsFio = true;
   _supportsDebugLink = false;
   _isNative = true;
 
@@ -135,14 +90,10 @@ export class NativeHDWallet
   #initialized: boolean;
   #mnemonic: string;
 
-  constructor({ mnemonic, deviceId }: NativeAdapterArgs) {
+  constructor(mnemonic: string, deviceId: string) {
     super();
     this.#mnemonic = mnemonic;
     this.#deviceId = deviceId;
-  }
-
-  async getFeatures(): Promise<Record<string, any>> {
-    return {};
   }
 
   async getDeviceID(): Promise<string> {
@@ -165,21 +116,19 @@ export class NativeHDWallet
    * @see: https://github.com/satoshilabs/slips/blob/master/slip-0132.md
    * to supports different styles of xpubs as can be defined by passing in a network to `fromSeed`
    */
-  getPublicKeys(msg: Array<core.GetPublicKey>): Promise<core.PublicKey[]> {
-    return this.needsMnemonic(!!this.#mnemonic, () =>
-      Promise.all(
-        msg.map(async (getPublicKey) => {
-          let { addressNList } = getPublicKey;
-          const seed = await mnemonicToSeed(this.#mnemonic);
-          const network = getNetwork(getPublicKey.coin, getPublicKey.scriptType);
-          const node = fromSeed(seed, network);
-          const xpub = node
-            .derivePath(core.addressNListToBIP32(core.hardenedPath(addressNList)))
-            .neutered()
-            .toBase58();
-          return { xpub };
-        })
-      )
+  getPublicKeys(msg: Array<core.GetPublicKey>): Promise<Array<core.PublicKey>> {
+    return Promise.all(
+      msg.map(async (getPublicKey) => {
+        let { addressNList } = getPublicKey;
+        const seed = await mnemonicToSeed(this.#mnemonic);
+        const network = getNetwork(getPublicKey.coin, getPublicKey.scriptType);
+        const node = fromSeed(seed, network);
+        const xpub = node
+          .derivePath(core.addressNListToBIP32(core.hardenedPath(addressNList)))
+          .neutered()
+          .toBase58();
+        return { xpub };
+      })
     );
   }
 
@@ -193,22 +142,16 @@ export class NativeHDWallet
 
   async clearSession(): Promise<void> {}
 
-  async initialize(): Promise<boolean> {
-    return this.needsMnemonic(!!this.#mnemonic, async () => {
-      try {
-        await super.btcInitializeWallet(this.#mnemonic);
-        await super.ethInitializeWallet(this.#mnemonic);
-        await super.cosmosInitializeWallet(this.#mnemonic);
-        await super.binanceInitializeWallet(this.#mnemonic);
+  async initialize(): Promise<any> {
+    const seed = await mnemonicToSeed(this.#mnemonic);
 
-        this.#initialized = true;
-      } catch (e) {
-        console.error("NativeHDWallet:initialize:error", e);
-        this.#initialized = false;
-      }
+    await super.btcInitializeWallet(seed);
+    super.ethInitializeWallet("0x" + seed.toString("hex"));
+    super.cosmosInitializeWallet(this.#mnemonic);
+    await super.binanceInitializeWallet(this.#mnemonic);
+    await super.fioInitializeWallet(this.#mnemonic);
 
-      return this.#initialized;
-    });
+    this.#initialized = true;
   }
 
   async ping(msg: core.Ping): Promise<core.Pong> {
@@ -225,14 +168,7 @@ export class NativeHDWallet
 
   async cancel(): Promise<void> {}
 
-  async wipe(): Promise<void> {
-    this.#mnemonic = null;
-
-    super.btcWipe();
-    super.ethWipe();
-    super.cosmosWipe();
-    super.binanceWipe();
-  }
+  async wipe(): Promise<void> {}
 
   async reset(): Promise<void> {}
 
@@ -242,15 +178,6 @@ export class NativeHDWallet
     this.#mnemonic = msg.mnemonic;
     this.#initialized = false;
     await this.initialize();
-
-    // Once we've been seeded with a mnemonic we re-emit the connected event
-    this.events.emit(
-      NativeEvents.READY,
-      core.makeEvent({
-        message_type: NativeEvents.READY,
-        from_wallet: true,
-      })
-    );
   }
 
   async disconnect(): Promise<void> {}
@@ -264,10 +191,6 @@ export function info() {
   return new NativeHDWalletInfo();
 }
 
-export function create(args: NativeAdapterArgs): NativeHDWallet {
-  return new NativeHDWallet(args);
+export function create(mnemonic: string, deviceId: string): NativeHDWallet {
+  return new NativeHDWallet(mnemonic, deviceId);
 }
-
-// This prevents any malicious code from overwriting the prototype
-// to potentially steal the mnemonic when calling "loadDevice"
-Object.freeze(Object.getPrototypeOf(NativeHDWallet));

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -108,6 +108,8 @@ class NativeHDWalletInfo
         return core.cosmosDescribePath(msg.path);
       case "binance":
         return core.binanceDescribePath(msg.path);
+      case "fio":
+        return core.fioDescribePath(msg.path);
       default:
         throw new Error("Unsupported path");
     }
@@ -118,14 +120,14 @@ export class NativeHDWallet
   extends MixinNativeBTCWallet(
     MixinNativeETHWallet(MixinNativeCosmosWallet(MixinNativeFioWallet(MixinNativeBinanceWallet(NativeHDWalletInfo))))
   )
-  implements core.HDWallet, core.BTCWallet, core.ETHWallet, core.CosmosWallet {
+  implements core.HDWallet, core.BTCWallet, core.ETHWallet, core.CosmosWallet, core.FioWallet {
   _supportsBTC = true;
   _supportsETH = true;
   _supportsCosmos = true;
   _supportsBinance = true;
   _supportsRipple = false;
   _supportsEos = false;
-  _supportsFio = true;
+  _supportsFio = false;
   _supportsDebugLink = false;
   _isNative = true;
 

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -72,6 +72,7 @@ export class PortisHDWallet implements HDWallet, ETHWallet, BTCWallet {
   _supportsRipple: boolean = false;
   _supportsEosInfo: boolean = false;
   _supportsEos: boolean = false;
+  _supportsFioInfo: boolean = false;
   _supportsFio: boolean = false;
 
   transport = new PortisTransport(new Keyring());
@@ -332,6 +333,7 @@ export class PortisHDWalletInfo implements HDWalletInfo, ETHWalletInfo, BTCWalle
   _supportsBinanceInfo: boolean = false;
   _supportsRippleInfo: boolean = false;
   _supportsEosInfo: boolean = false;
+  _supportsFioInfo: boolean = false;
 
   public getVendor(): string {
     return "Portis";

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -72,6 +72,7 @@ export class PortisHDWallet implements HDWallet, ETHWallet, BTCWallet {
   _supportsRipple: boolean = false;
   _supportsEosInfo: boolean = false;
   _supportsEos: boolean = false;
+  _supportsFio: boolean = false;
 
   transport = new PortisTransport(new Keyring());
 

--- a/packages/hdwallet-trezor/src/trezor.ts
+++ b/packages/hdwallet-trezor/src/trezor.ts
@@ -171,9 +171,10 @@ export class TrezorHDWalletInfo
   _supportsBTCInfo: boolean = true;
   _supportsETHInfo: boolean = true;
   _supportsCosmosInfo: boolean = false;
-  _supportsBinanceInfo: boolean = false; //TODO trezor actually supports bnb
-  _supportsRippleInfo: boolean = false;
-  _supportsEosInfo: boolean = false;
+  _supportsBinanceInfo: boolean = false; //TODO trezor supports bnb
+  _supportsRippleInfo: boolean = false; //TODO trezor supports xrp
+  _supportsEosInfo: boolean = false; //TODO trezor supports Eos
+  _supportsFioInfo: boolean = false; //TODO trezor supports Fio
 
   public getVendor(): string {
     return "Trezor";

--- a/packages/hdwallet-trezor/src/trezor.ts
+++ b/packages/hdwallet-trezor/src/trezor.ts
@@ -83,11 +83,7 @@ function describeETHPath(path: BIP32Path): PathDescription {
   };
 }
 
-function describeUTXOPath(
-  path: BIP32Path,
-  coin: Coin,
-  scriptType: BTCInputScriptType
-) {
+function describeUTXOPath(path: BIP32Path, coin: Coin, scriptType: BTCInputScriptType) {
   let pathStr = addressNListToBIP32(path);
   let unknown: PathDescription = {
     verbose: pathStr,
@@ -108,14 +104,11 @@ function describeUTXOPath(
 
   if (![44, 49, 84].includes(purpose)) return unknown;
 
-  if (purpose === 44 && scriptType !== BTCInputScriptType.SpendAddress)
-    return unknown;
+  if (purpose === 44 && scriptType !== BTCInputScriptType.SpendAddress) return unknown;
 
-  if (purpose === 49 && scriptType !== BTCInputScriptType.SpendP2SHWitness)
-    return unknown;
+  if (purpose === 49 && scriptType !== BTCInputScriptType.SpendP2SHWitness) return unknown;
 
-  if (purpose === 84 && scriptType !== BTCInputScriptType.SpendWitness)
-    return unknown;
+  if (purpose === 84 && scriptType !== BTCInputScriptType.SpendWitness) return unknown;
 
   if (path[1] !== 0x80000000 + slip44ByCoin(coin)) return unknown;
 
@@ -166,8 +159,7 @@ function describeUTXOPath(
   }
 }
 
-export class TrezorHDWalletInfo
-  implements HDWalletInfo, BTCWalletInfo, ETHWalletInfo {
+export class TrezorHDWalletInfo implements HDWalletInfo, BTCWalletInfo, ETHWalletInfo {
   _supportsBTCInfo: boolean = true;
   _supportsETHInfo: boolean = true;
   _supportsCosmosInfo: boolean = false;
@@ -184,10 +176,7 @@ export class TrezorHDWalletInfo
     return Btc.btcSupportsCoin(coin);
   }
 
-  public async btcSupportsScriptType(
-    coin: Coin,
-    scriptType: BTCInputScriptType
-  ): Promise<boolean> {
+  public async btcSupportsScriptType(coin: Coin, scriptType: BTCInputScriptType): Promise<boolean> {
     return Btc.btcSupportsScriptType(coin, scriptType);
   }
 
@@ -255,11 +244,7 @@ export class TrezorHDWalletInfo
   }
 
   public btcNextAccountPath(msg: BTCAccountPath): BTCAccountPath | undefined {
-    let description = describeUTXOPath(
-      msg.addressNList,
-      msg.coin,
-      msg.scriptType
-    );
+    let description = describeUTXOPath(msg.addressNList, msg.coin, msg.scriptType);
     if (!description.isKnown) {
       return undefined;
     }
@@ -317,6 +302,8 @@ export class TrezorHDWallet implements HDWallet, BTCWallet, ETHWallet {
   _supportsRipple: boolean = false;
   _supportsEosInfo: boolean = false;
   _supportsEos: boolean = false;
+  _supportsFioInfo: boolean = false;
+  _supportsFio: boolean = false;
 
   transport: TrezorTransport;
   featuresCache: any;
@@ -377,9 +364,7 @@ export class TrezorHDWallet implements HDWallet, BTCWallet, ETHWallet {
     this.featuresCache = features;
   }
 
-  public async getPublicKeys(
-    msg: Array<GetPublicKey>
-  ): Promise<Array<PublicKey | null>> {
+  public async getPublicKeys(msg: Array<GetPublicKey>): Promise<Array<PublicKey | null>> {
     if (!msg.length) return [];
     let res = await this.transport.call("getPublicKey", {
       bundle: msg.map((request) => {
@@ -411,8 +396,7 @@ export class TrezorHDWallet implements HDWallet, BTCWallet, ETHWallet {
   public async isLocked(): Promise<boolean> {
     const features = await this.getFeatures(false);
     if (features.pin_protection && !features.pin_cached) return true;
-    if (features.passphrase_protection && !features.passphrase_cached)
-      return true;
+    if (features.passphrase_protection && !features.passphrase_cached) return true;
     return false;
   }
 
@@ -512,10 +496,7 @@ export class TrezorHDWallet implements HDWallet, BTCWallet, ETHWallet {
     return this.info.btcSupportsCoin(coin);
   }
 
-  public async btcSupportsScriptType(
-    coin: Coin,
-    scriptType: BTCInputScriptType
-  ): Promise<boolean> {
+  public async btcSupportsScriptType(coin: Coin, scriptType: BTCInputScriptType): Promise<boolean> {
     return this.info.btcSupportsScriptType(coin, scriptType);
   }
 
@@ -604,9 +585,6 @@ export function info(): TrezorHDWalletInfo {
   return new TrezorHDWalletInfo();
 }
 
-export function create(
-  transport: TrezorTransport,
-  debuglink: boolean
-): TrezorHDWallet {
+export function create(transport: TrezorTransport, debuglink: boolean): TrezorHDWallet {
   return new TrezorHDWallet(transport);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,6 +1284,23 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fioprotocol/fiojs@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@fioprotocol/fiojs/-/fiojs-1.0.1.tgz#81779437603741bc4ca1c76d119b64c4157a3874"
+  integrity sha512-+rxJ/ynUkox/DO3ihHPpAc//DDI+DQvrphLqwRKufw0atC3GKluGR2qMTeO45O0UjorvOIw6esuuG7NpbVUm8Q==
+  dependencies:
+    ajv "^6.10.2"
+    babel-runtime "6.26.0"
+    bigi "^1.4.2"
+    browserify-aes "^1.2.0"
+    bs58 "^4.0.1"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    ecurve "^1.0.6"
+    long "^4.0.0"
+    randombytes "^2.1.0"
+    text-encoding "0.7.0"
+
 "@iarna/toml@^2.2.0":
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
@@ -2719,6 +2736,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/text-encoding@0.0.35":
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/@types/text-encoding/-/text-encoding-0.0.35.tgz#6f14474e0b232bc70c59677aadc65dcc5a99c3a9"
+  integrity sha512-jfo/A88XIiAweUa8np+1mPbm3h2w0s425YrI8t3wk5QxhH6UI7w517MboNVnGDeMSuoFwA8Rwmklno+FicvV4g==
+
 "@types/usb@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@types/usb/-/usb-1.5.1.tgz#7ade8ea0135089c9fbc1d2148084a3013fc4128f"
@@ -2852,6 +2874,16 @@ agentkeepalive@^3.4.1:
   integrity sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==
   dependencies:
     humanize-ms "^1.2.1"
+
+ajv@^6.10.2:
+  version "6.12.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.5.tgz#19b0e8bae8f476e5ba666300387775fb1a00a4da"
+  integrity sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 ajv@^6.5.5:
   version "6.12.2"
@@ -3655,20 +3687,20 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^5.8.20:
-  version "5.8.38"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
-  integrity sha1-HAsC62MxL18If/IEUIJ7QlydTBk=
-  dependencies:
-    core-js "^1.0.0"
-
-babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
+babel-runtime@6.26.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.6.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.11.0"
+
+babel-runtime@^5.8.20:
+  version "5.8.38"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-5.8.38.tgz#1c0b02eb63312f5f087ff20450827b425c9d4c19"
+  integrity sha1-HAsC62MxL18If/IEUIJ7QlydTBk=
+  dependencies:
+    core-js "^1.0.0"
 
 babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
@@ -3818,6 +3850,11 @@ big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
+
+bigi@^1.1.0, bigi@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/bigi/-/bigi-1.4.2.tgz#9c665a95f88b8b08fc05cfd731f561859d725825"
+  integrity sha1-nGZalfiLiwj8Bc/XMfVhhZ1yWCU=
 
 bignumber.js@^4.1.0:
   version "4.1.0"
@@ -4087,7 +4124,7 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.0.6:
+browserify-aes@^1.0.0, browserify-aes@^1.0.4, browserify-aes@^1.0.6, browserify-aes@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.2.0.tgz#326734642f403dabc3003209853bb70ad428ef48"
   integrity sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==
@@ -4181,7 +4218,7 @@ bs-logger@0.x:
   dependencies:
     fast-json-stable-stringify "2.x"
 
-bs58@^4.0.0:
+bs58@^4.0.0, bs58@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
@@ -4733,6 +4770,11 @@ component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+component-type@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-type/-/component-type-1.2.1.tgz#8a47901700238e4fc32269771230226f24b415a9"
+  integrity sha1-ikeQFwAjjk/DIml3EjAibyS0Fak=
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -5680,6 +5722,14 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+ecurve@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/ecurve/-/ecurve-1.0.6.tgz#dfdabbb7149f8d8b78816be5a7d5b83fcf6de797"
+  integrity sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==
+  dependencies:
+    bigi "^1.1.0"
+    safe-buffer "^5.0.1"
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -5691,6 +5741,11 @@ eip55@^1.0.3:
   integrity sha512-x1p4OJNlt0G3mPPZx9GgwOaLFvz8Wd4VFpkx3iNzW4SrakFnjjO4mDdmAJpETxJZp9SlNB4UFqDuFhElnX9K/Q==
   dependencies:
     keccak "^1.3.0"
+
+eivindfjeldstad-dot@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/eivindfjeldstad-dot/-/eivindfjeldstad-dot-0.0.1.tgz#22fc976bfaf306e0839a31db8e8213480fafb893"
+  integrity sha1-IvyXa/rzBuCDmjHbjoITSA+vuJM=
 
 electron-to-chromium@^1.3.413, electron-to-chromium@^1.3.47:
   version "1.3.481"
@@ -6684,6 +6739,18 @@ find-versions@^3.2.0:
   dependencies:
     semver-regex "^2.0.0"
 
+fiosdk-offline@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/fiosdk-offline/-/fiosdk-offline-1.1.4.tgz#52de347a3b95319469f4038a23ed99d48b8b67d6"
+  integrity sha512-VuPybAgAkMtMTzOZtYHqoa/gwfkLXD1EK7Dh8o+nqJArhmdy/ag3pZG97s40M7CZH5bEs9DiE9nHmldEqRe5ug==
+  dependencies:
+    "@fioprotocol/fiojs" "1.0.1"
+    "@types/text-encoding" "0.0.35"
+    bip39 "^3.0.2"
+    hdkey "^1.1.1"
+    validate "^5.1.0"
+    wif "^2.0.6"
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"
@@ -7232,6 +7299,15 @@ hash.js@^1.0.0, hash.js@^1.0.3, hash.js@^1.1.7:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
+
+hdkey@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/hdkey/-/hdkey-1.1.2.tgz#c60f9cf6f90fbf24a8a52ea06893f36a0108cd3e"
+  integrity sha512-PTQ4VKu0oRnCrYfLp04iQZ7T2Cxz0UsEXYauk2j8eh6PJXCpbXuCFhOmtIFtbET0i3PMWmHN9J11gU8LEgUljQ==
+  dependencies:
+    bs58check "^2.1.2"
+    safe-buffer "^5.1.1"
+    secp256k1 "^3.0.1"
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -8955,6 +9031,11 @@ log-symbols@^2.2.0:
   integrity sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==
   dependencies:
     chalk "^2.0.1"
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 long@~3:
   version "3.2.0"
@@ -12886,6 +12967,11 @@ test-exclude@^5.2.3:
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
 
+text-encoding@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
+  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
+
 text-extensions@^1.0.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
@@ -13157,6 +13243,11 @@ type@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/type/-/type-2.0.0.tgz#5f16ff6ef2eb44f260494dae271033b29c09a9c3"
   integrity sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==
+
+typecast@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/typecast/-/typecast-0.0.1.tgz#fffb75dcb6bdf1def8e293b6b6e893d6c1ed19de"
+  integrity sha1-//t13La98d744pO2tuiT1sHtGd4=
 
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
@@ -13503,6 +13594,15 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+validate@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/validate/-/validate-5.1.0.tgz#12d685e346067646cba491b27994ad98b6319fce"
+  integrity sha512-Y+vJv+xR3XsaQM8W1rQvwc6is/sgCUBv3lvNKc2DZ1HcVcEWAaHVSFB5uoxkQnw2riUq77Rg5nv1u8YuuSu/Zw==
+  dependencies:
+    component-type "1.2.1"
+    eivindfjeldstad-dot "0.0.1"
+    typecast "0.0.1"
 
 varint@^5.0.0, varint@~5.0.0:
   version "5.0.0"
@@ -13866,10 +13966,15 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@2.0.4, whatwg-fetch@^2.0.4, whatwg-fetch@^3.0.0:
+whatwg-fetch@2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
+
+whatwg-fetch@^3.0.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
+  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13966,15 +13966,10 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@2.0.4:
+whatwg-fetch@2.0.4, whatwg-fetch@^2.0.4, whatwg-fetch@^3.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
-
-whatwg-fetch@^3.0.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
-  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
(WIP)

# Bump reference tx to mainnet. Add FIO Asset and FIO network support to native

This pr Updates the reference FIO transaction example. It also enables signing of FIO transfer tx's in native. 

Notes:
Reference tx can be verified on chain as followed

(This PR ONLY covers a transfer TX. Naming and registration tx's will be a quick follow up)

## Type of change

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)