### PR TITLE
Improved Tests Phase 0: Get BNB Integration Tests Fixed (Part 2)

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -16,6 +16,7 @@
     "@shapeshiftoss/hdwallet-keepkey-tcp": "^1.13.1",
     "@shapeshiftoss/hdwallet-trezor": "^1.13.1",
     "debug": "^4.1.1",
+    "fast-json-stable-stringify": "^2.1.0",
     "parcel-bundler": "^1.12.4",
     "whatwg-fetch": "^2.0.4"
   },

--- a/integration/src/binance/bnbdecoder.ts
+++ b/integration/src/binance/bnbdecoder.ts
@@ -1,0 +1,73 @@
+import * as bnbSdk from "bnb-javascript-sdk-nobroadcast";
+import tinyecc from "tiny-secp256k1";
+import * as crypto from "crypto";
+
+export function decodeBnbTx(txBytes: Buffer, chainId: string) {
+  const txDecoded = bnbSdk.amino.decoder.unMarshalBinaryLengthPrefixed(txBytes, {
+    aminoPrefix: "f0625dee",
+    msgs: [
+      {
+        aminoPrefix: "2a2c87fa",
+        inputs: [{ address: Buffer.alloc(0), coins: [{ denom: "", amount: 0 }] }],
+        outputs: [{ address: Buffer.alloc(0), coins: [{ denom: "", amount: 0 }] }],
+      },
+    ],
+    signatures: [
+      {
+        pubKey: Buffer.alloc(0),
+        signature: Buffer.alloc(0),
+        accountNumber: 0,
+        sequence: 0,
+      },
+    ],
+    memo: "",
+    source: 0,
+    data: Buffer.alloc(0),
+  }).val;
+
+  if (txDecoded.data !== null) throw new Error("bad data length");
+  if (txDecoded.msgs.length !== 1) throw new Error("bad msgs length");
+  if (txDecoded.signatures.length !== 1) throw new Error("bad signatures length");
+
+  const signBytes = JSON.stringify({
+    account_number: String(txDecoded.signatures[0].accountNumber),
+    chain_id: chainId,
+    data: null,
+    memo: txDecoded.memo,
+    msgs: [
+      {
+        inputs: txDecoded.msgs[0].inputs.map((x: any) => ({
+          address: bnbSdk.crypto.encodeAddress(x.address, "bnb"),
+          coins: x.coins.map((y: any) => ({
+            amount: Number(y.amount),
+            denom: y.denom,
+          })),
+        })),
+        outputs: txDecoded.msgs[0].outputs.map((x: any) => ({
+          address: bnbSdk.crypto.encodeAddress(x.address, "bnb"),
+          coins: x.coins.map((y: any) => ({
+            amount: Number(y.amount),
+            denom: y.denom,
+          })),
+        })),
+      },
+    ],
+    sequence: String(txDecoded.signatures[0].sequence),
+    source: String(txDecoded.source),
+  });
+
+  const signBytesHash = crypto.createHash("sha256").update(Buffer.from(signBytes, "utf8")).digest();
+
+  const pubKeyAmino = Buffer.from(txDecoded.signatures[0].pubKey);
+  if (pubKeyAmino.readUInt32BE(0) !== 0xeb5ae987) throw new Error("bad pubkey aminoPrefix");
+  if (pubKeyAmino.readUInt8(4) !== 33) throw new Error("bad pubKey length");
+  const pubKey = pubKeyAmino.slice(5);
+
+  const signature = txDecoded.signatures[0].signature;
+  return { signBytes, signBytesHash, pubKey, signature };
+}
+
+export function validateBnbTx(txBytes: Buffer, chainId: string) {
+  const { signBytesHash, pubKey, signature } = decodeBnbTx(txBytes, chainId);
+  return tinyecc.verify(signBytesHash, pubKey, signature);
+}

--- a/integration/src/binance/tx02.mainnet.signed.json
+++ b/integration/src/binance/tx02.mainnet.signed.json
@@ -1,4 +1,5 @@
 {
+  "account_number": "471113",
   "chain_id": "Binance-Chain-Tigris",
   "data": null,
   "memo": "",
@@ -6,35 +7,30 @@
     {
       "inputs": [
         {
-          "address": {
-            "type": "Buffer",
-            "data": [234, 93, 122, 233, 154, 156, 226, 249, 219, 124, 67, 169, 7, 55, 112, 36, 183, 243, 67, 232]
-          },
+          "address": "bnb1afwh46v6nn30nkmugw5swdmsyjmlxslgjfugre",
           "coins": [
             {
-              "denom": "BNB",
-              "amount": "1000"
+              "amount": "1000",
+              "denom": "BNB"
             }
           ]
         }
       ],
       "outputs": [
         {
-          "address": {
-            "type": "Buffer",
-            "data": [103, 156, 216, 31, 171, 65, 66, 104, 64, 250, 96, 40, 9, 112, 81, 59, 129, 14, 180, 30]
-          },
+          "address": "bnb1v7wds8atg9pxss86vq5qjuz38wqsadq7e5m2rr",
           "coins": [
             {
-              "denom": "BNB",
-              "amount": "1000"
+              "amount": "1000",
+              "denom": "BNB"
             }
           ]
         }
-      ],
-      "msgType": "MsgSend"
+      ]
     }
   ],
+  "sequence": "17",
+  "source": "0",
   "txid": "A640902638C0F08B6BF225D18AE9A15FD0B6DBA6C739BD3F5E390CE737BC8E75",
   "serialized": "c001f0625dee0a482a2c87fa0a200a14ea5d7ae99a9ce2f9db7c43a907377024b7f343e812080a03424e4210e80712200a14679cd81fab41426840fa60280970513b810eb41e12080a03424e4210e80712700a26eb5ae9872102ddf08b1f51a4132c63c73455cac6569404c78c9e3b5bffd1f64e07a9a2f109b412406cca9c5ac3d068d2acb58a8ff3ea68007120921eaecc7f4a2c31cfde9b753d4c158cae5719a03acf6524da57ca8d91634903c6dac183f789f088385f7784c78e18c9e01c2011",
   "signatures": {

--- a/integration/src/binance/tx02.mainnet.unsigned.json
+++ b/integration/src/binance/tx02.mainnet.unsigned.json
@@ -1,6 +1,6 @@
 {
   "account_number": "471113",
-  "chain_id": "Binance-Chain-Nile",
+  "chain_id": "Binance-Chain-Tigris",
   "data": null,
   "memo": "",
   "msgs": [
@@ -29,6 +29,6 @@
       ]
     }
   ],
-  "sequence": 8,
-  "source": "1"
+  "sequence": "17",
+  "source": "0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6287,7 +6287,7 @@ fast-glob@^2.2.2, fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==


### PR DESCRIPTION
Fixes #267. Separating this from #251 allows confidence that the revised input values are in fact correct, as the serialized transaction and signatures are not affected by this change.