### PR TITLE
Improved Tests Phase -1: Fix hdwallet-native BNB math

### DIFF
--- a/integration/src/binance/tx02.mainnet.signed.json
+++ b/integration/src/binance/tx02.mainnet.signed.json
@@ -40,6 +40,6 @@
   "signatures": {
     "pub_key": "eb5ae9872102ddf08b1f51a4132c63c73455cac6569404c78c9e3b5bffd1f64e07a9a2f109b4",
     "signature": "bMqcWsPQaNKstYqP8+poAHEgkh6uzH9KLDHP3pt1PUwVjK5XGaA6z2Uk2lfKjZFjSQPG2sGD94nwiDhfd4THjg==",
-    "kksignature": "3Bk42J0FCCt7VSm3OVdn918IL3Z6bKqDzUxKy/eyd1JmJF+Qbd5Vv65YkqVWcK5xEVrwjFMC69I0WFwobySu0w=="
+    "kksignature": "JpznJ+cEUW/L8VUc3zGO1fLQYnzSG1qP11LsrN8ax+hhCag7Wr1MZC3nzdNDD2eHlFJQJXb7LdpF0l2rih29jw=="
   }
 }

--- a/integration/src/binance/tx02.mainnet.unsigned.json
+++ b/integration/src/binance/tx02.mainnet.unsigned.json
@@ -10,7 +10,7 @@
           "address": "bnb1afwh46v6nn30nkmugw5swdmsyjmlxslgjfugre",
           "coins": [
             {
-              "amount": "0.00001",
+              "amount": "1000",
               "denom": "BNB"
             }
           ]
@@ -21,7 +21,7 @@
           "address": "bnb1v7wds8atg9pxss86vq5qjuz38wqsadq7e5m2rr",
           "coins": [
             {
-              "amount": "0.00001",
+              "amount": "1000",
               "denom": "BNB"
             }
           ]

--- a/packages/hdwallet-keepkey/package.json
+++ b/packages/hdwallet-keepkey/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@keepkey/device-protocol": "^7.0.2",
     "@shapeshiftoss/hdwallet-core": "1.12.1",
+    "bignumber.js": "^9.0.1",
     "eip55": "^1.0.3",
     "ethereumjs-tx": "^1.3.7",
     "eventemitter2": "^5.0.1",

--- a/packages/hdwallet-keepkey/src/binance.ts
+++ b/packages/hdwallet-keepkey/src/binance.ts
@@ -10,6 +10,7 @@ import {
   BinanceTransferMsg,
 } from "@keepkey/device-protocol/lib/messages-binance_pb";
 import { MessageType } from "@keepkey/device-protocol/lib/messages_pb";
+import BigNumber from "bignumber.js";
 
 export function binanceGetAccountPaths(msg: Core.BinanceGetAccountPaths): Array<Core.BinanceAccountPath> {
   return [
@@ -45,8 +46,13 @@ export async function binanceSignTx(
     );
     if (resp.message_type === Core.Events.FAILURE) throw resp;
 
+    const outputAmount = new BigNumber(message.outputs[0].coins[0].amount);
+    const inputAmount = new BigNumber(message.inputs[0].coins[0].amount);
+    if (!outputAmount.isInteger()) throw new Error("Output amount must be an integer");
+    if (!inputAmount.isInteger()) throw new Error("Input amount must be an integer");
+
     let coinOut = new BinanceTransferMsg.BinanceCoin();
-    coinOut.setAmount(message.outputs[0].coins[0].amount.toString());
+    coinOut.setAmount(outputAmount.toString());
     coinOut.setDenom(message.outputs[0].coins[0].denom);
 
     let outputs = new BinanceTransferMsg.BinanceInputOutput();
@@ -54,7 +60,7 @@ export async function binanceSignTx(
     outputs.setCoinsList([coinOut]);
 
     let coinIn = new BinanceTransferMsg.BinanceCoin();
-    coinIn.setAmount(message.inputs[0].coins[0].amount.toString());
+    coinIn.setAmount(inputAmount.toString());
     coinIn.setDenom(message.inputs[0].coins[0].denom);
 
     let inputs = new BinanceTransferMsg.BinanceInputOutput();

--- a/packages/hdwallet-native/package.json
+++ b/packages/hdwallet-native/package.json
@@ -18,6 +18,7 @@
     "@shapeshiftoss/hdwallet-core": "1.12.1",
     "@terra-money/terra.js": "^1.6.0",
     "bchaddrjs": "^0.4.9",
+    "bignumber.js": "^9.0.1",
     "bip32": "^2.0.5",
     "bip39": "^3.0.2",
     "bitcoinjs-lib": "^5.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3556,7 +3556,7 @@ bignumber.js@^4.1.0:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
   integrity sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==
 
-bignumber.js@^9.0.0:
+bignumber.js@^9.0.0, bignumber.js@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
   integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -13976,10 +13976,15 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@2.0.4, whatwg-fetch@^2.0.4, whatwg-fetch@^3.0.0:
+whatwg-fetch@2.0.4, whatwg-fetch@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
+
+whatwg-fetch@^3.0.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Fixes #264 and then fixes #263.

This fix normalizes the behavior of BNB in hdwallet-native and BNB in everything else. The inputs to the BNB integration tests have been updated to reflect the correct input type, and are now consistent with the expected integration test outputs. The same string of bytes is still generated and signed, as evidenced by the updated inputs still producing the same signature value.

This change in integration test inputs also conveniently sidesteps #263. Because of this issue, the previous `kksignature` was made over an incorrect byte string; the signature is now made over the correct bytes, so the expected output had to be updated to match.

Per @natven this will require a minor version bump, which I'm pretty sure requires someone with write access to run the appropriate `lerna publish` command after this is merged to set up the tags and such.