### PR TITLE
Refactor public "getKeyPair" function to be private

### DIFF
--- a/packages/hdwallet-native/src/cosmos.ts
+++ b/packages/hdwallet-native/src/cosmos.ts
@@ -1,4 +1,5 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
+import { BIP32Interface } from "bitcoinjs-lib";
 import txBuilder from "cosmos-tx-builder";
 import * as bitcoin from "bitcoinjs-lib";
 import { NativeHDWalletBase } from "./native";
@@ -6,6 +7,9 @@ import { getNetwork } from "./networks";
 import { mnemonicToSeed } from "bip39";
 import { toWords, encode } from "bech32";
 import CryptoJS, { RIPEMD160, SHA256 } from "crypto-js";
+import util from "./util";
+
+const ATOM_CHAIN = "cosmoshub-3";
 
 export function MixinNativeCosmosWalletInfo<TBase extends core.Constructor>(Base: TBase) {
   return class MixinNativeCosmosWalletInfo extends Base implements core.CosmosWalletInfo {
@@ -41,23 +45,15 @@ export function MixinNativeCosmosWallet<TBase extends core.Constructor<NativeHDW
   return class MixinNativeCosmosWallet extends Base {
     _supportsCosmos = true;
 
-    #cosmosSeed: Buffer;
+    #wallet: BIP32Interface;
 
     async cosmosInitializeWallet(mnemonic: string): Promise<void> {
-      this.#cosmosSeed = await mnemonicToSeed(mnemonic);
+      const network = getNetwork("cosmos");
+      this.#wallet = bitcoin.bip32.fromSeed(await mnemonicToSeed(mnemonic), network);
     }
 
     cosmosWipe(): void {
-      this.#cosmosSeed = undefined;
-    }
-
-    cosmosGetKeyPair(addressNList: core.BIP32Path): bitcoin.ECPairInterface {
-      return this.needsMnemonic(!!this.#cosmosSeed, () => {
-        const network = getNetwork("cosmos");
-        const wallet = bitcoin.bip32.fromSeed(this.#cosmosSeed, network);
-        const path = core.addressNListToBIP32(addressNList);
-        return bitcoin.ECPair.fromWIF(wallet.derivePath(path).toWIF(), network);
-      });
+      this.#wallet = undefined;
     }
 
     bech32ify(address: ArrayLike<number>, prefix: string): string {
@@ -73,22 +69,18 @@ export function MixinNativeCosmosWallet<TBase extends core.Constructor<NativeHDW
     }
 
     async cosmosGetAddress(msg: core.CosmosGetAddress): Promise<string> {
-      const keyPair = this.cosmosGetKeyPair(msg.addressNList);
-      return this.createCosmosAddress(keyPair.publicKey.toString("hex"));
+      return this.needsMnemonic(!!this.#wallet, async () => {
+        return this.createCosmosAddress(util.getKeyPair(this.#wallet, msg.addressNList, "cosmos").publicKey);
+      });
     }
 
     async cosmosSignTx(msg: core.CosmosSignTx): Promise<core.CosmosSignedTx> {
-      const ATOM_CHAIN = "cosmoshub-3";
-      const keyPair = this.cosmosGetKeyPair(msg.addressNList);
+      return this.needsMnemonic(!!this.#wallet, async () => {
+        const keyPair = util.getKeyPair(this.#wallet, msg.addressNList, "cosmos");
+        const result = await txBuilder.sign(msg.tx, keyPair, msg.sequence, msg.account_number, ATOM_CHAIN);
 
-      const wallet = {
-        privateKey: keyPair.privateKey.toString("hex"),
-        publicKey: keyPair.publicKey.toString("hex"),
-      };
-
-      const result = await txBuilder.sign(msg.tx, wallet, msg.sequence, msg.account_number, ATOM_CHAIN);
-
-      return txBuilder.createSignedTx(msg.tx, result);
+        return txBuilder.createSignedTx(msg.tx, result);
+      });
     }
   };
 }

--- a/packages/hdwallet-native/src/util.ts
+++ b/packages/hdwallet-native/src/util.ts
@@ -1,0 +1,22 @@
+import { addressNListToBIP32 } from "@shapeshiftoss/hdwallet-core";
+import * as bitcoin from "bitcoinjs-lib";
+import { BIP32Interface } from "bitcoinjs-lib";
+import { getNetwork } from "./networks";
+
+function getKeyPair(
+  seed: BIP32Interface,
+  addressNList: number[],
+  network = "bitcoin"
+): { privateKey: string; publicKey: string } {
+  const path = addressNListToBIP32(addressNList);
+  const keypair = bitcoin.ECPair.fromWIF(seed.derivePath(path).toWIF(), getNetwork(network));
+  return {
+    privateKey: keypair.privateKey.toString("hex"),
+    publicKey: keypair.publicKey.toString("hex"),
+  };
+}
+
+// Prevent malicious JavaScript from replacing the method
+export default Object.freeze({
+  getKeyPair,
+});

--- a/packages/hdwallet-native/src/util.ts
+++ b/packages/hdwallet-native/src/util.ts
@@ -1,15 +1,18 @@
-import { addressNListToBIP32 } from "@shapeshiftoss/hdwallet-core";
+import { addressNListToBIP32, BTCInputScriptType, BTCOutputScriptType } from "@shapeshiftoss/hdwallet-core";
 import * as bitcoin from "bitcoinjs-lib";
 import { BIP32Interface } from "bitcoinjs-lib";
 import { getNetwork } from "./networks";
 
+type BTCScriptType = BTCInputScriptType | BTCOutputScriptType;
+
 function getKeyPair(
   seed: BIP32Interface,
   addressNList: number[],
-  network = "bitcoin"
+  network = "bitcoin",
+  scriptType?: BTCScriptType
 ): { privateKey: string; publicKey: string } {
   const path = addressNListToBIP32(addressNList);
-  const keypair = bitcoin.ECPair.fromWIF(seed.derivePath(path).toWIF(), getNetwork(network));
+  const keypair = bitcoin.ECPair.fromWIF(seed.derivePath(path).toWIF(), getNetwork(network, scriptType));
   return {
     privateKey: keypair.privateKey.toString("hex"),
     publicKey: keypair.publicKey.toString("hex"),


### PR DESCRIPTION
binance and cosmos support in hdwallet-native exposed a public `getKeyPair` function, which was used as a helper function but was also a class method, making it public. Malicious injected JavaScript would be able to call `wallet.binanceGetKeyPair` to get the PRIVATE key from the seed.

This refactors the code so the getKeyPair is a static method that requires providing the seed as a parameter. Thus, the private nature of the `#wallet` private variable is maintained.

Because of the nature of the MixIn class, it's not possible to make a private instance method.