### PR TITLE
native: Speed up initialization by running all coins in parallel

### DIFF
--- a/packages/hdwallet-native/src/binance.ts
+++ b/packages/hdwallet-native/src/binance.ts
@@ -4,7 +4,6 @@ import BncClient from "bnb-javascript-sdk-nobroadcast";
 import * as bitcoin from "bitcoinjs-lib";
 import { NativeHDWalletBase } from "./native";
 import { getNetwork } from "./networks";
-import { mnemonicToSeed } from "bip39";
 import { toWords, encode } from "bech32";
 import CryptoJS, { RIPEMD160, SHA256 } from "crypto-js";
 import util from "./util";
@@ -46,9 +45,9 @@ export function MixinNativeBinanceWallet<TBase extends core.Constructor<NativeHD
 
     #wallet: BIP32Interface;
 
-    async binanceInitializeWallet(mnemonic: string): Promise<void> {
+    async binanceInitializeWallet(seed: Buffer): Promise<void> {
       const network = getNetwork("cosmos");
-      this.#wallet = bitcoin.bip32.fromSeed(await mnemonicToSeed(mnemonic), network);
+      this.#wallet = bitcoin.bip32.fromSeed(seed, network);
     }
 
     binanceWipe(): void {

--- a/packages/hdwallet-native/src/bitcoin.ts
+++ b/packages/hdwallet-native/src/bitcoin.ts
@@ -1,4 +1,3 @@
-import { mnemonicToSeed } from "bip39";
 import { ECPairInterface } from "bitcoinjs-lib";
 import * as bitcoin from "bitcoinjs-lib";
 import { toCashAddress, toLegacyAddress } from "bchaddrjs";
@@ -136,8 +135,8 @@ export function MixinNativeBTCWallet<TBase extends core.Constructor<NativeHDWall
 
     #wallet: Buffer;
 
-    async btcInitializeWallet(mnemonic: string): Promise<void> {
-      this.#wallet = await mnemonicToSeed(mnemonic);
+    async btcInitializeWallet(seed: Buffer): Promise<void> {
+      this.#wallet = seed;
     }
 
     btcWipe(): void {

--- a/packages/hdwallet-native/src/cosmos.ts
+++ b/packages/hdwallet-native/src/cosmos.ts
@@ -4,7 +4,6 @@ import txBuilder from "cosmos-tx-builder";
 import * as bitcoin from "bitcoinjs-lib";
 import { NativeHDWalletBase } from "./native";
 import { getNetwork } from "./networks";
-import { mnemonicToSeed } from "bip39";
 import { toWords, encode } from "bech32";
 import CryptoJS, { RIPEMD160, SHA256 } from "crypto-js";
 import util from "./util";
@@ -47,9 +46,9 @@ export function MixinNativeCosmosWallet<TBase extends core.Constructor<NativeHDW
 
     #wallet: BIP32Interface;
 
-    async cosmosInitializeWallet(mnemonic: string): Promise<void> {
+    async cosmosInitializeWallet(seed: Buffer): Promise<void> {
       const network = getNetwork("cosmos");
-      this.#wallet = bitcoin.bip32.fromSeed(await mnemonicToSeed(mnemonic), network);
+      this.#wallet = bitcoin.bip32.fromSeed(seed, network);
     }
 
     cosmosWipe(): void {

--- a/packages/hdwallet-native/src/ethereum.ts
+++ b/packages/hdwallet-native/src/ethereum.ts
@@ -1,5 +1,4 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
-import { mnemonicToSeed } from "bip39";
 import { Wallet, utils } from "ethers";
 import txDecoder from "ethereum-tx-decoder";
 import { HDNode, defaultPath } from "@ethersproject/hdnode";
@@ -46,9 +45,9 @@ export function MixinNativeETHWallet<TBase extends core.Constructor<NativeHDWall
 
     #ethWallet: Wallet;
 
-    async ethInitializeWallet(mnemonic: string): Promise<void> {
-      const seed = `0x${(await mnemonicToSeed(mnemonic)).toString("hex")}`;
-      this.#ethWallet = new Wallet(HDNode.fromSeed(seed).derivePath(defaultPath));
+    async ethInitializeWallet(seed: Buffer): Promise<void> {
+      const address = `0x${seed.toString("hex")}`;
+      this.#ethWallet = new Wallet(HDNode.fromSeed(address).derivePath(defaultPath));
     }
 
     ethWipe() {

--- a/packages/hdwallet-native/src/fio.test.ts
+++ b/packages/hdwallet-native/src/fio.test.ts
@@ -1,0 +1,14 @@
+import { bip32ToAddressNList } from "@shapeshiftoss/hdwallet-core";
+import { mnemonicToSeed } from "bip39";
+import { NativeHDWallet } from "./native";
+
+describe("FIO", () => {
+  it("should generate a correct FIO address", async () => {
+    const x = new NativeHDWallet({ mnemonic: "all all all all all all all all all all all all", deviceId: "fioTest" });
+    const seed = await mnemonicToSeed("all all all all all all all all all all all all");
+    await x.fioInitializeWallet(seed);
+
+    const address = await x.fioGetAddress({ addressNList: bip32ToAddressNList("m/44'/235'/0'/0/0") });
+    expect(address).toBe("FIO5NSKecB4CcMpUxtpHzG4u43SmcGMAjRbxyG38rE4HPegGpaHu9");
+  });
+});

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -196,11 +196,15 @@ export class NativeHDWallet
   async initialize(): Promise<boolean> {
     return this.needsMnemonic(!!this.#mnemonic, async () => {
       try {
-        await super.btcInitializeWallet(this.#mnemonic);
-        await super.ethInitializeWallet(this.#mnemonic);
-        await super.cosmosInitializeWallet(this.#mnemonic);
-        await super.binanceInitializeWallet(this.#mnemonic);
-        await super.fioInitializeWallet(this.#mnemonic);
+        const seed = await mnemonicToSeed(this.#mnemonic);
+
+        await Promise.all([
+          super.btcInitializeWallet(seed),
+          super.ethInitializeWallet(seed),
+          super.cosmosInitializeWallet(seed),
+          super.binanceInitializeWallet(seed),
+          super.fioInitializeWallet(seed),
+        ]);
 
         this.#initialized = true;
       } catch (e) {


### PR DESCRIPTION
* Since all coins convert mnemonic to seed, just do it once and pass the seed buffer to each init function
* fio: SDK only exposes using a mnemonic, so I had to copy over the relevant code
