### PR TITLE
Improved Tests Phase 2: Improved Tests

### DIFF
--- a/packages/hdwallet-native/__mocks__/@shapeshiftoss/hdwallet-core.ts
+++ b/packages/hdwallet-native/__mocks__/@shapeshiftoss/hdwallet-core.ts
@@ -1,0 +1,7 @@
+// This ensures that the module's exports are all writable, so that jest.spyOn() will work.
+const mock = {};
+const actual = jest.requireActual("@shapeshiftoss/hdwallet-core");
+for (const key of Object.keys(Object.getOwnPropertyDescriptors(actual))) {
+  mock[key] = actual[key];
+}
+module.exports = mock;

--- a/packages/hdwallet-native/__mocks__/mswMock.ts
+++ b/packages/hdwallet-native/__mocks__/mswMock.ts
@@ -1,0 +1,50 @@
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
+export = function newMswMock(handlers = {}) {
+  Object.values(handlers).forEach((x) => {
+    Object.entries(x).forEach(([k, v]) => {
+      x[k] = Object.assign(jest.fn((...args: any[]) => (typeof v === "function" ? v(...args) : v)), v);
+    });
+  });
+
+  const self = jest.fn();
+  return Object.assign(self, {
+    handlers,
+    setupServer() {
+      return setupServer(
+        ...Object.entries(this.handlers)
+          .map(([method, mocks]) =>
+            Object.entries(mocks).map(([k, v]) =>
+              rest[method](k, (req, res, ctx) => {
+                self();
+                let status = 200;
+                let out;
+                try {
+                  out = v(typeof req.body === "string" && req.body !== "" ? JSON.parse(req.body) : req.body);
+                } catch (e) {
+                  if (typeof e !== "number") throw e;
+                  status = e;
+                  out = {};
+                }
+                return res(ctx.status(status), ctx.json(out));
+              })
+            )
+          )
+          .reduce((a, x) => a.concat(x), [])
+      );
+    },
+    startServer() {
+      this.setupServer().listen({
+        onUnhandledRequest(req) {
+          throw new Error(`Unhandled ${req.method} request to ${req.url.href}`);
+        },
+      });
+      return this;
+    },
+    clear() {
+      this.mockClear();
+      Object.values(this.handlers).forEach((x) => Object.values(x).forEach((y) => y.mockClear()));
+    },
+  });
+};

--- a/packages/hdwallet-native/__mocks__/untouchableMock.ts
+++ b/packages/hdwallet-native/__mocks__/untouchableMock.ts
@@ -1,0 +1,46 @@
+function mockTraps(mock: Function) {
+  return new Proxy(
+    {},
+    {
+      get(_, propName) {
+        return (...args: any[]) => (mock(), Reflect[propName](...args));
+      },
+    }
+  );
+}
+
+function doMock<T extends object>(target: T) {
+  const mock = jest.fn();
+  return [
+    typeof target === "object" || typeof target === "function" ? new Proxy(target, mockTraps(mock)) : target,
+    mock,
+  ] as const;
+}
+export const mock = doMock;
+
+export function bind(obj, prop, ...args) {
+  const mock = jest.fn();
+  const [objProxy, objMock] = doMock(obj);
+  objMock.mockImplementation(() => mock());
+  const argProxies = args.map((arg) => {
+    const [argProxy, argMock] = doMock(arg);
+    argMock.mockImplementation(() => mock());
+    return argProxy;
+  });
+  return [Function.prototype.bind.call(obj[prop], objProxy, ...argProxies), mock];
+}
+
+export function call(obj, prop, ...args) {
+  expect(obj[prop]).toBeInstanceOf(Function);
+  const [fn, mock] = bind(obj, prop, ...args);
+  const out = fn();
+  if ((typeof out === "object" || typeof out === "function") && "then" in out && out.then instanceof Function) {
+    return (async () => {
+      const outResolved = await out;
+      expect(mock).not.toHaveBeenCalled();
+      return out;
+    })();
+  }
+  expect(mock).not.toHaveBeenCalled();
+  return out;
+}

--- a/packages/hdwallet-native/package.json
+++ b/packages/hdwallet-native/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@peculiar/webcrypto": "^1.1.3",
+    "msw": "^0.27.1",
     "scrypt-js": "^3.0.1"
   }
 }

--- a/packages/hdwallet-native/src/adapter.test.ts
+++ b/packages/hdwallet-native/src/adapter.test.ts
@@ -1,0 +1,28 @@
+import { Keyring } from "@shapeshiftoss/hdwallet-core";
+import { NativeAdapter } from "./adapter";
+import { NativeHDWallet } from "./native";
+
+describe("NativeAdapter", () => {
+  it("creates a unique wallet per deviceId", async () => {
+    const keyring = new Keyring();
+    const adapter = NativeAdapter.useKeyring(keyring);
+    await expect(adapter.initialize()).resolves.toBe(0);
+    const wallet = await adapter.pairDevice("foobar");
+    expect(wallet).toBeInstanceOf(NativeHDWallet);
+    await expect(adapter.pairDevice("foobar")).resolves.toBe(wallet);
+  });
+
+  it("won't pair if the deviceId isn't specified", async () => {
+    const keyring = new Keyring();
+    const adapter = NativeAdapter.useKeyring(keyring);
+    await expect(adapter.pairDevice(undefined)).resolves.toBe(null);
+  });
+
+  it("won't pair if a non-native wallet with the same deviceId is present in the keyring", async () => {
+    const keyring = new Keyring();
+    const adapter = NativeAdapter.useKeyring(keyring);
+    const dummyWallet = {};
+    keyring.add(dummyWallet as any, "foobar");
+    await expect(adapter.pairDevice("foobar")).resolves.toBe(null);
+  });
+});

--- a/packages/hdwallet-native/src/binance.test.ts
+++ b/packages/hdwallet-native/src/binance.test.ts
@@ -1,0 +1,204 @@
+import * as core from "@shapeshiftoss/hdwallet-core";
+import * as NativeHDWallet from "./native";
+
+const MNEMONIC = "all all all all all all all all all all all all";
+
+const mswMock = require("mswMock")({
+  get: {
+    "https://dex.binance.org/api/v1/node-info": {
+      node_info: {
+        protocol_version: { p2p: 7, block: 10, app: 0 },
+        id: "46ba46d5b6fcb61b7839881a75b081123297f7cf",
+        listen_addr: "10.212.32.84:27146",
+        network: "Binance-Chain-Tigris",
+        version: "0.32.3",
+        channels: "3640202122233038",
+        moniker: "Ararat",
+        other: { tx_index: "on", rpc_address: "tcp://0.0.0.0:27147" },
+      },
+      sync_info: {
+        latest_block_hash: "307E98FD4A06AB02688C8539FF448431D521A3BB1C4D053DE3FBF1AD63276BA9",
+        latest_app_hash: "A868C9E3186A4A8D562F73F3F53DB768F7F690478BF4D2C293A0F77F2E0C94DE",
+        latest_block_height: 151030266,
+        latest_block_time: "2021-03-18T20:42:11.972086064Z",
+        catching_up: false,
+      },
+      validator_info: {
+        address: "B7707D9F593C62E85BB9E1A2366D12A97CD5DFF2",
+        pub_key: [
+          113,
+          242,
+          215,
+          184,
+          236,
+          28,
+          139,
+          153,
+          166,
+          83,
+          66,
+          155,
+          1,
+          24,
+          205,
+          32,
+          31,
+          121,
+          79,
+          64,
+          157,
+          15,
+          234,
+          77,
+          101,
+          177,
+          182,
+          98,
+          242,
+          176,
+          0,
+          99,
+        ],
+        voting_power: 1000000000000,
+      },
+    },
+  },
+}).startServer();
+afterEach(() => expect(mswMock).not.toHaveBeenCalled());
+
+const untouchable = require("untouchableMock");
+
+describe("NativeBinanceWalletInfo", () => {
+  const info = NativeHDWallet.info();
+
+  it("should return some static metadata", async () => {
+    await expect(untouchable.call(info, "binanceSupportsNetwork")).resolves.toBe(true);
+    await expect(untouchable.call(info, "binanceSupportsSecureTransfer")).resolves.toBe(false);
+    expect(untouchable.call(info, "binanceSupportsNativeShapeShift")).toBe(false);
+  });
+
+  it("should return the correct account paths", async () => {
+    const paths = info.binanceGetAccountPaths({ accountIdx: 0 });
+    expect(paths).toMatchObject([
+      {
+        addressNList: core.bip32ToAddressNList("m/44'/714'/0'/0/0"),
+      },
+    ]);
+  });
+
+  it("does not support getting the next account path", async () => {
+    expect(untouchable.call(info, "binanceNextAccountPath", {})).toBe(undefined);
+  });
+});
+
+describe("NativeBinanceWallet", () => {
+  let wallet: NativeHDWallet.NativeHDWallet;
+
+  beforeEach(async () => {
+    wallet = NativeHDWallet.create({ deviceId: "native" });
+    await wallet.loadDevice({ mnemonic: MNEMONIC });
+    await expect(wallet.initialize()).resolves.toBe(true);
+  });
+
+  it("should generate a correct binance address", async () => {
+    await expect(
+      wallet.binanceGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/714'/0'/0/0") })
+    ).resolves.toBe("bnb1qzc0v2q7u6484czzal6ncuvqmg9fae8n2xe2c6");
+  });
+
+  it("should generate another correct binance address", async () => {
+    await expect(
+      wallet.binanceGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/714'/1337'/123/4") })
+    ).resolves.toBe("bnb14awl92k30hyhu36wjy6pg0trx3zlqrpfgsf3xk");
+  });
+
+  it("should sign a transaction correctly", async () => {
+    const sig = await wallet.binanceSignTx({
+      addressNList: core.bip32ToAddressNList("m/44'/714'/0'/0/0"),
+      tx: {
+        chain_id: "foo",
+        account_number: "123",
+        data: "bar",
+        memo: "memo",
+        msgs: [
+          {
+            inputs: [
+              {
+                address: "bnb1qzc0v2q7u6484czzal6ncuvqmg9fae8n2xe2c6",
+                coins: [
+                  {
+                    amount: 1234,
+                  },
+                ],
+              },
+            ],
+            outputs: [{ address: "bnb14awl92k30hyhu36wjy6pg0trx3zlqrpfgsf3xk" }],
+          },
+        ],
+      },
+      chain_id: "foo",
+      account_number: "123",
+      sequence: 456,
+    });
+    expect(sig.signatures).toMatchInlineSnapshot(`
+      Object {
+        "pub_key": "A/7/niWhEmyNrOL5jDyKiFyN1fMYjCxVPgyucVvj9UNT",
+        "signature": "BnbtioXs2KyTQeJFpYQM6JmLgE4XOMLIDCCYw7z7wwpRMVwV0uVoeBoNh5zJrDcJzCQw8qmwzC+I5Cl/pTz+jg==",
+      }
+    `);
+    expect(mswMock.handlers.get["https://dex.binance.org/api/v1/node-info"]).toHaveBeenCalled();
+    mswMock.clear();
+  });
+
+  it("should not sign an invalid transaction", async () => {
+    await expect(
+      wallet.binanceSignTx({
+        addressNList: core.bip32ToAddressNList("m/44'/714'/0'/0/0"),
+        tx: {
+          chain_id: "",
+          account_number: "",
+          data: "",
+          memo: "",
+          msgs: [{}],
+        },
+        chain_id: "",
+        account_number: "foobar",
+        sequence: Number.NaN,
+      })
+    ).rejects.toThrowError();
+  });
+
+  it("should not sign a transaction from a different account", async () => {
+    await expect(
+      wallet.binanceSignTx({
+        addressNList: core.bip32ToAddressNList("m/44'/714'/0'/0/0"),
+        tx: {
+          chain_id: "foo",
+          account_number: "123",
+          data: "bar",
+          memo: "memo",
+          msgs: [
+            {
+              inputs: [
+                {
+                  address: "bnb14awl92k30hyhu36wjy6pg0trx3zlqrpfgsf3xk",
+                  coins: [
+                    {
+                      amount: 1234,
+                    },
+                  ],
+                },
+              ],
+              outputs: [{ address: "bnb1qzc0v2q7u6484czzal6ncuvqmg9fae8n2xe2c6" }],
+            },
+          ],
+        },
+        chain_id: "foo",
+        account_number: "123",
+        sequence: 456,
+      })
+    ).rejects.toThrowError("Invalid permissions to sign for address");
+    expect(mswMock.handlers.get["https://dex.binance.org/api/v1/node-info"]).toHaveBeenCalled();
+    mswMock.clear();
+  });
+});

--- a/packages/hdwallet-native/src/bitcoin.test.ts
+++ b/packages/hdwallet-native/src/bitcoin.test.ts
@@ -54,50 +54,6 @@ const BIP44_BENCHMARK_TX = benchmarkTx(
   "99000"
 );
 
-// Funding Tx: https://api.blockcypher.com/v1/btc/main/txs/918f59f7144fa389f66b6776e3417e1ec356214e18684050237acc056d5efbc1?includeHex=true
-// Spending Tx: https://api.blockcypher.com/v1/btc/main/txs/6e6ad85c99bfb6ed7c0fa3ec99af02dfcdb805aeda36674bbeb3960bfc6418ba?includeHex=true
-const BIP49_BENCHMARK_TX_INPUT_TXID = "918f59f7144fa389f66b6776e3417e1ec356214e18684050237acc056d5efbc1";
-const BIP49_BENCHMARK_TX_INPUT_HEX =
-  "01000000015c4813fb3e0203e3bfa21420d62f88d2f89d39a63fde0f6ef2b08c406bda5f7f000000006a47304402205c9c26e213470dcb1c6b9399cb6cfda2c2dfece806ef10d6e5a889e39bc2e201022027d07373261478c4c43fa7044d6128f48a496cb8c97b93e4460887c664e0ef960121022a6e02f34ea72544c24f96cde286916d162de1f448396c62943b72ea16e6fb47ffffffff028f8011f8000000001976a914d32f4064914d28c30f5b309a73435588e0161f7b88ac2a5d00000000000017a914c9e193b1af9e4349d2ee53b4190e2bd36e59719e8700000000";
-const BIP49_BENCHMARK_TX_OUTPUT_ADDR = "1EC9SktW9Y4kS4iW48idshNg9eNeBdY5Xi";
-const BIP49_BENCHMARK_TX_OUTPUT =
-  "01000000000101c1fb5e6d05cc7a23504068184e2156c31e7e41e376676bf689a34f14f7598f910100000017160014ef01be1e6c7709df95c0ed763aa3b845286bbe80ffffffff01a25c0000000000001976a91490b54270b8fb85ade07261e9edc99f96fd197de588ac02483045022100ee6c831ceb78d97d1e0c24d0de62a4e87494a436157a7f2291065523f3f673f9022055b24caa363a8c51a7ed9dce546e25aefbcf9af7a08f2ed63a3bf37c9978c167012102f770feae292b5b3f41d8c81220c2568cb73eb8042def35e648dfe048e4b41b1100000000";
-const BIP49_BENCHMARK_TX_OUTPUT_SIG = BIP49_BENCHMARK_TX_OUTPUT.slice(216, 216 + 144);
-const BIP49_BENCHMARK_TX = benchmarkTx(
-  "m/49'/0'/0'/0/0",
-  "p2sh-p2wpkh",
-  BIP49_BENCHMARK_TX_INPUT_TXID,
-  1,
-  "23850",
-  {
-    tx: {
-      vout: [undefined, { scriptPubKey: { hex: "a914c9e193b1af9e4349d2ee53b4190e2bd36e59719e87" } }],
-    },
-  },
-  BIP49_BENCHMARK_TX_OUTPUT_ADDR,
-  "23714"
-);
-
-// Funding Tx: https://api.blockcypher.com/v1/btc/main/txs/fa80a9949f1094119195064462f54d0e0eabd3139becd4514ae635b8c7fe3a46?includeHex=true
-// Spending Tx: https://api.blockcypher.com/v1/btc/main/txs/7e58757f43015242c0efa29447bea4583336f2358fdff587b52bbe040ad8982a?includeHex=true
-const BIP84_BENCHMARK_TX_INPUT_TXID = "fa80a9949f1094119195064462f54d0e0eabd3139becd4514ae635b8c7fe3a46";
-const BIP84_BENCHMARK_TX_INPUT_HEX =
-  "01000000000101360d7a720e95a6068678eb08e91b3a8a4774222c9f34becf57d0dc4329e0a686000000001716001495f41f5c0e0ec2c7fe27f0ac4bd59a5632a40b5fffffffff02d224000000000000160014ece6935b2a5a5b5ff997c87370b16fa10f16441088ba04000000000017a914dfe58cc93d35fb99e15436f47d3bbfce820328068702483045022100f312e8246e6a00d21fd762f12231c5fb7a20094a32940b9a84e28d712a5ced9b02203b9124d7a94aa7eb1e090ceda32e884511d7068b8d47593aa46537900e3e37d40121037e8bf05c6c7223cfba3ea484ecd61ee910ae38609ea89b4a4839beed2186b3fb00000000";
-const BIP84_BENCHMARK_TX_OUTPUT_ADDR = "36JkLACrdxARqXXffZk91V9W6SJvghKaVK";
-const BIP84_BENCHMARK_TX_OUTPUT =
-  "01000000000101463afec7b835e64a51d4ec9b13d3ab0e0e4df562440695911194109f94a980fa0000000000ffffffff01611900000000000017a91432a276261d6f084fa46917300b6be8848853211187024730440220200b1192c3d49338678bdb30678fa270720e7ff1de4f45d5340a0cb7fbf8f2de02202457250ae49f088fc9d9663db8c92db4606dc25b098874ed7bb548d3002c346f01210396070f2813933502e907c011ae7ba928683a9c2f0e888dae7ebd2c41120ee6b500000000";
-const BIP84_BENCHMARK_TX_OUTPUT_SIG = BIP84_BENCHMARK_TX_OUTPUT.slice(166, 166 + 142);
-const BIP84_BENCHMARK_TX = benchmarkTx(
-  "m/84'/0'/0'/0/0",
-  "p2wpkh",
-  BIP84_BENCHMARK_TX_INPUT_TXID,
-  0,
-  "9426",
-  { hex: BIP84_BENCHMARK_TX_INPUT_HEX },
-  BIP84_BENCHMARK_TX_OUTPUT_ADDR,
-  "6497"
-);
-
 describe("NativeBTCWalletInfo", () => {
   const info = NativeHDWallet.info();
 
@@ -345,25 +301,10 @@ describe("NativeBTCWallet", () => {
     expect(out.serializedTx).toBe(BIP44_BENCHMARK_TX_OUTPUT);
   });
 
-  it("should sign a BIP49 transaction correctly", async () => {
-    const input = BIP49_BENCHMARK_TX;
-    const out = await wallet.btcSignTx(input);
-    expect(out.signatures).toMatchObject([BIP49_BENCHMARK_TX_OUTPUT_SIG]);
-    expect(out.serializedTx).toBe(BIP49_BENCHMARK_TX_OUTPUT);
-  });
-
-  it("should sign a BIP84 transaction correctly", async () => {
-    const input = BIP84_BENCHMARK_TX;
-    const out = await wallet.btcSignTx(input);
-
-    expect(out.signatures).toMatchObject([BIP84_BENCHMARK_TX_OUTPUT_SIG]);
-    expect(out.serializedTx).toBe(BIP84_BENCHMARK_TX_OUTPUT);
-  });
-
   it("should not sign a transaction without having the raw input transaction", async () => {
     const input = _.cloneDeep(BIP44_BENCHMARK_TX);
     delete input.inputs[0].hex;
-    await expect(wallet.btcSignTx(input)).rejects.toThrowError("must provide prev rawTx");
+    await expect(wallet.btcSignTx(input)).rejects.toThrowError();
   });
 
   it("should sign a transaction with a locktime correctly", async () => {

--- a/packages/hdwallet-native/src/bitcoin.test.ts
+++ b/packages/hdwallet-native/src/bitcoin.test.ts
@@ -1,0 +1,464 @@
+import * as core from "@shapeshiftoss/hdwallet-core";
+import * as NativeHDWallet from "./native";
+import * as Networks from "./networks";
+import * as _ from "lodash";
+
+const MNEMONIC = "all all all all all all all all all all all all";
+
+const mswMock = require("mswMock")().startServer();
+afterEach(() => expect(mswMock).not.toHaveBeenCalled());
+
+const untouchable = require("untouchableMock");
+
+function benchmarkTx(inPath, inScriptType, inTxId, inVout, inAmount, inputExtra, outAddr, outAmount) {
+  return {
+    coin: "Bitcoin",
+    inputs: [
+      {
+        addressNList: core.bip32ToAddressNList(inPath),
+        scriptType: inScriptType as any,
+        amount: inAmount,
+        vout: inVout,
+        txid: inTxId,
+        ...inputExtra,
+      },
+    ],
+    outputs: [
+      {
+        address: outAddr,
+        addressType: core.BTCOutputAddressType.Spend,
+        amount: outAmount,
+        isChange: false,
+      },
+    ],
+  };
+}
+
+// Funding Tx: https://api.blockcypher.com/v1/btc/main/txs/350eebc1012ce2339b71b5fca317a0d174abc3a633684bc65a71845deb596539?includeHex=true
+// Spending Tx: https://api.blockcypher.com/v1/btc/main/txs/1869cdbb3a86ab8b71a3e4a0d11135926b18f62bc0ebeb8e8a56635135616f00?includeHex=true
+const BIP44_BENCHMARK_TX_INPUT_TXID = "350eebc1012ce2339b71b5fca317a0d174abc3a633684bc65a71845deb596539";
+const BIP44_BENCHMARK_TX_INPUT_HEX =
+  "0100000001ac941afec3d31edd772cf45647c2c97b25b1dbfbc0045a83ca3658942a155619010000006a47304402206c8e9ce1116842cb0ea8d1e2a07d930b3692ea36964251fc453cb0b51d281b5002203b493db783d69eaad775f3b0ee2a6855dffab3977fb68a3a34a1c067716f1fb2012103fa9122a96ca4223ab9518db03fb600bbb59de61dbd4b8ae587cd3e7b9f968764ffffffff02a0860100000000001976a914bc4c06f0e7da28b37ee22fc9c93e2bb7bd8f305c88ac20dac100000000001976a9143435bb2ebfe441f268fd5a7933f43f28d2a3dfe288ac00000000";
+const BIP44_BENCHMARK_TX_OUTPUT_ADDR = "1MCgrVZjXRJJJhi2Z6SR11GpRjCyvNjscY";
+const BIP44_BENCHMARK_TX_OUTPUT =
+  "0100000001396559eb5d84715ac64b6833a6c3ab74d1a017a3fcb5719b33e22c01c1eb0e35000000006a47304402203b727eb80b3bac3b23bb88e8a22a77eb5232dd4bf079cb1520769a1eca88d96302201e36cf5919f17eb61ef87b8e5f1dc684df98a42f58e815f002b7dcc6c665ee0d012103c6d9cc725bb7e19c026df03bf693ee1171371a8eaf25f04b7a58f6befabcd38cffffffff01b8820100000000001976a914dd985beff82366763a5d86dd8c61b98d3f79590b88ac00000000";
+const BIP44_BENCHMARK_TX_OUTPUT_SIG = BIP44_BENCHMARK_TX_OUTPUT.slice(86, 86 + 140);
+const BIP44_BENCHMARK_TX = benchmarkTx(
+  "m/44'/0'/0'/0/0",
+  "p2pkh",
+  BIP44_BENCHMARK_TX_INPUT_TXID,
+  0,
+  "100000",
+  { hex: BIP44_BENCHMARK_TX_INPUT_HEX },
+  BIP44_BENCHMARK_TX_OUTPUT_ADDR,
+  "99000"
+);
+
+// Funding Tx: https://api.blockcypher.com/v1/btc/main/txs/918f59f7144fa389f66b6776e3417e1ec356214e18684050237acc056d5efbc1?includeHex=true
+// Spending Tx: https://api.blockcypher.com/v1/btc/main/txs/6e6ad85c99bfb6ed7c0fa3ec99af02dfcdb805aeda36674bbeb3960bfc6418ba?includeHex=true
+const BIP49_BENCHMARK_TX_INPUT_TXID = "918f59f7144fa389f66b6776e3417e1ec356214e18684050237acc056d5efbc1";
+const BIP49_BENCHMARK_TX_INPUT_HEX =
+  "01000000015c4813fb3e0203e3bfa21420d62f88d2f89d39a63fde0f6ef2b08c406bda5f7f000000006a47304402205c9c26e213470dcb1c6b9399cb6cfda2c2dfece806ef10d6e5a889e39bc2e201022027d07373261478c4c43fa7044d6128f48a496cb8c97b93e4460887c664e0ef960121022a6e02f34ea72544c24f96cde286916d162de1f448396c62943b72ea16e6fb47ffffffff028f8011f8000000001976a914d32f4064914d28c30f5b309a73435588e0161f7b88ac2a5d00000000000017a914c9e193b1af9e4349d2ee53b4190e2bd36e59719e8700000000";
+const BIP49_BENCHMARK_TX_OUTPUT_ADDR = "1EC9SktW9Y4kS4iW48idshNg9eNeBdY5Xi";
+const BIP49_BENCHMARK_TX_OUTPUT =
+  "01000000000101c1fb5e6d05cc7a23504068184e2156c31e7e41e376676bf689a34f14f7598f910100000017160014ef01be1e6c7709df95c0ed763aa3b845286bbe80ffffffff01a25c0000000000001976a91490b54270b8fb85ade07261e9edc99f96fd197de588ac02483045022100ee6c831ceb78d97d1e0c24d0de62a4e87494a436157a7f2291065523f3f673f9022055b24caa363a8c51a7ed9dce546e25aefbcf9af7a08f2ed63a3bf37c9978c167012102f770feae292b5b3f41d8c81220c2568cb73eb8042def35e648dfe048e4b41b1100000000";
+const BIP49_BENCHMARK_TX_OUTPUT_SIG = BIP49_BENCHMARK_TX_OUTPUT.slice(216, 216 + 144);
+const BIP49_BENCHMARK_TX = benchmarkTx(
+  "m/49'/0'/0'/0/0",
+  "p2sh-p2wpkh",
+  BIP49_BENCHMARK_TX_INPUT_TXID,
+  1,
+  "23850",
+  {
+    tx: {
+      vout: [undefined, { scriptPubKey: { hex: "a914c9e193b1af9e4349d2ee53b4190e2bd36e59719e87" } }],
+    },
+  },
+  BIP49_BENCHMARK_TX_OUTPUT_ADDR,
+  "23714"
+);
+
+// Funding Tx: https://api.blockcypher.com/v1/btc/main/txs/fa80a9949f1094119195064462f54d0e0eabd3139becd4514ae635b8c7fe3a46?includeHex=true
+// Spending Tx: https://api.blockcypher.com/v1/btc/main/txs/7e58757f43015242c0efa29447bea4583336f2358fdff587b52bbe040ad8982a?includeHex=true
+const BIP84_BENCHMARK_TX_INPUT_TXID = "fa80a9949f1094119195064462f54d0e0eabd3139becd4514ae635b8c7fe3a46";
+const BIP84_BENCHMARK_TX_INPUT_HEX =
+  "01000000000101360d7a720e95a6068678eb08e91b3a8a4774222c9f34becf57d0dc4329e0a686000000001716001495f41f5c0e0ec2c7fe27f0ac4bd59a5632a40b5fffffffff02d224000000000000160014ece6935b2a5a5b5ff997c87370b16fa10f16441088ba04000000000017a914dfe58cc93d35fb99e15436f47d3bbfce820328068702483045022100f312e8246e6a00d21fd762f12231c5fb7a20094a32940b9a84e28d712a5ced9b02203b9124d7a94aa7eb1e090ceda32e884511d7068b8d47593aa46537900e3e37d40121037e8bf05c6c7223cfba3ea484ecd61ee910ae38609ea89b4a4839beed2186b3fb00000000";
+const BIP84_BENCHMARK_TX_OUTPUT_ADDR = "36JkLACrdxARqXXffZk91V9W6SJvghKaVK";
+const BIP84_BENCHMARK_TX_OUTPUT =
+  "01000000000101463afec7b835e64a51d4ec9b13d3ab0e0e4df562440695911194109f94a980fa0000000000ffffffff01611900000000000017a91432a276261d6f084fa46917300b6be8848853211187024730440220200b1192c3d49338678bdb30678fa270720e7ff1de4f45d5340a0cb7fbf8f2de02202457250ae49f088fc9d9663db8c92db4606dc25b098874ed7bb548d3002c346f01210396070f2813933502e907c011ae7ba928683a9c2f0e888dae7ebd2c41120ee6b500000000";
+const BIP84_BENCHMARK_TX_OUTPUT_SIG = BIP84_BENCHMARK_TX_OUTPUT.slice(166, 166 + 142);
+const BIP84_BENCHMARK_TX = benchmarkTx(
+  "m/84'/0'/0'/0/0",
+  "p2wpkh",
+  BIP84_BENCHMARK_TX_INPUT_TXID,
+  0,
+  "9426",
+  { hex: BIP84_BENCHMARK_TX_INPUT_HEX },
+  BIP84_BENCHMARK_TX_OUTPUT_ADDR,
+  "6497"
+);
+
+describe("NativeBTCWalletInfo", () => {
+  const info = NativeHDWallet.info();
+
+  it("should return some static metadata", async () => {
+    expect(info["btcSupportsNetwork"]).not.toBeDefined();
+    await expect(untouchable.call(info, "btcSupportsSecureTransfer")).resolves.toBe(false);
+    expect(untouchable.call(info, "btcSupportsNativeShapeShift")).toBe(false);
+  });
+
+  it("should return some dynamic metadata", async () => {
+    await expect(info.btcSupportsCoin("bitcoin")).resolves.toBe(true);
+    await expect(info.btcSupportsCoin("bitcoincash")).resolves.toBe(false);
+
+    await expect(info.btcSupportsScriptType("bitcoin", "p2pkh" as any)).resolves.toBe(true);
+    await expect(info.btcSupportsScriptType("bitcoin", "p2sh" as any)).resolves.toBe(true);
+    await expect(info.btcSupportsScriptType("bitcoin", "p2wpkh" as any)).resolves.toBe(true);
+    await expect(info.btcSupportsScriptType("bitcoin", "p2sh-p2wpkh" as any)).resolves.toBe(true);
+    await expect(info.btcSupportsScriptType("bitcoin", "cashaddr" as any)).resolves.toBe(false);
+    await expect(info.btcSupportsScriptType("bitcoincash", "cashaddr" as any)).resolves.toBe(false);
+    await expect(info.btcSupportsScriptType("bitcoin", "foobar" as any)).resolves.toBe(false);
+    await expect(info.btcSupportsScriptType("foobar", "p2pkh" as any)).resolves.toBe(false);
+  });
+
+  it("should not do anything when btcIsSameAccount is called", async () => {
+    expect(untouchable.call(info, "btcIsSameAccount", [])).toBe(false);
+  });
+
+  it.each([
+    [
+      "an undefined scriptType",
+      "Bitcoin",
+      undefined,
+      0,
+      [
+        {
+          coin: "Bitcoin",
+          scriptType: "p2pkh",
+          addressNList: core.bip32ToAddressNList("m/44'/0'/0'"),
+        },
+        {
+          coin: "Bitcoin",
+          scriptType: "p2sh-p2wpkh",
+          addressNList: core.bip32ToAddressNList("m/49'/0'/0'"),
+        },
+        {
+          coin: "Bitcoin",
+          scriptType: "p2wpkh",
+          addressNList: core.bip32ToAddressNList("m/84'/0'/0'"),
+        },
+      ],
+    ],
+    [
+      "BIP44",
+      "Bitcoin",
+      "p2pkh",
+      1337,
+      [
+        {
+          coin: "Bitcoin",
+          scriptType: "p2pkh",
+          addressNList: core.bip32ToAddressNList("m/44'/0'/1337'"),
+        },
+      ],
+    ],
+    [
+      "BIP49",
+      "Bitcoin",
+      "p2sh-p2wpkh",
+      1337,
+      [
+        {
+          coin: "Bitcoin",
+          scriptType: "p2sh-p2wpkh",
+          addressNList: core.bip32ToAddressNList("m/49'/0'/1337'"),
+        },
+      ],
+    ],
+    [
+      "BIP84",
+      "Bitcoin",
+      "p2wpkh",
+      1337,
+      [
+        {
+          coin: "Bitcoin",
+          scriptType: "p2wpkh",
+          addressNList: core.bip32ToAddressNList("m/84'/0'/1337'"),
+        },
+      ],
+    ],
+  ])("should return the correct account paths for %s", (_, coin, scriptType: any, accountIdx, out) => {
+    expect(info.btcGetAccountPaths({ coin, scriptType, accountIdx })).toMatchObject(out);
+  });
+
+  it("should not return any account paths for a bad coin type", () => {
+    expect(
+      info.btcGetAccountPaths({
+        coin: "foobar",
+        accountIdx: 0,
+      })
+    ).toMatchObject([]);
+  });
+
+  describe("btcNextAccountPath", () => {
+    it.each([
+      ["BIP44", "Bitcoin", "p2pkh", "m/44'/0'/0'", "m/44'/0'/1'"],
+      ["BIP44", "Bitcoin", "p2pkh", "m/44'/0'/1337'", "m/44'/0'/1338'"],
+      ["BIP49", "Bitcoin", "p2sh-p2wpkh", "m/49'/0'/0'", "m/49'/0'/1'"],
+      ["BIP84", "Bitcoin", "p2wpkh", "m/84'/0'/0'", "m/84'/0'/1'"],
+      ["Bitcoin Cash", "BitcoinCash", "p2pkh", "m/44'/145'/1337'", "m/44'/145'/1338'"],
+    ])("should work for %s", (_, coin, scriptType: any, inPath, outPath) => {
+      expect(
+        info.btcNextAccountPath({
+          coin,
+          scriptType,
+          addressNList: core.bip32ToAddressNList(inPath),
+        })
+      ).toMatchObject({
+        coin,
+        scriptType,
+        addressNList: core.bip32ToAddressNList(outPath),
+      });
+    });
+
+    it.each([
+      ["BIP44 with p2sh-p2wpkh scripts", "Bitcoin", "p2sh-p2wpkh", "m/44'/0'/0'"],
+      ["BIP44 with p2wpkh scripts", "Bitcoin", "p2wpkh", "m/44'/0'/0'"],
+      ["BIP49 with p2pkh scripts", "Bitcoin", "p2pkh", "m/49'/0'/0'"],
+      ["BIP49 with p2wpkh scripts", "Bitcoin", "p2wpkh", "m/49'/0'/0'"],
+      ["BIP84 with p2pkh scripts", "Bitcoin", "p2pkh", "m/84'/0'/0'"],
+      ["BIP84 with p2sh-p2wpkh scripts", "Bitcoin", "p2sh-p2wpkh", "m/84'/0'/0'"],
+      ["an unrecognized path", "Bitcoin", "p2pkh", "m/1337'/0'/0'"],
+      ["a lowercase coin name", "bitcoin", "p2pkh", "m/44'/0'/0'"],
+      ["a bad coin name", "foobar", "p2pkh", "m/44'/0'/0'"],
+      ["a bad script type name", "Bitcoin", "foobar", "m/44'/0'/0'"],
+    ])("should not work for %s", (_, coin, scriptType: any, path) => {
+      expect(
+        info.btcNextAccountPath({
+          coin,
+          scriptType,
+          addressNList: core.bip32ToAddressNList(path),
+        })
+      ).toBeUndefined();
+    });
+
+    it.each([
+      ["BIP44", "m/44'/0'/0'/0/0", "p2pkh"],
+      ["BIP49", "m/49'/0'/0'/0/0", "p2sh-p2wpkh"],
+      ["BIP84", "m/84'/0'/0'/0/0", "p2wpkh"],
+    ])("should not work for a %s path with an unrecognized purpose field", (_, path, scriptType: any) => {
+      const mock = jest
+        .spyOn(core, "describeUTXOPath")
+        .mockReturnValue(core.describeUTXOPath(core.bip32ToAddressNList(path), "Bitcoin", scriptType));
+      expect(
+        info.btcNextAccountPath({
+          coin: "Bitcoin",
+          scriptType,
+          addressNList: core.bip32ToAddressNList("m/1337'/0'/0'/0/0"),
+        })
+      ).toBeUndefined();
+      mock.mockRestore();
+    });
+  });
+});
+
+describe("NativeBTCWallet", () => {
+  let wallet: NativeHDWallet.NativeHDWallet;
+
+  beforeEach(async () => {
+    wallet = NativeHDWallet.create({ deviceId: "native" });
+    await wallet.loadDevice({ mnemonic: MNEMONIC });
+    await expect(wallet.initialize()).resolves.toBe(true);
+  });
+
+  it.each([
+    [
+      "BIP44",
+      "Bitcoin",
+      "p2pkh",
+      [
+        ["m/44'/0'/0'/0/0", "1JAd7XCBzGudGpJQSDSfpmJhiygtLQWaGL"],
+        ["m/44'/0'/1337'/123/4", "12EgVaC3wL5rVczoMfTwJWpZ2v783cptjs"],
+      ],
+    ],
+    [
+      "BIP49",
+      "Bitcoin",
+      "p2sh-p2wpkh",
+      [
+        ["m/49'/0'/0'/0/0", "3L6TyTisPBmrDAj6RoKmDzNnj4eQi54gD2"],
+        ["m/49'/0'/1337'/123/4", "3CXezZxPpvNMriYWXUHYuxAByUXpANWMzb"],
+      ],
+    ],
+    [
+      "BIP84",
+      "Bitcoin",
+      "p2wpkh",
+      [
+        ["m/84'/0'/0'/0/0", "bc1qannfxke2tfd4l7vhepehpvt05y83v3qsf6nfkk"],
+        ["m/84'/0'/1337'/123/4", "bc1q9sjm947kn2hz84syykmem7dshvevm8xm5dkrpg"],
+      ],
+    ],
+    [
+      "Bitcoin Cash",
+      "BitcoinCash",
+      // maybe "cashaddr" should work here, but it doesn't.
+      "p2pkh",
+      [
+        ["m/44'/145'/0'/0/0", "bitcoincash:qr08q88p9etk89wgv05nwlrkm4l0urz4cyl36hh9sv"],
+        ["m/44'/145'/1337'/123/4", "bitcoincash:qzrgv3veuqtu9g345w3hz8kwx796ty6vuu7hqstryu"],
+      ],
+    ],
+  ])("should generate correct %s addresses", async (_, coin, scriptType: any, addrSpec) => {
+    for (const [path, addr] of addrSpec) {
+      expect(await wallet.btcGetAddress({ coin, scriptType, addressNList: core.bip32ToAddressNList(path) })).toBe(addr);
+    }
+  });
+
+  it("does not support p2sh addresses", async () => {
+    await expect(
+      wallet.btcGetAddress({
+        coin: "Bitcoin",
+        scriptType: "p2sh" as any,
+        addressNList: core.bip32ToAddressNList("m/44'/0'/0'/0/0"),
+      })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`"Not enough data"`);
+  });
+
+  it("should not generate addresses for bad script types", async () => {
+    const mock = jest.spyOn(Networks, "getNetwork").mockReturnValue(Networks.getNetwork("bitcoin", "p2pkh"));
+    await expect(
+      wallet.btcGetAddress({
+        coin: "Bitcoin",
+        scriptType: "foobar" as any,
+        addressNList: core.bip32ToAddressNList("m/44'/0'/0'/0/0"),
+      })
+    ).rejects.toThrowError("no implementation for script type");
+    mock.mockRestore();
+  });
+
+  it("should sign a BIP44 transaction correctly", async () => {
+    const input = BIP44_BENCHMARK_TX;
+    const out = await wallet.btcSignTx(input);
+    expect(out.signatures).toMatchObject([BIP44_BENCHMARK_TX_OUTPUT_SIG]);
+    expect(out.serializedTx).toBe(BIP44_BENCHMARK_TX_OUTPUT);
+  });
+
+  it("should sign a BIP49 transaction correctly", async () => {
+    const input = BIP49_BENCHMARK_TX;
+    const out = await wallet.btcSignTx(input);
+    expect(out.signatures).toMatchObject([BIP49_BENCHMARK_TX_OUTPUT_SIG]);
+    expect(out.serializedTx).toBe(BIP49_BENCHMARK_TX_OUTPUT);
+  });
+
+  it("should sign a BIP84 transaction correctly", async () => {
+    const input = BIP84_BENCHMARK_TX;
+    const out = await wallet.btcSignTx(input);
+
+    expect(out.signatures).toMatchObject([BIP84_BENCHMARK_TX_OUTPUT_SIG]);
+    expect(out.serializedTx).toBe(BIP84_BENCHMARK_TX_OUTPUT);
+  });
+
+  it("should not sign a transaction without having the raw input transaction", async () => {
+    const input = _.cloneDeep(BIP44_BENCHMARK_TX);
+    delete input.inputs[0].hex;
+    await expect(wallet.btcSignTx(input)).rejects.toThrowError("must provide prev rawTx");
+  });
+
+  it("should sign a transaction with a locktime correctly", async () => {
+    const input = {
+      locktime: 338841,
+      ...BIP44_BENCHMARK_TX,
+    };
+
+    const locktimeBuf = Buffer.alloc(4);
+    locktimeBuf.writeUInt32LE(input["locktime"]);
+    const locktimeHex = locktimeBuf.toString("hex");
+
+    const out = await wallet.btcSignTx(input);
+    const sigHex =
+      "3044022006e609c8a9bedb7088d46140ab5f54a1a2023bc49b44cdf8fa147a181974b39702203e159bd869d8ccc85468856d9165cfc5df1885a8d8f1ebeaaaa5b8211f6317af";
+    expect(out.signatures).toMatchObject([sigHex]);
+    expect(out.serializedTx).toBe(
+      `${BIP44_BENCHMARK_TX_OUTPUT.slice(0, 86)}${sigHex}${BIP44_BENCHMARK_TX_OUTPUT.slice(-156, -8)}${locktimeHex}`
+    );
+  });
+
+  it("should sign a pre-fork BitcoinCash transaction correctly", async () => {
+    const input = {
+      ...BIP44_BENCHMARK_TX,
+      coin: "BitcoinCash",
+    };
+
+    const out = await wallet.btcSignTx(input);
+    expect(out.signatures).toMatchObject([BIP44_BENCHMARK_TX_OUTPUT_SIG]);
+    expect(out.serializedTx).toBe(BIP44_BENCHMARK_TX_OUTPUT);
+  });
+
+  it("should automatically set the output address for a transaction", async () => {
+    const input = {
+      ...BIP44_BENCHMARK_TX,
+      outputs: [
+        {
+          addressNList: core.bip32ToAddressNList("m/44'/0'/0'/0/1"),
+          scriptType: core.BTCOutputScriptType.PayToAddress,
+          amount: "99000",
+          isChange: false,
+        },
+      ],
+    };
+
+    const out = await wallet.btcSignTx(input as any);
+
+    expect(out.signatures[0]).toMatchInlineSnapshot(
+      `"3045022100b5971b81e1da04beec2ebe58b909953119b57490581de23e55721832b70c361a022038478c5a5036026fab419ccdae380143b6f14c379186dafa2a7e04735808aa1f"`
+    );
+    expect(out.serializedTx).toMatchInlineSnapshot(
+      `"0100000001396559eb5d84715ac64b6833a6c3ab74d1a017a3fcb5719b33e22c01c1eb0e35000000006b483045022100b5971b81e1da04beec2ebe58b909953119b57490581de23e55721832b70c361a022038478c5a5036026fab419ccdae380143b6f14c379186dafa2a7e04735808aa1f012103c6d9cc725bb7e19c026df03bf693ee1171371a8eaf25f04b7a58f6befabcd38cffffffff01b8820100000000001976a91402eea9ab5f88d829c501760bec348a5baa55cf3888ac00000000"`
+    );
+  });
+
+  it("should not automatically set the output address for a transaction requesting an invalid scriptType", async () => {
+    const input = {
+      ...BIP44_BENCHMARK_TX,
+      outputs: [
+        {
+          addressNList: core.bip32ToAddressNList("m/44'/0'/0'/0/1"),
+          scriptType: "foobar" as any,
+          amount: "99000",
+          isChange: false,
+        },
+      ],
+    };
+
+    await expect(wallet.btcSignTx(input as any)).rejects.toThrowError("failed to add output");
+  });
+
+  it("should not sign a transaction with the wrong key", async () => {
+    const input = _.cloneDeep(BIP44_BENCHMARK_TX);
+    input.inputs[0].addressNList = core.bip32ToAddressNList("m/44'/0'/1337'/123/4");
+
+    await expect(wallet.btcSignTx(input as any)).rejects.toThrowError("Can not sign for this input");
+  });
+
+  it("doesn't support signing messages", async () => {
+    await expect(
+      wallet.btcSignMessage({
+        addressNList: core.bip32ToAddressNList("m/44'/0'/0'/0/0"),
+        message: "foobar",
+      })
+    ).rejects.toThrowError("not implemented");
+  });
+
+  it("doesn't support verifying messages", async () => {
+    await expect(
+      wallet.btcVerifyMessage({
+        coin: "Bitcoin",
+        address: "1JAd7XCBzGudGpJQSDSfpmJhiygtLQWaGL",
+        message: "foo",
+        signature: "bar",
+      })
+    ).rejects.toThrowError("not implemented");
+  });
+});

--- a/packages/hdwallet-native/src/cosmos.test.ts
+++ b/packages/hdwallet-native/src/cosmos.test.ts
@@ -22,7 +22,54 @@ describe("NativeCosmosWalletInfo", () => {
     expect(paths).toMatchObject([{ addressNList: core.bip32ToAddressNList("m/44'/118'/0'/0/0") }]);
   });
 
-  it("does not support getting the next account path", async()=>{
+  it("does not support getting the next account path", async () => {
     expect(untouchable.call(info, "cosmosNextAccountPath", {})).toBe(undefined);
-  })
+  });
+});
+
+describe("NativeCosmosWallet", () => {
+  let wallet: NativeHDWallet.NativeHDWallet;
+
+  beforeEach(async () => {
+    wallet = NativeHDWallet.create({ deviceId: "native" });
+    await wallet.loadDevice({ mnemonic: MNEMONIC });
+    await expect(wallet.initialize()).resolves.toBe(true);
+  });
+
+  it("should generate a correct cosmos address", async () => {
+    await expect(
+      wallet.cosmosGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/118'/0'/0/0") })
+    ).resolves.toBe("cosmos1knuunh0lmwyrkjmrj7sky49uxk3peyzhzsvqqf");
+  });
+
+  it("should generate another correct cosmos address", async () => {
+    await expect(
+      wallet.cosmosGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/118'/1337'/123/4") })
+    ).resolves.toBe("cosmos14k4dnrrmxdch6nkvvuugsywrgmvlwrqszjfxjt");
+  });
+
+  it("should sign a transaction correctly", async () => {
+    const signed = await wallet.cosmosSignTx({
+      addressNList: core.bip32ToAddressNList("m/44'/118'/0'/0/0"),
+      tx: {
+        msg: [{ type: "foo", value: "bar" }],
+        fee: {
+          amount: [{ denom: "foo", amount: "bar" }],
+          gas: "baz",
+        },
+        signatures: null,
+        memo: "foobar",
+      },
+      chain_id: "cosmoshub-4",
+      account_number: "foo",
+      sequence: "bar",
+    });
+    await expect(signed.signatures.length).toBe(1);
+    await expect(signed.signatures[0].pub_key.value).toMatchInlineSnapshot(
+      `"AuGwbxSqxtP4HsVyUqrWiAZfb7Ur+gKYcAQ+Ru8mIBxQ"`
+    );
+    await expect(signed.signatures[0].signature).toMatchInlineSnapshot(
+      `"pWgTUZC5NUcqVrJJQL3BhLtIRcerd21H6EaTkkYIw/VGCau1hMDQDSKzKDvVICN7CSS4i1I7BhZs8nqF/E3Y9w=="`
+    );
+  });
 });

--- a/packages/hdwallet-native/src/cosmos.test.ts
+++ b/packages/hdwallet-native/src/cosmos.test.ts
@@ -1,0 +1,28 @@
+import * as core from "@shapeshiftoss/hdwallet-core";
+import * as NativeHDWallet from "./native";
+
+const MNEMONIC = "all all all all all all all all all all all all";
+
+const mswMock = require("mswMock")().startServer();
+afterEach(() => expect(mswMock).not.toHaveBeenCalled());
+
+const untouchable = require("untouchableMock");
+
+describe("NativeCosmosWalletInfo", () => {
+  const info = NativeHDWallet.info();
+
+  it("should return some static metadata", async () => {
+    await expect(untouchable.call(info, "cosmosSupportsNetwork")).resolves.toBe(true);
+    await expect(untouchable.call(info, "cosmosSupportsSecureTransfer")).resolves.toBe(false);
+    expect(untouchable.call(info, "cosmosSupportsNativeShapeShift")).toBe(false);
+  });
+
+  it("should return the correct account paths", async () => {
+    const paths = info.cosmosGetAccountPaths({ accountIdx: 0 });
+    expect(paths).toMatchObject([{ addressNList: core.bip32ToAddressNList("m/44'/118'/0'/0/0") }]);
+  });
+
+  it("does not support getting the next account path", async()=>{
+    expect(untouchable.call(info, "cosmosNextAccountPath", {})).toBe(undefined);
+  })
+});

--- a/packages/hdwallet-native/src/crypto/CryptoHelper.test.ts
+++ b/packages/hdwallet-native/src/crypto/CryptoHelper.test.ts
@@ -5,6 +5,7 @@ import CryptoHelper from "./CryptoHelper";
 import { WebCryptoEngine } from "./engines";
 import { fromBufferToUtf8, toArrayBuffer } from "./utils";
 import { Crypto } from "@peculiar/webcrypto";
+import { CipherString } from "./classes";
 
 const PLAINTEXT_STRING = "totally random secret data"
 const ENCRYPTED_STRING = "2.A/tC/OC0U/KN3XuAuz2L36lydOyr5x367tPSGSrPkvQ=|AAAAAAAAAAAAAAAAAAAAAA==|ZqR8HTeOg4+8mzcty10jVFZ5MqFFbn5bwEaqlL0c/Mg="
@@ -74,14 +75,14 @@ describe("CryptoHelpers", () => {
   describe("aesDecrypt", () => {
     it("should decrypt data with an hmac signature", async () => {
       const key = await helper.makeKey("password", "email");
-      const encrypted = await helper.aesEncrypt(toArrayBuffer(PLAINTEXT_STRING), key);
+      const encrypted = (new CipherString(ENCRYPTED_STRING)).toEncryptedObject(key);
       const decrypted = await helper.aesDecrypt(encrypted.data, encrypted.iv, encrypted.mac, encrypted.key);
       expect(fromBufferToUtf8(decrypted)).toEqual(PLAINTEXT_STRING);
     });
 
     it("should fail if the mac is incorrect", async () => {
       const key = await helper.makeKey("password", "email");
-      const encrypted = await helper.aesEncrypt(toArrayBuffer(PLAINTEXT_STRING), key);
+      const encrypted = (new CipherString(ENCRYPTED_STRING)).toEncryptedObject(key);
       const mac = new Uint8Array(encrypted.mac.byteLength).fill(128);
       await expect(helper.aesDecrypt(encrypted.data, encrypted.iv, mac, encrypted.key)).rejects.toThrow(
         "HMAC signature is not valid"

--- a/packages/hdwallet-native/src/crypto/CryptoHelper.test.ts
+++ b/packages/hdwallet-native/src/crypto/CryptoHelper.test.ts
@@ -35,16 +35,14 @@ describe("CryptoHelpers", () => {
 
     it.each([[undefined], [null], ["encrypteddatastring"], [[1, 2, 3, 4, 5, 6]], [{}]])(
       "should throw an error if data is not an ArrayBuffer (%o)",
-      async (param) => {
-        // @ts-ignore
-        await expect(helper.aesEncrypt(param)).rejects.toThrow("is not an ArrayBuffer");
+      async (param: any) => {
+        await expect(helper.aesEncrypt(param, undefined)).rejects.toThrow("is not an ArrayBuffer");
       }
     );
 
     it.each([[undefined], [null], ["encrypteddatastring"], [[1, 2, 3, 4, 5, 6]], [{}]])(
       "should throw an error if key is not a SymmetricCryptoKey (%o)",
-      async (param) => {
-        // @ts-ignore
+      async (param: any) => {
         await expect(helper.aesEncrypt(new Uint8Array(32), param)).rejects.toThrow("is not a SymmetricCryptoKey");
       }
     );
@@ -69,35 +67,31 @@ describe("CryptoHelpers", () => {
 
     it.each([[undefined], [null], ["encrypteddatastring"], [[1, 2, 3, 4, 5, 6]], [{}]])(
       "should throw an error if data is not an ArrayBuffer (%o)",
-      async (param) => {
-        // @ts-ignore
-        await expect(helper.aesDecrypt(param)).rejects.toThrow("is not an ArrayBuffer");
+      async (param: any) => {
+        await expect(helper.aesDecrypt(param, undefined, undefined, undefined)).rejects.toThrow("is not an ArrayBuffer");
       }
     );
 
     it.each([[undefined], [null], ["encrypteddatastring"], [[1, 2, 3, 4, 5, 6]], [{}]])(
       "should throw an error if iv is not an ArrayBuffer (%o)",
-      async (param) => {
+      async (param: any) => {
         const array = new Uint8Array(32).fill(0);
-        // @ts-ignore
-        await expect(helper.aesDecrypt(array, param)).rejects.toThrow("is not an ArrayBuffer");
+        await expect(helper.aesDecrypt(array, param, undefined, undefined)).rejects.toThrow("is not an ArrayBuffer");
       }
     );
 
     it.each([[undefined], [null], ["encrypteddatastring"], [[1, 2, 3, 4, 5, 6]], [{}]])(
       "should throw an error if mac is not an ArrayBuffer (%o)",
-      async (param) => {
+      async (param: any) => {
         const array = new Uint8Array(32).fill(0);
-        // @ts-ignore
-        await expect(helper.aesDecrypt(array, array, param)).rejects.toThrow("is not an ArrayBuffer");
+        await expect(helper.aesDecrypt(array, array, param, undefined)).rejects.toThrow("is not an ArrayBuffer");
       }
     );
 
     it.each([[undefined], [null], ["encrypteddatastring"], [[1, 2, 3, 4, 5, 6]], [{}]])(
       "should throw an error if key is not a SymmetricCryptoKey (%o)",
-      async (param) => {
+      async (param: any) => {
         const array = new Uint8Array(32).fill(0);
-        // @ts-ignore
         await expect(helper.aesDecrypt(array, array, array, param)).rejects.toThrow("is not a SymmetricCryptoKey");
       }
     );
@@ -119,14 +113,12 @@ describe("CryptoHelpers", () => {
   describe("makeKey", () => {
     it.each([[undefined], [null], [""], [[1, 2, 3, 4, 5, 6]], [{}]])(
       "should require a password (%o)",
-      async (param) => {
-        // @ts-ignore
-        await expect(helper.makeKey(param)).rejects.toThrow("password");
+      async (param: any) => {
+        await expect(helper.makeKey(param, undefined)).rejects.toThrow("password");
       }
     );
 
-    it.each([[undefined], [null], [""], [[1, 2, 3, 4, 5, 6]], [{}]])("should require an email (%o)", async (param) => {
-      // @ts-ignore
+    it.each([[undefined], [null], [""], [[1, 2, 3, 4, 5, 6]], [{}]])("should require an email (%o)", async (param: any) => {
       await expect(helper.makeKey("mypassword", param)).rejects.toThrow("email");
     });
   });

--- a/packages/hdwallet-native/src/crypto/CryptoHelper.test.ts
+++ b/packages/hdwallet-native/src/crypto/CryptoHelper.test.ts
@@ -9,7 +9,6 @@ import { CipherString } from "./classes";
 
 const PLAINTEXT_STRING = "totally random secret data"
 const ENCRYPTED_STRING = "2.A/tC/OC0U/KN3XuAuz2L36lydOyr5x367tPSGSrPkvQ=|AAAAAAAAAAAAAAAAAAAAAA==|ZqR8HTeOg4+8mzcty10jVFZ5MqFFbn5bwEaqlL0c/Mg="
-const ENCRYPTED_EMPTY_STRING = "2.7wpUO5ISHHdT1voBnjzyXQ==|AAAAAAAAAAAAAAAAAAAAAA==|02KQ8aQWWXUX7foOmf4T2W0XCFAk4OTKFQO+hRhlRcY=";
 
 describe("CryptoHelpers", () => {
   // Load shim to support running tests in node
@@ -42,21 +41,6 @@ describe("CryptoHelpers", () => {
       expect(encrypted.mac.byteLength).toBe(32);
       expect(encrypted.data.byteLength).toBe(32);
       expect(encrypted.toString()).toEqual(ENCRYPTED_STRING);
-    });
-
-    it("should encrypt the empty string", async () => {
-      const randomMock = jest
-        .spyOn(global.crypto, "getRandomValues")
-        .mockImplementation((array) => new Uint8Array(array.byteLength).fill(0));
-      const key = await helper.makeKey("password", "email");
-      const encrypted = await helper.aesEncrypt(toArrayBuffer(""), key);
-      randomMock.mockRestore();
-
-      expect(encrypted.key).toEqual(key);
-      expect(encrypted.iv.byteLength).toBe(16);
-      expect(encrypted.mac.byteLength).toBe(32);
-      expect(encrypted.data.byteLength).toBe(16);
-      expect(encrypted.toString()).toEqual(ENCRYPTED_EMPTY_STRING);
     });
 
     it.each([[undefined], [null], ["encrypteddatastring"], [[1, 2, 3, 4, 5, 6]], [{}]])(

--- a/packages/hdwallet-native/src/crypto/CryptoHelper.test.ts
+++ b/packages/hdwallet-native/src/crypto/CryptoHelper.test.ts
@@ -7,6 +7,7 @@ import { fromBufferToUtf8, toArrayBuffer } from "./utils";
 import { Crypto } from "@peculiar/webcrypto";
 
 const PLAINTEXT_STRING = "totally random secret data"
+const ENCRYPTED_STRING = "2.A/tC/OC0U/KN3XuAuz2L36lydOyr5x367tPSGSrPkvQ=|AAAAAAAAAAAAAAAAAAAAAA==|ZqR8HTeOg4+8mzcty10jVFZ5MqFFbn5bwEaqlL0c/Mg="
 
 describe("CryptoHelpers", () => {
   // Load shim to support running tests in node
@@ -27,12 +28,18 @@ describe("CryptoHelpers", () => {
 
   describe("aesEncrypt", () => {
     it("should encrypt data with an hmac signature", async () => {
+      const randomMock = jest
+        .spyOn(global.crypto, "getRandomValues")
+        .mockImplementation((array) => new Uint8Array(array.byteLength).fill(0));
       const key = await helper.makeKey("password", "email");
       const encrypted = await helper.aesEncrypt(toArrayBuffer(PLAINTEXT_STRING), key);
+      randomMock.mockRestore();
+
       expect(encrypted.key).toEqual(key);
       expect(encrypted.iv.byteLength).toBe(16);
       expect(encrypted.mac.byteLength).toBe(32);
       expect(encrypted.data.byteLength).toBe(32);
+      expect(encrypted.toString()).toEqual(ENCRYPTED_STRING);
     });
 
     it.each([[undefined], [null], ["encrypteddatastring"], [[1, 2, 3, 4, 5, 6]], [{}]])(

--- a/packages/hdwallet-native/src/crypto/EncryptedWallet.test.ts
+++ b/packages/hdwallet-native/src/crypto/EncryptedWallet.test.ts
@@ -14,6 +14,9 @@ const PLAINTEXT_MNEMONIC2 =
 const ENCRYPTED_MNEMONIC2 =
   "2.1gm0swmYoZCc/T/U1aSGTsp0NgSQFtNT/N8U4nAgTWeJ28xpjlrGAjZwezW4vrwR8+TprSfaNCsh9lv1Nr19+/R3Ya2kj9obHhZZz1FL6qVY1dOdqfoaEWiqui54zlCb|AAAAAAAAAAAAAAAAAAAAAA==|R5969JYt8Y5CH55TFsafDVl8CXx8tv2ii2wjOMurdf4=";
 
+const ENCRYPTED_EMPTY_STRING =
+  "2.7wpUO5ISHHdT1voBnjzyXQ==|AAAAAAAAAAAAAAAAAAAAAA==|02KQ8aQWWXUX7foOmf4T2W0XCFAk4OTKFQO+hRhlRcY=";
+
 describe("EncryptedWallet", () => {
   // Load shim to support running tests in node
   globalThis.crypto = new Crypto();
@@ -135,6 +138,12 @@ describe("EncryptedWallet", () => {
       const wallet = new EncryptedWallet(engine);
       await wallet.init("email", "password2", ENCRYPTED_MNEMONIC);
       await expect(wallet.decrypt()).rejects.toThrow("signature is not valid");
+    });
+
+    it("should throw an error if the decrypted mnemonic is the empty string", async () => {
+      const wallet = new EncryptedWallet(engine);
+      await wallet.init("email", "password", ENCRYPTED_EMPTY_STRING);
+      await expect(wallet.decrypt()).rejects.toThrow("Decryption failed");
     });
   });
 

--- a/packages/hdwallet-native/src/crypto/classes/cipherString.test.ts
+++ b/packages/hdwallet-native/src/crypto/classes/cipherString.test.ts
@@ -1,7 +1,4 @@
-import { CipherString } from "./cipherString";
-import { EncryptedObject } from "./encryptedObject";
-import { EncryptionType } from "./encryptionType";
-import { SymmetricCryptoKey } from "./symmetricCryptoKey";
+import { CipherString, EncryptedObject, EncryptionType, SymmetricCryptoKey } from ".";
 
 describe("CipherString", () => {
   it.each([undefined, null, 0, [1, 2, 3], { data: "", iv: "", key: "" }, "", "abc|abc|abc"])(

--- a/packages/hdwallet-native/src/crypto/classes/cipherString.test.ts
+++ b/packages/hdwallet-native/src/crypto/classes/cipherString.test.ts
@@ -8,6 +8,11 @@ describe("CipherString", () => {
     }
   );
 
+  it("should throw an error if an invalid encryption type is specified", () => {
+    const string = "999.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=|AAAAAAAAAAAAAAAAAAAAAA==|AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    expect(() => new CipherString(string)).toThrow("Unsupported encryption method");
+  });
+
   it("should accept a properly formatted cipher string", () => {
     const string = new CipherString("2.AAAA|AAAA|AAAA");
     expect(string.encryptionType).toEqual(2);

--- a/packages/hdwallet-native/src/ethereum.test.ts
+++ b/packages/hdwallet-native/src/ethereum.test.ts
@@ -56,12 +56,6 @@ describe("NativeETHWallet", () => {
     ).resolves.toBe("0x387F3031b30E2c8eB997E87a69FEA02756983b77");
   });*/
 
-  it("fails when generating another ethereum address", async () => {
-    await expect(
-      wallet.ethGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/60'/1337'/123/4") })
-    ).rejects.toThrowError("path not supported");
-  });
-
   it("should sign a transaction correctly", async () => {
     await expect(
       wallet.ethSignTx({

--- a/packages/hdwallet-native/src/ethereum.test.ts
+++ b/packages/hdwallet-native/src/ethereum.test.ts
@@ -1,0 +1,133 @@
+import * as core from "@shapeshiftoss/hdwallet-core";
+import * as NativeHDWallet from "./native";
+
+const MNEMONIC = "all all all all all all all all all all all all";
+
+const mswMock = require("mswMock")().startServer();
+afterEach(() => expect(mswMock).not.toHaveBeenCalled());
+
+const untouchable = require("untouchableMock");
+
+describe("NativeETHWalletInfo", () => {
+  const info = NativeHDWallet.info();
+
+  it("should return some static metadata", async () => {
+    await expect(untouchable.call(info, "ethSupportsNetwork")).resolves.toBe(true);
+    await expect(untouchable.call(info, "ethSupportsSecureTransfer")).resolves.toBe(false);
+    expect(untouchable.call(info, "ethSupportsNativeShapeShift")).toBe(false);
+  });
+
+  it("should return the correct account paths", async () => {
+    const paths = info.ethGetAccountPaths({ coin: "Ethereum", accountIdx: 0 });
+    expect(paths).toMatchObject([
+      {
+        addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
+        hardenedPath: core.bip32ToAddressNList("m/44'/60'/0'"),
+        relPath: [0, 0],
+        description: "Native",
+      },
+    ]);
+  });
+
+  it("does not support getting the next account path", async()=>{
+    expect(untouchable.call(info, "ethNextAccountPath", {})).toBe(undefined);
+  })
+});
+
+describe("NativeETHWallet", () => {
+  let wallet: NativeHDWallet.NativeHDWallet;
+
+  beforeEach(async () => {
+    wallet = NativeHDWallet.create({ deviceId: "native" });
+    await wallet.loadDevice({ mnemonic: MNEMONIC });
+    await expect(wallet.initialize()).resolves.toBe(true);
+  });
+
+  it("should generate a correct ethereum address", async () => {
+    await expect(wallet.ethGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0") })).resolves.toBe(
+      "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8"
+    );
+  });
+
+  // Reflection. Surprise. Terror. For the future.
+  /*it("should generate another correct ethereum address", async () => {
+    await expect(
+      wallet.ethGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/60'/1337'/123/4") })
+    ).resolves.toBe("0x387F3031b30E2c8eB997E87a69FEA02756983b77");
+  });*/
+
+  it("fails when generating another ethereum address", async () => {
+    await expect(
+      wallet.ethGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/60'/1337'/123/4") })
+    ).rejects.toThrowError("path not supported");
+  });
+
+  it("should sign a transaction correctly", async () => {
+    await expect(
+      wallet.ethSignTx({
+        addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
+        nonce: "0xDEADBEEF",
+        gasPrice: "0xDEADBEEF",
+        gasLimit: "0xDEADBEEF",
+        to: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+        value: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+        data: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+        chainId: 1,
+      })
+    ).resolves.toMatchInlineSnapshot(`
+                  Object {
+                    "r": "0xec482d7dfc3bfaf395b72dd1de692ab57c24134fb0bea39e986b16a4ad422d2f",
+                    "s": "0x505506a0fb590d7ef63c24e9ae684eef608a6f48914d7cce762164d8c0a6fb29",
+                    "serialized": "0xf88984deadbeef84deadbeef84deadbeef94deadbeefdeadbeefdeadbeefdeadbeefdeadbeef90deadbeefdeadbeefdeadbeefdeadbeef90deadbeefdeadbeefdeadbeefdeadbeef26a0ec482d7dfc3bfaf395b72dd1de692ab57c24134fb0bea39e986b16a4ad422d2fa0505506a0fb590d7ef63c24e9ae684eef608a6f48914d7cce762164d8c0a6fb29",
+                    "v": 38,
+                  }
+              `);
+  });
+
+  it("should sign a message correctly", async () => {
+    await expect(
+      wallet.ethSignMessage({
+        addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
+        message: "super secret message",
+      })
+    ).resolves.toMatchInlineSnapshot(`
+      Object {
+        "address": "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8",
+        "signature": "0xd67ad52016d6fbc19fb9db81f32dd22cb67570b93b1c0e64ae30a4c2bc0b9c265c2d0f86906610d0cecac42ab90ee298a3474a5eb6d895aa7279d344f32aab191b",
+      }
+    `);
+  });
+
+  it("should verify a correctly signed message", async () => {
+    await expect(
+      wallet.ethVerifyMessage({
+        address: "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8",
+        message: "super secret message",
+        signature:
+          "0xd67ad52016d6fbc19fb9db81f32dd22cb67570b93b1c0e64ae30a4c2bc0b9c265c2d0f86906610d0cecac42ab90ee298a3474a5eb6d895aa7279d344f32aab191b",
+      })
+    ).resolves.toBe(true);
+  });
+
+  it("should not verify if the message doesn't match", async () => {
+    await expect(
+      wallet.ethVerifyMessage({
+        address: "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8",
+        message: "super public message",
+        signature:
+          "0xd67ad52016d6fbc19fb9db81f32dd22cb67570b93b1c0e64ae30a4c2bc0b9c265c2d0f86906610d0cecac42ab90ee298a3474a5eb6d895aa7279d344f32aab191b",
+      })
+    ).resolves.toBe(false);
+  });
+
+  it("should not verify if the signature is invalid", async () => {
+    await expect(
+      wallet.ethVerifyMessage({
+        address: "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8",
+        message: "super secret message",
+        signature:
+          "deadbeef16d6fbc19fb9db81f32dd22cb67570b93b1c0e64ae30a4c2bc0b9c265c2d0f86906610d0cecac42ab90ee298a3474a5eb6d895aa7279d344f32aab191b",
+      })
+    ).resolves.toBe(false);
+  });
+});

--- a/packages/hdwallet-native/src/fio.test.ts
+++ b/packages/hdwallet-native/src/fio.test.ts
@@ -1,14 +1,161 @@
-import { bip32ToAddressNList } from "@shapeshiftoss/hdwallet-core";
-import { mnemonicToSeed } from "bip39";
-import { NativeHDWallet } from "./native";
+import * as fio from "fiosdk-offline";
+import * as core from "@shapeshiftoss/hdwallet-core";
+import * as NativeHDWallet from "./native";
 
-describe("FIO", () => {
-  it("should generate a correct FIO address", async () => {
-    const x = new NativeHDWallet({ mnemonic: "all all all all all all all all all all all all", deviceId: "fioTest" });
-    const seed = await mnemonicToSeed("all all all all all all all all all all all all");
-    await x.fioInitializeWallet(seed);
+const MNEMONIC = "all all all all all all all all all all all all";
 
-    const address = await x.fioGetAddress({ addressNList: bip32ToAddressNList("m/44'/235'/0'/0/0") });
-    expect(address).toBe("FIO5NSKecB4CcMpUxtpHzG4u43SmcGMAjRbxyG38rE4HPegGpaHu9");
+const mswMock = require("mswMock")({
+  get: {
+    "https://fio.eu.eosamsterdam.net/v1/chain/get_info": {
+      server_version: "0b30e123",
+      chain_id: "21dcae42c0182200e93f954a074011f9048a7624c6fe81d3c9541a614a88bd1c",
+      head_block_num: 61842307,
+      last_irreversible_block_num: 61841978,
+      last_irreversible_block_id: "03afa23a114cfee7ef1c7ca90e270422fe37396080738ece42391d9ef31440e8",
+      head_block_id: "03afa38300f285879d00fe0f2f659f7a4b09d134dcd678ad12fc788dccf67952",
+      head_block_time: "2021-03-18T00:05:14.000",
+      head_block_producer: "aloha3joooqd",
+      virtual_block_cpu_limit: 200000000,
+      virtual_block_net_limit: 1048576000,
+      block_cpu_limit: 199900,
+      block_net_limit: 1048576,
+      server_version_string: "v2.0.0",
+      fork_db_head_block_num: 61842307,
+      fork_db_head_block_id: "03afa38300f285879d00fe0f2f659f7a4b09d134dcd678ad12fc788dccf67952",
+    },
+  },
+  post: {
+    "https://fio.eu.eosamsterdam.net/v1/chain/get_block": {
+      timestamp: "2021-03-18T00:02:29.500",
+      producer: "sweidrpkehv2",
+      confirmed: 0,
+      previous: "03afa2397459431ac5325ceefccfc17168d96efa07198221a48dc7339e4cc265",
+      transaction_mroot: "0000000000000000000000000000000000000000000000000000000000000000",
+      action_mroot: "5ceb022b440279ec9943e07564aadfa82a3fadfccc9531510ae60c8d6e035d4e",
+      schedule_version: 73,
+      new_producers: null,
+      header_extensions: [],
+      producer_signature:
+        "SIG_K1_KAJ9KUhQ94GWqPGmZ13rzHYbaR7kB3f4xaK73G24EEU82fMjboJTtBxZWk65Qdcy3iQimgeJ6bUWaSsU7kmmMMMFwb2fmR",
+      transactions: [],
+      block_extensions: [],
+      id: "03afa23a114cfee7ef1c7ca90e270422fe37396080738ece42391d9ef31440e8",
+      block_num: 61841978,
+      ref_block_prefix: 2843483375,
+    },
+    "https://fio.eu.eosamsterdam.net/v1/chain/get_raw_abi": (body) => {
+      const abis = {
+        "fio.address": {
+          account_name: "fio.address",
+          code_hash: "0aacfee458bee8aa4ba6773bfcf05f9d3565a12e2ea03dfa4124aa32672d6948",
+          abi_hash: "0dca0ca50be70bb04a84c2494e3eecdf72c083498a3acdbe0ed7ebc4a89d8ad9",
+          abi:
+            "DmVvc2lvOjphYmkvMS4wABMHZmlvbmFtZQAJAmlkBnVpbnQ2NARuYW1lBnN0cmluZwhuYW1laGFzaAd1aW50MTI4BmRvbWFpbgZzdHJpbmcKZG9tYWluaGFzaAd1aW50MTI4CmV4cGlyYXRpb24GdWludDY0DW93bmVyX2FjY291bnQEbmFtZQlhZGRyZXNzZXMOdG9rZW5wdWJhZGRyW10XYnVuZGxlZWxpZ2libGVjb3VudGRvd24GdWludDY0BmRvbWFpbgAGAmlkBnVpbnQ2NARuYW1lBnN0cmluZwpkb21haW5oYXNoB3VpbnQxMjgHYWNjb3VudARuYW1lCWlzX3B1YmxpYwV1aW50OApleHBpcmF0aW9uBnVpbnQ2NAplb3Npb19uYW1lAAMHYWNjb3VudARuYW1lCWNsaWVudGtleQZzdHJpbmcHa2V5aGFzaAd1aW50MTI4CnJlZ2FkZHJlc3MABQtmaW9fYWRkcmVzcwZzdHJpbmcUb3duZXJfZmlvX3B1YmxpY19rZXkGc3RyaW5nB21heF9mZWUFaW50NjQFYWN0b3IEbmFtZQR0cGlkBnN0cmluZwx0b2tlbnB1YmFkZHIAAwp0b2tlbl9jb2RlBnN0cmluZwpjaGFpbl9jb2RlBnN0cmluZw5wdWJsaWNfYWRkcmVzcwZzdHJpbmcKYWRkYWRkcmVzcwAFC2Zpb19hZGRyZXNzBnN0cmluZxBwdWJsaWNfYWRkcmVzc2VzDnRva2VucHViYWRkcltdB21heF9mZWUFaW50NjQFYWN0b3IEbmFtZQR0cGlkBnN0cmluZwpyZW1hZGRyZXNzAAULZmlvX2FkZHJlc3MGc3RyaW5nEHB1YmxpY19hZGRyZXNzZXMOdG9rZW5wdWJhZGRyW10HbWF4X2ZlZQVpbnQ2NAVhY3RvcgRuYW1lBHRwaWQGc3RyaW5nCnJlbWFsbGFkZHIABAtmaW9fYWRkcmVzcwZzdHJpbmcHbWF4X2ZlZQVpbnQ2NAVhY3RvcgRuYW1lBHRwaWQGc3RyaW5nCXJlZ2RvbWFpbgAFCmZpb19kb21haW4Gc3RyaW5nFG93bmVyX2Zpb19wdWJsaWNfa2V5BnN0cmluZwdtYXhfZmVlBWludDY0BWFjdG9yBG5hbWUEdHBpZAZzdHJpbmcLcmVuZXdkb21haW4ABApmaW9fZG9tYWluBnN0cmluZwdtYXhfZmVlBWludDY0BHRwaWQGc3RyaW5nBWFjdG9yBG5hbWUMcmVuZXdhZGRyZXNzAAQLZmlvX2FkZHJlc3MGc3RyaW5nB21heF9mZWUFaW50NjQEdHBpZAZzdHJpbmcFYWN0b3IEbmFtZQxzZXRkb21haW5wdWIABQpmaW9fZG9tYWluBnN0cmluZwlpc19wdWJsaWMEaW50OAdtYXhfZmVlBWludDY0BWFjdG9yBG5hbWUEdHBpZAZzdHJpbmcLYnVybmV4cGlyZWQAAAtkZWNyY291bnRlcgACC2Zpb19hZGRyZXNzBnN0cmluZwRzdGVwBWludDMyCmJpbmQyZW9zaW8AAwdhY2NvdW50BG5hbWUKY2xpZW50X2tleQZzdHJpbmcIZXhpc3RpbmcEYm9vbAtidXJuYWRkcmVzcwAEC2Zpb19hZGRyZXNzBnN0cmluZwdtYXhfZmVlBWludDY0BHRwaWQGc3RyaW5nBWFjdG9yBG5hbWUKeGZlcmRvbWFpbgAFCmZpb19kb21haW4Gc3RyaW5nGG5ld19vd25lcl9maW9fcHVibGljX2tleQZzdHJpbmcHbWF4X2ZlZQVpbnQ2NAVhY3RvcgRuYW1lBHRwaWQGc3RyaW5nC3hmZXJhZGRyZXNzAAULZmlvX2FkZHJlc3MGc3RyaW5nGG5ld19vd25lcl9maW9fcHVibGljX2tleQZzdHJpbmcHbWF4X2ZlZQVpbnQ2NAVhY3RvcgRuYW1lBHRwaWQGc3RyaW5nCmFkZGJ1bmRsZXMABQtmaW9fYWRkcmVzcwZzdHJpbmcLYnVuZGxlX3NldHMFaW50NjQHbWF4X2ZlZQVpbnQ2NAR0cGlkBnN0cmluZwVhY3RvcgRuYW1lDwCuylNTdJFKC2RlY3Jjb3VudGVyAAAAxuqmZJi6CnJlZ2FkZHJlc3MAAADG6qZkUjIKYWRkYWRkcmVzcwAAAMbqpmSkugpyZW1hZGRyZXNzAADATcnEaKS6CnJlbWFsbGFkZHIAAACYzkiamLoJcmVnZG9tYWluAACmM5Imrqa6C3JlbmV3ZG9tYWluAICxuikZrqa6DHJlbmV3YWRkcmVzcwAAkrqudjWvPgtidXJuZXhwaXJlZABwdJ3OSJqywgxzZXRkb21haW5wdWIAAAB1mCqRpjsKYmluZDJlb3NpbwAAMFY3JTOvPgtidXJuYWRkcmVzcwAAwHRG0nTV6gp4ZmVyZG9tYWluAAAwVjclc9XqC3hmZXJhZGRyZXNzAAAAVjFNfVIyCmFkZGJ1bmRsZXMAAwAAAFhJM6lbA2k2NAECaWQBBnN0cmluZwdmaW9uYW1lAAAAAE9nJE0DaTY0AQJpZAEGc3RyaW5nBmRvbWFpbgBANTJPTREyA2k2NAEHYWNjb3VudAEGdWludDY0CmVvc2lvX25hbWUAAAAA=",
+        },
+        "fio.reqobt": {
+          account_name: "fio.reqobt",
+          code_hash: "acf8c14120e6930948e8977e9f7472054fb87066fd15da7ab1b4e5970d6885f5",
+          abi_hash: "93118de6229f77f4213dc948674c4e11d462f573db821204224a73628b942ffd",
+          abi:
+            "DmVvc2lvOjphYmkvMS4wAAoKZmlvcmVxY3R4dAANDmZpb19yZXF1ZXN0X2lkBnVpbnQ2NBFwYXllcl9maW9fYWRkcmVzcwd1aW50MTI4EXBheWVlX2Zpb19hZGRyZXNzB3VpbnQxMjgZcGF5ZXJfZmlvX2FkZHJlc3NfaGV4X3N0cgZzdHJpbmcZcGF5ZWVfZmlvX2FkZHJlc3NfaGV4X3N0cgZzdHJpbmcbcGF5ZXJfZmlvX2FkZHJlc3Nfd2l0aF90aW1lB3VpbnQxMjgbcGF5ZWVfZmlvX2FkZHJlc3Nfd2l0aF90aW1lB3VpbnQxMjgHY29udGVudAZzdHJpbmcKdGltZV9zdGFtcAZ1aW50NjQOcGF5ZXJfZmlvX2FkZHIGc3RyaW5nDnBheWVlX2Zpb19hZGRyBnN0cmluZwlwYXllcl9rZXkGc3RyaW5nCXBheWVlX2tleQZzdHJpbmcOcmVjb3Jkb2J0X2luZm8ADQJpZAZ1aW50NjQRcGF5ZXJfZmlvX2FkZHJlc3MHdWludDEyOBFwYXllZV9maW9fYWRkcmVzcwd1aW50MTI4GXBheWVyX2Zpb19hZGRyZXNzX2hleF9zdHIGc3RyaW5nGXBheWVlX2Zpb19hZGRyZXNzX2hleF9zdHIGc3RyaW5nG3BheWVyX2Zpb19hZGRyZXNzX3dpdGhfdGltZQd1aW50MTI4G3BheWVlX2Zpb19hZGRyZXNzX3dpdGhfdGltZQd1aW50MTI4B2NvbnRlbnQGc3RyaW5nCnRpbWVfc3RhbXAGdWludDY0DnBheWVyX2Zpb19hZGRyBnN0cmluZw5wYXllZV9maW9fYWRkcgZzdHJpbmcJcGF5ZXJfa2V5BnN0cmluZwlwYXllZV9rZXkGc3RyaW5nCWZpb3JlcXN0cwAFAmlkBnVpbnQ2NA5maW9fcmVxdWVzdF9pZAZ1aW50NjQGc3RhdHVzBnVpbnQ2NAhtZXRhZGF0YQZzdHJpbmcKdGltZV9zdGFtcAZ1aW50NjQMZmlvdHJ4dF9pbmZvAA8CaWQGdWludDY0DmZpb19yZXF1ZXN0X2lkBnVpbnQ2NBJwYXllcl9maW9fYWRkcl9oZXgHdWludDEyOBJwYXllZV9maW9fYWRkcl9oZXgHdWludDEyOA1maW9fZGF0YV90eXBlBXVpbnQ4CHJlcV90aW1lBnVpbnQ2NA5wYXllcl9maW9fYWRkcgZzdHJpbmcOcGF5ZWVfZmlvX2FkZHIGc3RyaW5nCXBheWVyX2tleQZzdHJpbmcJcGF5ZWVfa2V5BnN0cmluZw1wYXllcl9hY2NvdW50BG5hbWUNcGF5ZWVfYWNjb3VudARuYW1lC3JlcV9jb250ZW50BnN0cmluZwtvYnRfY29udGVudAZzdHJpbmcIb2J0X3RpbWUGdWludDY0Cm1pZ3JsZWRnZXIABwJpZAZ1aW50NjQIYmVnaW5vYnQFaW50NjQKY3VycmVudG9idAVpbnQ2NAdiZWdpbnJxBWludDY0CWN1cnJlbnRycQVpbnQ2NApjdXJyZW50c3RhBWludDY0CmlzRmluaXNoZWQEaW50OAdtaWdydHJ4AAIGYW1vdW50BWludDE2BWFjdG9yBnN0cmluZwlyZWNvcmRvYnQABw5maW9fcmVxdWVzdF9pZAZzdHJpbmcRcGF5ZXJfZmlvX2FkZHJlc3MGc3RyaW5nEXBheWVlX2Zpb19hZGRyZXNzBnN0cmluZwdjb250ZW50BnN0cmluZwdtYXhfZmVlBWludDY0BWFjdG9yBnN0cmluZwR0cGlkBnN0cmluZwtuZXdmdW5kc3JlcQAGEXBheWVyX2Zpb19hZGRyZXNzBnN0cmluZxFwYXllZV9maW9fYWRkcmVzcwZzdHJpbmcHY29udGVudAZzdHJpbmcHbWF4X2ZlZQVpbnQ2NAVhY3RvcgZzdHJpbmcEdHBpZAZzdHJpbmcMcmVqZWN0Zm5kcmVxAAQOZmlvX3JlcXVlc3RfaWQGc3RyaW5nB21heF9mZWUFaW50NjQFYWN0b3IGc3RyaW5nBHRwaWQGc3RyaW5nDGNhbmNlbGZuZHJlcQAEDmZpb19yZXF1ZXN0X2lkBnN0cmluZwdtYXhfZmVlBWludDY0BWFjdG9yBnN0cmluZwR0cGlkBnN0cmluZwUAAACg33yZkwdtaWdydHJ4AAAAyIemS5G6CXJlY29yZG9idAAArLo4Tb24mgtuZXdmdW5kc3JlcQBg1U1zZaSeugxyZWplY3RmbmRyZXEAYNVNc0WFpkEMY2FuY2VsZm5kcmVxAAUAcO4ZWXWpWwNpNjQBDmZpb19yZXF1ZXN0X2lkAQZ1aW50NjQKZmlvcmVxY3R4dAAAzoemS5G6A2k2NAECaWQBBnVpbnQ2NA5yZWNvcmRvYnRfaW5mbwAAxhlbdalbA2k2NAECaWQBBnVpbnQ2NAlmaW9yZXFzdHMAAMA495upWwNpNjQBAmlkAQZ1aW50NjQMZmlvdHJ4dF9pbmZvAPBVLKl4mZMDaTY0AQJpZAEGdWludDY0Cm1pZ3JsZWRnZXIAAAAA=",
+        },
+        "fio.token": {
+          account_name: "fio.token",
+          code_hash: "f20c3d91844682c1ac035fee1509f1c91a934122e372ac6df45594bb3f3f171e",
+          abi_hash: "b368fbc363f0da588eea9c943b75caadffb881dcb4dc4f283bfee7a86c97850f",
+          abi:
+            "DmVvc2lvOjphYmkvMS4xAAoHYWNjb3VudAABB2JhbGFuY2UFYXNzZXQGY3JlYXRlAAEObWF4aW11bV9zdXBwbHkFYXNzZXQOY3VycmVuY3lfc3RhdHMAAwZzdXBwbHkFYXNzZXQKbWF4X3N1cHBseQVhc3NldAZpc3N1ZXIEbmFtZQVpc3N1ZQADAnRvBG5hbWUIcXVhbnRpdHkFYXNzZXQEbWVtbwZzdHJpbmcLbG9ja3BlcmlvZHMAAghkdXJhdGlvbgVpbnQ2NAdwZXJjZW50B2Zsb2F0NjQHbWludGZpbwACAnRvBG5hbWUGYW1vdW50BnVpbnQ2NAZyZXRpcmUAAghxdWFudGl0eQVhc3NldARtZW1vBnN0cmluZwh0cmFuc2ZlcgAEBGZyb20EbmFtZQJ0bwRuYW1lCHF1YW50aXR5BWFzc2V0BG1lbW8Gc3RyaW5nDHRybnNmaW9wdWJreQAFEHBheWVlX3B1YmxpY19rZXkGc3RyaW5nBmFtb3VudAVpbnQ2NAdtYXhfZmVlBWludDY0BWFjdG9yBG5hbWUEdHBpZAZzdHJpbmcLdHJuc2xvY3Rva3MABxBwYXllZV9wdWJsaWNfa2V5BnN0cmluZwhjYW5fdm90ZQVpbnQzMgdwZXJpb2RzDWxvY2twZXJpb2RzW10GYW1vdW50BWludDY0B21heF9mZWUFaW50NjQFYWN0b3IEbmFtZQR0cGlkBnN0cmluZwcAAAAAqGzURQZjcmVhdGUAAAAAAAClMXYFaXNzdWUAAAAAgLqVp5MHbWludGZpbwAAAAAAqOuyugZyZXRpcmUAAAAAVy08zc0IdHJhbnNmZXIA4OHRlbqF580MdHJuc2Zpb3B1Ymt5AAAwpBnRiOfNC3RybnNsb2N0b2tzAAIAAAA4T00RMgNpNjQAAAdhY2NvdW50AAAAAACQTcYDaTY0AAAOY3VycmVuY3lfc3RhdHMAAAAA=",
+        },
+        eosio: {
+          account_name: "eosio",
+          code_hash: "811bd423b5d3ba3ac4760e15acfa298fa2b9896b319812a40019b37b3ecfb450",
+          abi_hash: "ead7a5cf52addda442d99acf5a35494f235330392b02c4ced3d4a09dd5a7602d",
+          abi:
+            "DmVvc2lvOjphYmkvMS4xADcIYWJpX2hhc2gAAgVvd25lcgRuYW1lBGhhc2gLY2hlY2tzdW0yNTYJYWRkYWN0aW9uAAMGYWN0aW9uBG5hbWUIY29udHJhY3QGc3RyaW5nBWFjdG9yBG5hbWUMYWRkZ2VubG9ja2VkAAQFb3duZXIEbmFtZQdwZXJpb2RzDWxvY2twZXJpb2RzW10HY2Fudm90ZQRib29sBmFtb3VudAVpbnQ2NAlhZGRsb2NrZWQAAwVvd25lcgRuYW1lBmFtb3VudAVpbnQ2NAhsb2NrdHlwZQVpbnQxNglhdXRob3JpdHkABAl0aHJlc2hvbGQGdWludDMyBGtleXMMa2V5X3dlaWdodFtdCGFjY291bnRzGXBlcm1pc3Npb25fbGV2ZWxfd2VpZ2h0W10Fd2FpdHMNd2FpdF93ZWlnaHRbXQxibG9ja19oZWFkZXIACAl0aW1lc3RhbXAGdWludDMyCHByb2R1Y2VyBG5hbWUJY29uZmlybWVkBnVpbnQxNghwcmV2aW91cwtjaGVja3N1bTI1NhF0cmFuc2FjdGlvbl9tcm9vdAtjaGVja3N1bTI1NgxhY3Rpb25fbXJvb3QLY2hlY2tzdW0yNTYQc2NoZWR1bGVfdmVyc2lvbgZ1aW50MzINbmV3X3Byb2R1Y2VycxJwcm9kdWNlcl9zY2hlZHVsZT8VYmxvY2tjaGFpbl9wYXJhbWV0ZXJzABETbWF4X2Jsb2NrX25ldF91c2FnZQZ1aW50NjQadGFyZ2V0X2Jsb2NrX25ldF91c2FnZV9wY3QGdWludDMyGW1heF90cmFuc2FjdGlvbl9uZXRfdXNhZ2UGdWludDMyHmJhc2VfcGVyX3RyYW5zYWN0aW9uX25ldF91c2FnZQZ1aW50MzIQbmV0X3VzYWdlX2xlZXdheQZ1aW50MzIjY29udGV4dF9mcmVlX2Rpc2NvdW50X25ldF91c2FnZV9udW0GdWludDMyI2NvbnRleHRfZnJlZV9kaXNjb3VudF9uZXRfdXNhZ2VfZGVuBnVpbnQzMhNtYXhfYmxvY2tfY3B1X3VzYWdlBnVpbnQzMhp0YXJnZXRfYmxvY2tfY3B1X3VzYWdlX3BjdAZ1aW50MzIZbWF4X3RyYW5zYWN0aW9uX2NwdV91c2FnZQZ1aW50MzIZbWluX3RyYW5zYWN0aW9uX2NwdV91c2FnZQZ1aW50MzIYbWF4X3RyYW5zYWN0aW9uX2xpZmV0aW1lBnVpbnQzMh5kZWZlcnJlZF90cnhfZXhwaXJhdGlvbl93aW5kb3cGdWludDMyFW1heF90cmFuc2FjdGlvbl9kZWxheQZ1aW50MzIWbWF4X2lubGluZV9hY3Rpb25fc2l6ZQZ1aW50MzIXbWF4X2lubGluZV9hY3Rpb25fZGVwdGgGdWludDE2E21heF9hdXRob3JpdHlfZGVwdGgGdWludDE2CmJ1cm5hY3Rpb24AAQtmaW9hZGRyaGFzaAd1aW50MTI4C2NhbmNlbGRlbGF5AAIOY2FuY2VsaW5nX2F1dGgQcGVybWlzc2lvbl9sZXZlbAZ0cnhfaWQLY2hlY2tzdW0yNTYLY3JhdXRvcHJveHkAAgVwcm94eQRuYW1lBW93bmVyBG5hbWUKZGVsZXRlYXV0aAADB2FjY291bnQEbmFtZQpwZXJtaXNzaW9uBG5hbWUHbWF4X2ZlZQZ1aW50NjQSZW9zaW9fZ2xvYmFsX3N0YXRlFWJsb2NrY2hhaW5fcGFyYW1ldGVycwsdbGFzdF9wcm9kdWNlcl9zY2hlZHVsZV91cGRhdGUUYmxvY2tfdGltZXN0YW1wX3R5cGUYbGFzdF9wZXJ2b3RlX2J1Y2tldF9maWxsCnRpbWVfcG9pbnQOcGVydm90ZV9idWNrZXQFaW50NjQPcGVyYmxvY2tfYnVja2V0BWludDY0E3RvdGFsX3VucGFpZF9ibG9ja3MGdWludDMyD3RvdGFsX3ZvdGVkX2ZpbwVpbnQ2NBV0aHJlc2hfdm90ZWRfZmlvX3RpbWUKdGltZV9wb2ludBtsYXN0X3Byb2R1Y2VyX3NjaGVkdWxlX3NpemUGdWludDE2GnRvdGFsX3Byb2R1Y2VyX3ZvdGVfd2VpZ2h0B2Zsb2F0NjQPbGFzdF9uYW1lX2Nsb3NlFGJsb2NrX3RpbWVzdGFtcF90eXBlD2xhc3RfZmVlX3VwZGF0ZRRibG9ja190aW1lc3RhbXBfdHlwZRNlb3Npb19nbG9iYWxfc3RhdGUyAAMObGFzdF9ibG9ja19udW0UYmxvY2tfdGltZXN0YW1wX3R5cGUcdG90YWxfcHJvZHVjZXJfdm90ZXBheV9zaGFyZQdmbG9hdDY0CHJldmlzaW9uBXVpbnQ4E2Vvc2lvX2dsb2JhbF9zdGF0ZTMAAhZsYXN0X3ZwYXlfc3RhdGVfdXBkYXRlCnRpbWVfcG9pbnQcdG90YWxfdnBheV9zaGFyZV9jaGFuZ2VfcmF0ZQdmbG9hdDY0BmluY3JhbQACCWFjY291bnRtbgRuYW1lBmFtb3VudAVpbnQ2NAxpbmhpYml0dW5sY2sAAgVvd25lcgRuYW1lBXZhbHVlBnVpbnQzMgRpbml0AAIHdmVyc2lvbgl2YXJ1aW50MzIEY29yZQZzeW1ib2wKa2V5X3dlaWdodAACA2tleQpwdWJsaWNfa2V5BndlaWdodAZ1aW50MTYIbGlua2F1dGgABQdhY2NvdW50BG5hbWUEY29kZQRuYW1lBHR5cGUEbmFtZQtyZXF1aXJlbWVudARuYW1lB21heF9mZWUGdWludDY0GGxvY2tlZF90b2tlbl9ob2xkZXJfaW5mbwAHBW93bmVyBG5hbWUSdG90YWxfZ3JhbnRfYW1vdW50BnVpbnQ2NBV1bmxvY2tlZF9wZXJpb2RfY291bnQGdWludDMyCmdyYW50X3R5cGUGdWludDMyEWluaGliaXRfdW5sb2NraW5nBnVpbnQzMhdyZW1haW5pbmdfbG9ja2VkX2Ftb3VudAZ1aW50NjQJdGltZXN0YW1wBnVpbnQzMhJsb2NrZWRfdG9rZW5zX2luZm8ACAJpZAVpbnQ2NA1vd25lcl9hY2NvdW50BG5hbWULbG9ja19hbW91bnQFaW50NjQRcGF5b3V0c19wZXJmb3JtZWQFaW50MzIIY2FuX3ZvdGUFaW50MzIHcGVyaW9kcw1sb2NrcGVyaW9kc1tdFXJlbWFpbmluZ19sb2NrX2Ftb3VudAVpbnQ2NAl0aW1lc3RhbXAGdWludDMyC2xvY2twZXJpb2RzAAIIZHVyYXRpb24FaW50NjQHcGVyY2VudAdmbG9hdDY0Cm5ld2FjY291bnQABAdjcmVhdG9yBG5hbWUEbmFtZQRuYW1lBW93bmVyCWF1dGhvcml0eQZhY3RpdmUJYXV0aG9yaXR5B29uYmxvY2sAAQZoZWFkZXIMYmxvY2tfaGVhZGVyB29uZXJyb3IAAglzZW5kZXJfaWQHdWludDEyOAhzZW50X3RyeAVieXRlcxBwZXJtaXNzaW9uX2xldmVsAAIFYWN0b3IEbmFtZQpwZXJtaXNzaW9uBG5hbWUXcGVybWlzc2lvbl9sZXZlbF93ZWlnaHQAAgpwZXJtaXNzaW9uEHBlcm1pc3Npb25fbGV2ZWwGd2VpZ2h0BnVpbnQxNg1wcm9kdWNlcl9pbmZvAAwCaWQGdWludDY0BW93bmVyBG5hbWULZmlvX2FkZHJlc3MGc3RyaW5nC2FkZHJlc3NoYXNoB3VpbnQxMjgLdG90YWxfdm90ZXMHZmxvYXQ2NBNwcm9kdWNlcl9wdWJsaWNfa2V5CnB1YmxpY19rZXkJaXNfYWN0aXZlBGJvb2wDdXJsBnN0cmluZw11bnBhaWRfYmxvY2tzBnVpbnQzMg9sYXN0X2NsYWltX3RpbWUKdGltZV9wb2ludAxsYXN0X2JwY2xhaW0GdWludDMyCGxvY2F0aW9uBnVpbnQxNgxwcm9kdWNlcl9rZXkAAg1wcm9kdWNlcl9uYW1lBG5hbWURYmxvY2tfc2lnbmluZ19rZXkKcHVibGljX2tleRFwcm9kdWNlcl9zY2hlZHVsZQACB3ZlcnNpb24GdWludDMyCXByb2R1Y2Vycw5wcm9kdWNlcl9rZXlbXQtyZWdwcm9kdWNlcgAGC2Zpb19hZGRyZXNzBnN0cmluZwtmaW9fcHViX2tleQZzdHJpbmcDdXJsBnN0cmluZwhsb2NhdGlvbgZ1aW50MTYFYWN0b3IEbmFtZQdtYXhfZmVlBWludDY0CHJlZ3Byb3h5AAMLZmlvX2FkZHJlc3MGc3RyaW5nBWFjdG9yBG5hbWUHbWF4X2ZlZQVpbnQ2NAlyZW1hY3Rpb24AAgZhY3Rpb24EbmFtZQVhY3RvcgRuYW1lCnJlc2V0Y2xhaW0AAQhwcm9kdWNlcgRuYW1lC3JtdnByb2R1Y2VyAAEIcHJvZHVjZXIEbmFtZQZzZXRhYmkAAgdhY2NvdW50BG5hbWUDYWJpBWJ5dGVzDHNldGF1dG9wcm94eQACBXByb3h5BG5hbWUFb3duZXIEbmFtZQdzZXRjb2RlAAQHYWNjb3VudARuYW1lBnZtdHlwZQV1aW50OAl2bXZlcnNpb24FdWludDgEY29kZQVieXRlcwlzZXRwYXJhbXMAAQZwYXJhbXMVYmxvY2tjaGFpbl9wYXJhbWV0ZXJzB3NldHByaXYAAgdhY2NvdW50BG5hbWUHaXNfcHJpdgV1aW50OA10b3BfcHJvZF9pbmZvAAEIcHJvZHVjZXIEbmFtZQp1bmxpbmthdXRoAAMHYWNjb3VudARuYW1lBGNvZGUEbmFtZQR0eXBlBG5hbWUMdW5sb2NrdG9rZW5zAAEFYWN0b3IEbmFtZQl1bnJlZ3Byb2QAAwtmaW9fYWRkcmVzcwZzdHJpbmcFYWN0b3IEbmFtZQdtYXhfZmVlBWludDY0CnVucmVncHJveHkAAwtmaW9fYWRkcmVzcwZzdHJpbmcFYWN0b3IEbmFtZQdtYXhfZmVlBWludDY0CnVwZGF0ZWF1dGgABQdhY2NvdW50BG5hbWUKcGVybWlzc2lvbgRuYW1lBnBhcmVudARuYW1lBGF1dGgJYXV0aG9yaXR5B21heF9mZWUGdWludDY0C3VwZGF0ZXBvd2VyAAIFdm90ZXIEbmFtZQp1cGRhdGVvbmx5BGJvb2wLdXBkbGJwY2xhaW0AAQhwcm9kdWNlcgRuYW1lCXVwZGxvY2tlZAACBW93bmVyBG5hbWUPYW1vdW50cmVtYWluaW5nBnVpbnQ2NAx1cGR0cmV2aXNpb24AAQhyZXZpc2lvbgV1aW50OA51c2VyX3Jlc291cmNlcwAEBW93bmVyBG5hbWUKbmV0X3dlaWdodAVhc3NldApjcHVfd2VpZ2h0BWFzc2V0CXJhbV9ieXRlcwVpbnQ2NAx2b3RlcHJvZHVjZXIABAlwcm9kdWNlcnMIc3RyaW5nW10LZmlvX2FkZHJlc3MGc3RyaW5nBWFjdG9yBG5hbWUHbWF4X2ZlZQVpbnQ2NAl2b3RlcHJveHkABAVwcm94eQZzdHJpbmcLZmlvX2FkZHJlc3MGc3RyaW5nBWFjdG9yBG5hbWUHbWF4X2ZlZQVpbnQ2NAp2b3Rlcl9pbmZvAAwCaWQGdWludDY0CmZpb2FkZHJlc3MGc3RyaW5nC2FkZHJlc3NoYXNoB3VpbnQxMjgFb3duZXIEbmFtZQVwcm94eQRuYW1lCXByb2R1Y2VycwZuYW1lW10QbGFzdF92b3RlX3dlaWdodAdmbG9hdDY0E3Byb3hpZWRfdm90ZV93ZWlnaHQHZmxvYXQ2NAhpc19wcm94eQRib29sDWlzX2F1dG9fcHJveHkEYm9vbAlyZXNlcnZlZDIGdWludDMyCXJlc2VydmVkMwVhc3NldAt3YWl0X3dlaWdodAACCHdhaXRfc2VjBnVpbnQzMgZ3ZWlnaHQGdWludDE2IwAAmNRlZFIyCWFkZGFjdGlvbgCQFEQ0TsVSMgxhZGRnZW5sb2NrZWQAAABICiIaUzIJYWRkbG9ja2VkAADApC4jM68+CmJ1cm5hY3Rpb24AALyJKkWFpkELY2FuY2VsZGVsYXkAAHynt9KszUULY3JhdXRvcHJveHkAAEDL2qisokoKZGVsZXRlYXV0aAAAAAAASHPRdAZpbmNyYW0AAFGcOrvj2nQMaW5oaWJpdHVubGNrAAAAAAAAkN10BGluaXQAAAAALWsDp4sIbGlua2F1dGgAAECemiJkuJoKbmV3YWNjb3VudAAAAAAAIhrPpAdvbmJsb2NrAAAAAODSe9WkB29uZXJyb3IAAK5COtFbmboLcmVncHJvZHVjZXIAAAAAvtNbmboIcmVncHJveHkAAACY1GVkpLoJcmVtYWN0aW9uAACAdCairLC6CnJlc2V0Y2xhaW0AAK5COtFbt7wLcm12cHJvZHVjZXIAAAAAALhjssIGc2V0YWJpAOA7vZVmbbLCDHNldGF1dG9wcm94eQAAAABAJYqywgdzZXRjb2RlAAAAwNJcU7PCCXNldHBhcmFtcwAAAABgu1uzwgdzZXRwcml2AABAy9rA6eLUCnVubGlua2F1dGgAgKeCNENE49QMdW5sb2NrdG9rZW5zAAAASPRWpu7UCXVucmVncHJvZAAAgO/0Vqbu1Ap1bnJlZ3Byb3h5AABAy9qobFLVCnVwZGF0ZWF1dGgAAK7itKpsUtULdXBkYXRlcG93ZXIAAKQzEdUTU9ULdXBkbGJwY2xhaW0AAABICiIaU9UJdXBkbG9ja2VkADCpw26rm1PVDHVwZHRyZXZpc2lvbgBwFdKJ3qoy3Qx2b3RlcHJvZHVjZXIAAADwnd6qMt0Jdm90ZXByb3h5AAoAAACgYdPcMQNpNjQAAAhhYmlfaGFzaAAAAABEc2hkA2k2NAAAEmVvc2lvX2dsb2JhbF9zdGF0ZQAAAEBEc2hkA2k2NAAAE2Vvc2lvX2dsb2JhbF9zdGF0ZTIAAABgRHNoZANpNjQAABNlb3Npb19nbG9iYWxfc3RhdGUzgKeCNCcFEY0DaTY0AAAYbG9ja2VkX3Rva2VuX2hvbGRlcl9pbmZvAACeCtIMEY0DaTY0AAASbG9ja2VkX3Rva2Vuc19pbmZvAADAVyGd6K0DaTY0AAANcHJvZHVjZXJfaW5mbwAAADjRWyvNA2k2NAAADXRvcF9wcm9kX2luZm8AAAAAq3sV1gNpNjQAAA51c2VyX3Jlc291cmNlcwAAAADgqzLdA2k2NAAACnZvdGVyX2luZm8AAAAA=",
+        },
+      };
+      const out = abis[body.account_name];
+      if (!out) throw 500;
+      return out;
+    },
+  },
+}).startServer();
+
+describe("NativeFioWallet", () => {
+  let wallet: NativeHDWallet.NativeHDWallet;
+
+  beforeEach(async () => {
+    wallet = NativeHDWallet.create({ deviceId: "native" });
+    await wallet.loadDevice({ mnemonic: MNEMONIC });
+    await expect(wallet.initialize()).resolves.toBe(true);
+  });
+
+  afterEach(() => {
+    expect(mswMock).not.toHaveBeenCalled();
+  });
+
+  describe("stuff that uses the network", () => {
+    afterEach(() => {
+      expect(mswMock.handlers.post["https://fio.eu.eosamsterdam.net/v1/chain/get_raw_abi"]).toHaveBeenCalledWith({
+        account_name: "fio.address",
+      });
+      expect(mswMock.handlers.post["https://fio.eu.eosamsterdam.net/v1/chain/get_raw_abi"]).toHaveBeenCalledWith({
+        account_name: "fio.reqobt",
+      });
+      expect(mswMock.handlers.post["https://fio.eu.eosamsterdam.net/v1/chain/get_raw_abi"]).toHaveBeenCalledWith({
+        account_name: "fio.token",
+      });
+      expect(mswMock.handlers.post["https://fio.eu.eosamsterdam.net/v1/chain/get_raw_abi"]).toHaveBeenCalledWith({
+        account_name: "eosio",
+      });
+      mswMock.clear();
+    });
+
+    it("should generate a correct FIO address", async () => {
+      const address = await wallet.fioGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/235'/0'/0/0") });
+      expect(address).toBe("FIO5NSKecB4CcMpUxtpHzG4u43SmcGMAjRbxyG38rE4HPegGpaHu9");
+    });
+
+    it("should generate another correct FIO address", async () => {
+      const address = await wallet.fioGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/235'/1337'/123/4") });
+      expect(address).toBe("FIO8Pok1EBMsZWphhfUj2m3MXrxBZJq7erqyi7E1teAfZE18HyjK5");
+    });
+
+    it("should expose the FIO SDK", async () => {
+      await expect(wallet.getFioSdk(core.bip32ToAddressNList("m/44'/235'/0'/0/0"))).resolves.toBeInstanceOf(fio.FIOSDK);
+    });
+
+    it("should sign a message", async () => {
+      await expect(
+        wallet.fioSignTx({
+          addressNList: core.bip32ToAddressNList("m/44'/235'/0'/0/0"),
+          actions: [
+            {
+              account: "fio.address",
+              name: "addaddress",
+              data: {
+                fio_address: "FIO5NSKecB4CcMpUxtpHzG4u43SmcGMAjRbxyG38rE4HPegGpaHu9",
+                public_addresses: [
+                  {
+                    chain_code: "foo",
+                    token_code: "bar",
+                    public_address: "baz",
+                  },
+                ],
+                max_fee: 0,
+                tpid: "FIO5NSKecB4CcMpUxtpHzG4u43SmcGMAjRbxyG38rE4HPegGpaHu9",
+              },
+            },
+          ],
+        })
+      ).resolves.toMatchInlineSnapshot(`
+        Object {
+          "serialized": "ee9952603aa2ef1c7ca90000000001003056372503a85b0000c6eaa66452320180f2f085077460fd00000000a8ed323289013546494f354e534b6563423443634d7055787470487a4734753433536d63474d416a5262787947333872453448506567477061487539010362617203666f6f0362617a000000000000000080f2f085077460fd3546494f354e534b6563423443634d7055787470487a4734753433536d63474d416a526278794733387245344850656747706148753900",
+          "signature": "SIG_K1_JxgRLcqJHYjaqAhwHpsi8iGGkYVZRKMGT46xozonn2YwBF6vv3Jg7UZ95PsFKh9BFpHNTwhcLHhzyzhxdvw47zF12REeM2",
+        }
+      `);
+      expect(mswMock.handlers.get["https://fio.eu.eosamsterdam.net/v1/chain/get_info"]).toHaveBeenCalled();
+      expect(mswMock.handlers.post["https://fio.eu.eosamsterdam.net/v1/chain/get_block"]).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/hdwallet-native/src/fio.test.ts
+++ b/packages/hdwallet-native/src/fio.test.ts
@@ -81,6 +81,27 @@ const mswMock = require("mswMock")({
   },
 }).startServer();
 
+const untouchable = require("untouchableMock");
+
+describe("NativeFioWalletInfo", () => {
+  const info = NativeHDWallet.info();
+
+  it("should return some static metadata", async () => {
+    await expect(untouchable.call(info, "fioSupportsNetwork")).resolves.toBe(true);
+    await expect(untouchable.call(info, "fioSupportsSecureTransfer")).resolves.toBe(false);
+    expect(untouchable.call(info, "fioSupportsNativeShapeShift")).toBe(false);
+  });
+
+  it("should return the correct account paths", async () => {
+    const paths = info.fioGetAccountPaths({ accountIdx: 0 });
+    expect(paths).toMatchObject([{ addressNList: core.bip32ToAddressNList("m/44'/235'/0'/0/0") }]);
+  });
+  
+  it("does not support getting the next account path", async()=>{
+    expect(untouchable.call(info, "fioNextAccountPath", {})).toBe(undefined);
+  })
+});
+
 describe("NativeFioWallet", () => {
   let wallet: NativeHDWallet.NativeHDWallet;
 

--- a/packages/hdwallet-native/src/native.test.ts
+++ b/packages/hdwallet-native/src/native.test.ts
@@ -91,22 +91,13 @@ describe("NativeHDWallet", () => {
   describe("loadDevice", () => {
     it("should load wallet with a mnemonic", async () => {
       const wallet = NativeHDWallet.create({ deviceId: "native" });
-      await expect(wallet.isInitialized()).resolves.toBe(false);
+      await expect(wallet.isInitialized()).resolves.toBeFalsy();
       await expect(wallet.isLocked()).resolves.toBe(false);
       await wallet.loadDevice({ mnemonic: MNEMONIC });
       await expect(wallet.initialize()).resolves.toBe(true);
       await expect(wallet.isInitialized()).resolves.toBe(true);
       await expect(wallet.isLocked()).resolves.toBe(false);
       ([
-        {
-          in: [{ coin: "bitcoin", addressNList: [] }],
-          out: [
-            {
-              xpub:
-                "xpub661MyMwAqRbcFLgDU7wpcEVubSF7NkswwmXBUkDiGUW6uopeUMys4AqKXNgpfZKRTLnpKQgffd6a2c3J8JxLkF1AQN17Pm9QYHEqEfo1Rsx",
-            },
-          ],
-        },
         {
           in: [{ coin: "bitcoin", addressNList: [1 + 0x80000000, 2 + 0x80000000] }],
           out: [
@@ -161,27 +152,6 @@ describe("NativeHDWallet", () => {
         );
       }
     );
-  });
-
-  it("should wipe if an error occurs during initialization", async () => {
-    expect.assertions(7);
-    const wallet = NativeHDWallet.create({ deviceId: "native" });
-    await wallet.loadDevice({ mnemonic: MNEMONIC });
-    const mocks = [
-      jest.spyOn(bip39, "mnemonicToSeed").mockImplementationOnce(() => {
-        throw "mock error";
-      }),
-      jest.spyOn(console, "error").mockImplementationOnce((msg, error) => {
-        expect(msg).toMatch("NativeHDWallet:initialize:error");
-        expect(error).toEqual("mock error");
-      }),
-      jest.spyOn(wallet, "wipe"),
-    ];
-    await expect(wallet.initialize()).resolves.toBe(false);
-    mocks.forEach((x) => {
-      expect(x).toHaveBeenCalled();
-      x.mockRestore();
-    });
   });
 
   it("should have correct metadata", async () => {

--- a/packages/hdwallet-native/src/native.test.ts
+++ b/packages/hdwallet-native/src/native.test.ts
@@ -97,6 +97,38 @@ describe("NativeHDWallet", () => {
       await expect(wallet.initialize()).resolves.toBe(true);
       await expect(wallet.isInitialized()).resolves.toBe(true);
       await expect(wallet.isLocked()).resolves.toBe(false);
+      ([
+        {
+          in: [{ coin: "bitcoin", addressNList: [] }],
+          out: [
+            {
+              xpub:
+                "xpub661MyMwAqRbcFLgDU7wpcEVubSF7NkswwmXBUkDiGUW6uopeUMys4AqKXNgpfZKRTLnpKQgffd6a2c3J8JxLkF1AQN17Pm9QYHEqEfo1Rsx",
+            },
+          ],
+        },
+        {
+          in: [{ coin: "bitcoin", addressNList: [1 + 0x80000000, 2 + 0x80000000] }],
+          out: [
+            {
+              xpub:
+                "xpub6A4ydEAik39rFLs1hcm6XiwpFN5XKEf9tdAZWK23tkXmSr8bHmfYyfVt2nTskZQj3yYydcST2DLUFq2iJAELtTVfW9UNnnK8zBi8bzFcQVB",
+            },
+          ],
+        },
+        // Note how this produces the same xpub as the path above. This is not intuitive behavior, and is probably a bug.
+        {
+          in: [{ coin: "bitcoin", addressNList: [1 + 0x80000000, 2 + 0x80000000, 3] }],
+          out: [
+            {
+              xpub:
+                "xpub6A4ydEAik39rFLs1hcm6XiwpFN5XKEf9tdAZWK23tkXmSr8bHmfYyfVt2nTskZQj3yYydcST2DLUFq2iJAELtTVfW9UNnnK8zBi8bzFcQVB",
+            },
+          ],
+        },
+      ] as Array<{ in: any; out: any }>).forEach((params) => {
+        expect(wallet.getPublicKeys(params.in)).resolves.toStrictEqual(params.out);
+      });
     });
 
     it("should load wallet with a mnemonic and deviceId", async () => {

--- a/packages/hdwallet-native/src/native.test.ts
+++ b/packages/hdwallet-native/src/native.test.ts
@@ -1,9 +1,85 @@
 import * as NativeHDWallet from "./native";
 import * as bip39 from "bip39";
+import { BTCInputScriptType } from "@shapeshiftoss/hdwallet-core";
 
 const MNEMONIC = "all all all all all all all all all all all all";
 
-describe("hdwallet-native", () => {
+const mswMock = require("mswMock")().startServer();
+afterEach(() => expect(mswMock).not.toHaveBeenCalled());
+
+const untouchable = require("untouchableMock");
+
+describe("NativeHDWalletInfo", () => {
+  it("should have correct metadata", () => {
+    const info = NativeHDWallet.info();
+    expect(info.getVendor()).toBe("Native");
+    expect(info.hasOnDevicePinEntry()).toBe(false);
+    expect(info.hasOnDevicePassphrase()).toBe(false);
+    expect(info.hasOnDeviceDisplay()).toBe(false);
+    expect(info.hasOnDeviceRecovery()).toBe(false);
+  });
+  it("should produce correct path descriptions", () => {
+    const info = NativeHDWallet.info();
+    expect(info.hasNativeShapeShift()).toBe(false);
+    [
+      {
+        msg: { coin: "bitcoin", path: [1, 2, 3] },
+        out: { coin: "bitcoin", verbose: "m/1/2/3", isKnown: false },
+      },
+      {
+        msg: {
+          coin: "bitcoin",
+          path: [44 + 0x80000000, 0 + 0x80000000, 0 + 0x80000000, 0, 0],
+          scriptType: BTCInputScriptType.SpendAddress,
+        },
+        out: { coin: "bitcoin", verbose: "m/44'/0'/0'/0/0", isKnown: false },
+      },
+      {
+        msg: {
+          coin: "Bitcoin",
+          path: [44 + 0x80000000, 0 + 0x80000000, 0 + 0x80000000],
+          scriptType: BTCInputScriptType.SpendAddress,
+        },
+        out: { coin: "Bitcoin", verbose: "Bitcoin Account #0 (Legacy)", isKnown: true, wholeAccount: true },
+      },
+      {
+        msg: {
+          coin: "Bitcoin",
+          path: [44 + 0x80000000, 0 + 0x80000000, 0 + 0x80000000, 0, 0],
+          scriptType: BTCInputScriptType.SpendAddress,
+        },
+        out: { coin: "Bitcoin", verbose: "Bitcoin Account #0, Address #0 (Legacy)", isKnown: true },
+      },
+      {
+        msg: { coin: "dash", path: [1, 2, 3], scriptType: BTCInputScriptType.SpendWitness },
+        out: { coin: "dash", verbose: "m/1/2/3", scriptType: BTCInputScriptType.SpendWitness, isKnown: false },
+      },
+      {
+        msg: { coin: "bitcoincash", path: [1, 2, 3] },
+        out: { coin: "bitcoincash", verbose: "m/1/2/3", isKnown: false },
+      },
+      {
+        msg: { coin: "ethereum", path: [44 + 0x80000000, 60 + 0x80000000, 0 + 0x80000000, 0, 0] },
+        out: { coin: "Ethereum", verbose: "Ethereum Account #0", isKnown: true },
+      },
+      {
+        msg: { coin: "atom", path: [44 + 0x80000000, 118 + 0x80000000, 0 + 0x80000000, 0, 0] },
+        out: { coin: "Atom", verbose: "Cosmos Account #0", isKnown: true },
+      },
+      {
+        msg: { coin: "binance", path: [44 + 0x80000000, 714 + 0x80000000, 0 + 0x80000000, 0, 0] },
+        out: { coin: "Binance", verbose: "Binance Account #0", isKnown: true },
+      },
+      {
+        msg: { coin: "fio", path: [44 + 0x80000000, 235 + 0x80000000, 0 + 0x80000000, 0, 0] },
+        out: { coin: "Fio", verbose: "Fio Account #0", isKnown: true },
+      },
+    ].forEach((x) => expect(info.describePath(x.msg)).toMatchObject(x.out));
+    expect(() => info.describePath({ coin: "foobar", path: [1, 2, 3] })).toThrowError("Unsupported path");
+  });
+});
+
+describe("NativeHDWallet", () => {
   it("should keep mnemonic private", () => {
     const wallet = NativeHDWallet.create({ mnemonic: MNEMONIC, deviceId: "deviceId" });
     const json = JSON.stringify(wallet);
@@ -15,8 +91,12 @@ describe("hdwallet-native", () => {
   describe("loadDevice", () => {
     it("should load wallet with a mnemonic", async () => {
       const wallet = NativeHDWallet.create({ deviceId: "native" });
+      await expect(wallet.isInitialized()).resolves.toBe(false);
+      await expect(wallet.isLocked()).resolves.toBe(false);
       await wallet.loadDevice({ mnemonic: MNEMONIC });
       await expect(wallet.initialize()).resolves.toBe(true);
+      await expect(wallet.isInitialized()).resolves.toBe(true);
+      await expect(wallet.isLocked()).resolves.toBe(false);
     });
 
     it("should load wallet with a mnemonic and deviceId", async () => {
@@ -35,6 +115,11 @@ describe("hdwallet-native", () => {
       }
     );
 
+    it("should throw an error when loadDevice is missing its parameters", async () => {
+      const wallet = NativeHDWallet.create({ deviceId: "native" });
+      await expect(wallet.loadDevice(undefined)).rejects.toThrow("Required property [mnemonic] is missing or invalid");
+    });
+
     it.each([[undefined], [null], [0], [[1, 2, 3]], [{}], [""], ["all all all all all all"]])(
       "should throw an error if mnemonic is not a string (%o)",
       async (param: any) => {
@@ -44,5 +129,107 @@ describe("hdwallet-native", () => {
         );
       }
     );
+  });
+
+  it("should wipe if an error occurs during initialization", async () => {
+    expect.assertions(7);
+    const wallet = NativeHDWallet.create({ deviceId: "native" });
+    await wallet.loadDevice({ mnemonic: MNEMONIC });
+    const mocks = [
+      jest.spyOn(bip39, "mnemonicToSeed").mockImplementationOnce(() => {
+        throw "mock error";
+      }),
+      jest.spyOn(console, "error").mockImplementationOnce((msg, error) => {
+        expect(msg).toMatch("NativeHDWallet:initialize:error");
+        expect(error).toEqual("mock error");
+      }),
+      jest.spyOn(wallet, "wipe"),
+    ];
+    await expect(wallet.initialize()).resolves.toBe(false);
+    mocks.forEach((x) => {
+      expect(x).toHaveBeenCalled();
+      x.mockRestore();
+    });
+  });
+
+  it("should have correct metadata", async () => {
+    const deviceId = "foobar";
+    const wallet = NativeHDWallet.create({ deviceId });
+    await expect(wallet.getFeatures()).resolves.toEqual({});
+    await expect(wallet.getDeviceID()).resolves.toEqual(deviceId);
+    await expect(wallet.getFirmwareVersion()).resolves.toEqual("Software");
+    await expect(wallet.getModel()).resolves.toEqual("Native");
+    await expect(wallet.getLabel()).resolves.toEqual("Native");
+  });
+
+  it("should emit MNEMONIC_REQUIRED when initialized without a mnemonic", async () => {
+    const wallet = NativeHDWallet.create({ deviceId: "native" });
+    const mnemonicRequiredMock = jest.fn(({ message_type }) => {
+      expect(message_type).toBe(NativeHDWallet.NativeEvents.MNEMONIC_REQUIRED);
+    });
+    const readyMock = jest.fn(({ message_type }) => {
+      expect(message_type).toBe(NativeHDWallet.NativeEvents.READY);
+    });
+    wallet.events.addListener(NativeHDWallet.NativeEvents.READY, readyMock);
+    wallet.events.addListener(NativeHDWallet.NativeEvents.MNEMONIC_REQUIRED, mnemonicRequiredMock);
+    await expect(wallet.initialize()).resolves.toBe(null);
+    expect(mnemonicRequiredMock).toHaveBeenCalled();
+    expect(readyMock).not.toHaveBeenCalled();
+  });
+
+  it("should emit READY when initialized with a mnemonic", async () => {
+    const wallet = NativeHDWallet.create({ deviceId: "native" });
+    const mnemonicRequiredMock = jest.fn(({ message_type }) => {
+      expect(message_type).toBe(NativeHDWallet.NativeEvents.MNEMONIC_REQUIRED);
+    });
+    const readyMock = jest.fn(({ message_type }) => {
+      expect(message_type).toBe(NativeHDWallet.NativeEvents.READY);
+    });
+    wallet.events.addListener(NativeHDWallet.NativeEvents.READY, readyMock);
+    wallet.events.addListener(NativeHDWallet.NativeEvents.MNEMONIC_REQUIRED, mnemonicRequiredMock);
+    await wallet.loadDevice({ mnemonic: MNEMONIC });
+    await expect(wallet.initialize()).resolves.toBe(true);
+    expect(mnemonicRequiredMock).not.toHaveBeenCalled();
+    expect(readyMock).toHaveBeenCalled();
+  });
+
+  it("should emit MNEMONIC_REQUIRED when initialized after a wipe", async () => {
+    const wallet = NativeHDWallet.create({ deviceId: "native" });
+    const mock = jest.fn();
+    wallet.events.addListener(NativeHDWallet.NativeEvents.MNEMONIC_REQUIRED, mock);
+    await wallet.loadDevice({ mnemonic: MNEMONIC });
+    await expect(wallet.initialize()).resolves.toBe(true);
+    await wallet.wipe();
+    expect(mock).not.toHaveBeenCalled();
+    await expect(wallet.initialize()).resolves.toBe(null);
+    expect(mock).toHaveBeenCalled();
+  });
+
+  it("should work with isNative", () => {
+    const wallet = NativeHDWallet.create({ deviceId: "native" });
+    expect(NativeHDWallet.isNative(wallet)).toBe(true);
+  });
+
+  it("should respond to .ping()", async () => {
+    const wallet = NativeHDWallet.create({ deviceId: "native" });
+    await expect(wallet.ping({ msg: "pong" })).resolves.toEqual({ msg: "pong" });
+  });
+
+  describe("nothing happens", () => {
+    const wallet = NativeHDWallet.create({ deviceId: "native" });
+
+    it.each([
+      ["clearSession"],
+      ["sendPin"],
+      ["sendPassphrase"],
+      ["sendCharacter"],
+      ["sendWord"],
+      ["cancel"],
+      ["reset"],
+      ["recover"],
+      ["disconnect"],
+    ])("when %s is called", async (methodName) => {
+      await expect(untouchable.call(wallet, methodName)).resolves.toBe(undefined);
+    });
   });
 });

--- a/packages/hdwallet-native/src/networks.test.ts
+++ b/packages/hdwallet-native/src/networks.test.ts
@@ -1,0 +1,29 @@
+import { getNetwork } from "./networks";
+
+describe("getNetwork", () => {
+  it("should return the bitcoin network", () => {
+    expect(getNetwork("bitcoin")).toMatchObject({
+      bech32: "bc",
+      pubKeyHash: 0x00,
+      scriptHash: 0x05,
+      wif: 0x80,
+    });
+  });
+
+  it("should return the testnet network", () => {
+    expect(getNetwork("testnet")).toMatchObject({
+      bech32: "tb",
+      pubKeyHash: 0x6f,
+      scriptHash: 0xc4,
+      wif: 0xef,
+    });
+  });
+
+  it("should throw if asked for an unsupported network", () => {
+    expect(() => getNetwork("foobar")).toThrowError("foobar network not supported");
+  });
+
+  it("should throw if asked for an unsupported script type", () => {
+    expect(() => getNetwork("bitcoin", "foobar")).toThrowError("foobar not supported for bitcoin network");
+  });
+});

--- a/packages/hdwallet-native/src/util.test.ts
+++ b/packages/hdwallet-native/src/util.test.ts
@@ -1,0 +1,14 @@
+import { default as util } from "./util";
+import * as bip32 from "bip32";
+import * as bip39 from "bip39";
+
+describe("getKeyPair", () => {
+  const seed = bip32.fromSeed(bip39.mnemonicToSeedSync("all all all all all all all all all all all all"));
+
+  it("should produce the key pair at m/1337/0", async () => {
+    expect(util.getKeyPair(seed, [1337, 0])).toEqual({
+      publicKey: "029bf8b52f7efe773323bf1746b8489c4e823adb73644476cc099df57b1be0cb94",
+      privateKey: "89cd054013cc6badeb49baf2b287531317d33e4bc48c3fa5d1c6661ef054f6db",
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,6 +2442,11 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@open-draft/until@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@open-draft/until/-/until-1.0.3.tgz#db9cc719191a62e7d9200f6e7bab21c5b848adca"
+  integrity sha512-Aq58f5HiWdyDlFffbbSjAlv596h/cOnt2DO1w3DOC7OJ5EHs0hd/nycJfiu9RJbT6Yk6F1knnRRXNSpxoIVZ9Q==
+
 "@parcel/fs@^1.11.0":
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/@parcel/fs/-/fs-1.11.0.tgz#fb8a2be038c454ad46a50dc0554c1805f13535cd"
@@ -2607,6 +2612,11 @@
   dependencies:
     "@types/filesystem" "*"
 
+"@types/cookie@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.0.tgz#14f854c0f93d326e39da6e3b6f34f7d37513d108"
+  integrity sha512-y7mImlc/rNkvCRmg8gC3/lj87S7pTUIJ6QGjwHR9WQJcFs+ZMTOaoPrkdFA/YdbuqVEmEbb5RdhVxMkAcgOnpg==
+
 "@types/crypto-js@^3.1.9-1":
   version "3.1.47"
   resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-3.1.47.tgz#36e549dd3f1322742a3a738e7c113ebe48221860"
@@ -2674,6 +2684,14 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.4.tgz#8c3496bd1b50cc04aeefd691140aa571d4dbfa34"
   integrity sha512-t2szdkwmg2JJyuCM20e8kR2X59WCE5Zkl4bzm1u1Oukjm79zpbiAv+QjnwLnuuV0WHEcX2NgUItu0pAMKuOPww==
 
+"@types/inquirer@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-7.3.1.tgz#1f231224e7df11ccfaf4cf9acbcc3b935fea292d"
+  integrity sha512-osD38QVIfcdgsPCT0V3lD7eH0OFurX71Jft18bZrsVQWVRt6TuxRzlr0GJLrxoHZR2V5ph7/qP8se/dcnI7o0g==
+  dependencies:
+    "@types/through" "*"
+    rxjs "^6.4.0"
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
@@ -2700,6 +2718,11 @@
   integrity sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==
   dependencies:
     jest-diff "^24.3.0"
+
+"@types/js-levenshtein@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.0.tgz#9541eec4ad6e3ec5633270a3a2b55d981edc44a9"
+  integrity sha512-14t0v1ICYRtRVcHASzes0v/O+TIeASb8aD55cWF1PidtInhFWSXcmhzhHqGjUWf9SUq1w70cvd1cWKUULubAfQ==
 
 "@types/lodash@^4.14.110", "@types/lodash@^4.14.85":
   version "4.14.162"
@@ -2795,6 +2818,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/set-cookie-parser@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/set-cookie-parser/-/set-cookie-parser-2.4.0.tgz#10cc0446bad372827671a5195fbd14ebce4a9baf"
+  integrity sha512-w7BFUq81sy7H/0jN0K5cax8MwRN6NOSURpY4YuO4+mOgoicxCZ33BUYz+gyF/sUf7uDl2We2yGJfppxzEXoAXQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/shelljs@^0.8.0":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.8.tgz#e439c69929b88a2c8123c1a55e09eb708315addf"
@@ -2807,6 +2837,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/through@*":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@types/through/-/through-0.0.30.tgz#e0e42ce77e897bd6aead6f6ea62aeb135b8a3895"
+  integrity sha512-FvnCJljyxhPM3gkRgWmxmDZyAQSiBQQWLI0A0VFL0K7W1oRUrPJSqNO0NvTnLkBcotdlp3lKvaT0JrnyRDkzOg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/usb@^1.5.1":
   version "1.5.2"
@@ -2967,6 +3004,13 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
+ansi-escapes@^4.2.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
+  integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+  dependencies:
+    type-fest "^0.11.0"
+
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
@@ -2982,6 +3026,11 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -2993,6 +3042,13 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
 
 ansi-to-html@^0.6.4:
   version "0.6.14"
@@ -3013,6 +3069,14 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
+
+anymatch@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
+  integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+  dependencies:
+    normalize-path "^3.0.0"
+    picomatch "^2.0.4"
 
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
@@ -3453,6 +3517,11 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
+binary-extensions@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
+  integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
 bindings@^1.2.1, bindings@^1.3.0, bindings@^1.4.0, bindings@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
@@ -3665,6 +3734,13 @@ braces@^2.3.1, braces@^2.3.2:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
+
+braces@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
+  integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+  dependencies:
+    fill-range "^7.0.1"
 
 brfs@^1.2.0:
   version "1.6.1"
@@ -4075,6 +4151,14 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
+  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -4105,6 +4189,21 @@ chokidar@^2.1.5:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
+
+chokidar@^3.4.2:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.1.tgz#ee9ce7bbebd2b79f49f304799d5468e31e14e68a"
+  integrity sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.3.1"
 
 chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
@@ -4157,6 +4256,13 @@ cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
+
 cli-spinners@^1.1.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
@@ -4167,6 +4273,11 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
+
 cliui@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
@@ -4175,6 +4286,15 @@ cliui@^5.0.0:
     string-width "^3.1.0"
     strip-ansi "^5.2.0"
     wrap-ansi "^5.1.0"
+
+cliui@^7.0.2:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-7.0.4.tgz#a0265ee655476fc807aea9df3df8df7783808b4f"
+  integrity sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
 
 clone-deep@^4.0.1:
   version "4.0.1"
@@ -4243,12 +4363,19 @@ color-convert@^1.9.0, color-convert@^1.9.1:
   dependencies:
     color-name "1.1.3"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -4492,6 +4619,11 @@ cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
+
+cookie@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 cookiejar@^2.1.1:
   version "2.1.2"
@@ -4910,6 +5042,13 @@ debug@^4.1.0, debug@^4.1.1, debug@^4.2.0:
   dependencies:
     ms "2.1.2"
 
+debug@^4.3.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
+  integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+  dependencies:
+    ms "2.1.2"
+
 debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
@@ -5288,6 +5427,11 @@ emoji-regex@^7.0.1:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
 
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -5450,7 +5594,7 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
     d "^1.0.1"
     ext "^1.1.2"
 
-escalade@^3.1.0:
+escalade@^3.1.0, escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
@@ -6133,6 +6277,13 @@ figures@^2.0.0:
   dependencies:
     escape-string-regexp "^1.0.5"
 
+figures@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
+  integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+
 file-uri-to-path@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
@@ -6152,6 +6303,13 @@ fill-range@^4.0.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
+
+fill-range@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
+  integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -6349,6 +6507,11 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
+fsevents@~2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
@@ -6383,7 +6546,7 @@ gensync@^1.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
   integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
 
-get-caller-file@^2.0.1:
+get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
@@ -6523,6 +6686,13 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@~5.1.0:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
@@ -6627,6 +6797,11 @@ grapheme-breaker@^0.3.2:
     brfs "^1.2.0"
     unicode-trie "^0.3.1"
 
+graphql@^15.4.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
+  integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -6683,6 +6858,11 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
   integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
 has-symbol-support-x@^1.4.1:
   version "1.4.2"
@@ -6782,6 +6962,11 @@ hdkey@^1.1.1:
     bs58check "^2.1.2"
     safe-buffer "^5.1.1"
     secp256k1 "^3.0.1"
+
+headers-utils@^1.2.0:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/headers-utils/-/headers-utils-1.2.5.tgz#899d6a76b21bcbe18d6108f56136fdbd4f30c404"
+  integrity sha512-DAzV5P/pk3wTU/8TLZN+zFTDv4Xa1QDTU8pRvovPetcOMbmqq8CwsAvZBLPZHH6usxyy31zMp7I4aCYb6XIf6w==
 
 hex-color-regex@^1.1.0:
   version "1.1.0"
@@ -7121,6 +7306,25 @@ inquirer@^6.2.0:
     strip-ansi "^5.1.0"
     through "^2.3.6"
 
+inquirer@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
 interpret@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
@@ -7193,6 +7397,13 @@ is-binary-path@^1.0.0:
   integrity sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=
   dependencies:
     binary-extensions "^1.0.0"
+
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
 
 is-boolean-object@^1.1.0:
   version "1.1.0"
@@ -7321,6 +7532,11 @@ is-fullwidth-code-point@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
 is-function@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.2.tgz#4f097f30abf6efadac9833b17ca5dc03f8144e08"
@@ -7343,7 +7559,7 @@ is-glob@^3.1.0:
   dependencies:
     is-extglob "^2.1.0"
 
-is-glob@^4.0.0, is-glob@^4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -7383,6 +7599,11 @@ is-number@^3.0.0:
   integrity sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
   dependencies:
     kind-of "^3.0.2"
+
+is-number@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
+  integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
 is-obj@^1.0.0:
   version "1.0.1"
@@ -7983,6 +8204,11 @@ jquery@^3.4.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
   integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 js-sha3@0.5.7, js-sha3@^0.5.7:
   version "0.5.7"
@@ -8958,6 +9184,30 @@ ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+msw@^0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/msw/-/msw-0.27.1.tgz#9dad215cd53b8b1b5e9446aa586e20cc8e2e086a"
+  integrity sha512-oAhqvOTEX16DjMFoYZaI10KeiYMMCnQR8EcXEFu2KzA6khmUe9tSM0rDRyO/wvuMLffODgVRdSkjCId90yFyVw==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    "@types/cookie" "^0.4.0"
+    "@types/inquirer" "^7.3.1"
+    "@types/js-levenshtein" "^1.1.0"
+    chalk "^4.1.0"
+    chokidar "^3.4.2"
+    cookie "^0.4.1"
+    graphql "^15.4.0"
+    headers-utils "^1.2.0"
+    inquirer "^7.3.3"
+    js-levenshtein "^1.1.6"
+    node-fetch "^2.6.1"
+    node-match-path "^0.6.1"
+    node-request-interceptor "^0.6.3"
+    statuses "^2.0.0"
+    strict-event-emitter "^0.1.0"
+    virtual-cookies "^0.1.2"
+    yargs "^16.2.0"
+
 multibase@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/multibase/-/multibase-0.7.0.tgz#1adfc1c50abe05eefeb5091ac0c2728d6b84581b"
@@ -9024,7 +9274,7 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-mute-stream@~0.0.4:
+mute-stream@0.0.8, mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
@@ -9226,6 +9476,11 @@ node-libs-browser@^2.0.0:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
+node-match-path@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/node-match-path/-/node-match-path-0.6.1.tgz#63570f8e60f726e75d6d9f016d08cbac609ec7d5"
+  integrity sha512-5KjUxG0fUqiIB4HXVatTYGNXf0fD/ZIC88P2w5izFrk6jz45hgavoVuIERsTqb+lMPMuvvL3rxvFWwpnJzN/wQ==
+
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
@@ -9246,6 +9501,16 @@ node-releases@^1.1.61:
   version "1.1.63"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.63.tgz#db6dbb388544c31e888216304e8fd170efee3ff5"
   integrity sha512-ukW3iCfQaoxJkSPN+iK7KznTeqDGVJatAEuXsJERYHa9tn/KaT5lBdIyxQjLEVTzSkyjJEuQ17/vaEjrOauDkg==
+
+node-request-interceptor@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/node-request-interceptor/-/node-request-interceptor-0.6.3.tgz#f2f0dbec2d421584419dd39ff6782ce1e02b42a7"
+  integrity sha512-8I2V7H2Ch0NvW7qWcjmS0/9Lhr0T6x7RD6PDirhvWEkUQvy83x8BA4haYMr09r/rig7hcgYSjYh6cd4U7G1vLA==
+  dependencies:
+    "@open-draft/until" "^1.0.3"
+    debug "^4.3.0"
+    headers-utils "^1.2.0"
+    strict-event-emitter "^0.1.0"
 
 noop-logger@^0.1.1:
   version "0.1.1"
@@ -9282,7 +9547,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -9993,6 +10258,11 @@ physical-cpu-count@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/physical-cpu-count/-/physical-cpu-count-2.0.0.tgz#18de2f97e4bf7a9551ad7511942b5496f7aba660"
   integrity sha1-GN4vl+S/epVRrXURlCtUlverpmA=
+
+picomatch@^2.0.4, picomatch@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
+  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -11005,6 +11275,13 @@ readdirp@^2.2.1:
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
 
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
+
 realpath-native@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/realpath-native/-/realpath-native-1.1.0.tgz#2003294fea23fb0672f2476ebe22fcf498a2d65c"
@@ -11240,6 +11517,14 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+
 ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
@@ -11400,7 +11685,7 @@ rsvp@^4.8.4:
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-run-async@^2.2.0:
+run-async@^2.2.0, run-async@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
   integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
@@ -11426,6 +11711,13 @@ rxjs@^6.4.0, rxjs@^6.5.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.0:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
+  integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
   dependencies:
     tslib "^1.9.0"
 
@@ -11597,6 +11889,11 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+set-cookie-parser@^2.4.6:
+  version "2.4.8"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-2.4.8.tgz#d0da0ed388bc8f24e706a391f9c9e252a13c58b2"
+  integrity sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==
 
 set-immediate-shim@^1.0.1:
   version "1.0.1"
@@ -11959,6 +12256,11 @@ static-module@^2.2.0:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
+statuses@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
+  integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
+
 stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
@@ -11995,6 +12297,11 @@ stream-shift@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.1.tgz#d7088281559ab2778424279b0877da3c392d5a3d"
   integrity sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==
+
+strict-event-emitter@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.1.0.tgz#fd742c1fb7e3852f0b964ecdae2d7666a6fb7ef8"
+  integrity sha512-8hSYfU+WKLdNcHVXJ0VxRXiPESalzRe7w1l8dg9+/22Ry+iZQUoQuoJ27R30GMD1TiyYINWsIEGY05WrskhSKw==
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -12034,6 +12341,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
 
 string.prototype.trimend@^1.0.1:
   version "1.0.1"
@@ -12106,6 +12422,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 strip-bom@^2.0.0:
   version "2.0.0"
@@ -12203,6 +12526,13 @@ supports-color@^6.1.0:
   integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
 
 svgo@^1.0.0, svgo@^1.3.2:
   version "1.3.2"
@@ -12459,6 +12789,13 @@ to-regex-range@^2.1.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
 
+to-regex-range@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
+  integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+  dependencies:
+    is-number "^7.0.0"
+
 to-regex@^3.0.1, to-regex@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
@@ -12567,6 +12904,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-fest@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
 
 type-fest@^0.13.1:
   version "0.13.1"
@@ -13033,6 +13375,14 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+virtual-cookies@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/virtual-cookies/-/virtual-cookies-0.1.2.tgz#67683d2bba98b9351d9446274ccbfb9c105671cd"
+  integrity sha512-mcjWP9Jp1Qzsm06aXKVUJaTaSdnPuRFz/KOLkx7joAJEcWjdQVJwfyKjlvUS6kpKDhZGWi0qSCZelMc6uij9BQ==
+  dependencies:
+    "@types/set-cookie-parser" "^2.4.0"
+    set-cookie-parser "^2.4.6"
 
 vlq@^0.2.2:
   version "0.2.3"
@@ -13760,6 +14110,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
@@ -13924,6 +14283,11 @@ y18n@^4.0.0:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
 
+y18n@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.5.tgz#8769ec08d03b1ea2df2500acef561743bbb9ab18"
+  integrity sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+
 yaeti@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/yaeti/-/yaeti-0.0.6.tgz#f26f484d72684cf42bedfb76970aa1608fbf9577"
@@ -13965,6 +14329,11 @@ yargs-parser@^18.1.3:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^20.2.2:
+  version "20.2.7"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
+  integrity sha512-FiNkvbeHzB/syOjIUxFDCnhSfzAL8R5vs40MgLFBorXACCOAEaWu0gRZl14vG8MR9AOJIZbmkjhusqBYZ3HTHw==
+
 yargs@^13.3.0:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
@@ -13997,3 +14366,16 @@ yargs@^14.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.1"
+
+yargs@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"


### PR DESCRIPTION
Following on from the groundwork laid in #265, #270, #251, #252, #253, and #250 (:facepalm:), this is a test-only PR which adds full test coverage<sup>1</sup> to `hdwallet-native`<sup>2</sup>.

<sup>1</sup>: Offer of full coverage only applies to code committed by v1.10.0 or thereabouts. Offer may not yet include Thorchain, Terra, Kava, Secret, or any other strangely-named coins.
<sup>2</sup>: Claims of "Full Coverage" exclude the last commit, which removes all the tests which don't work because they expose parts of the code that is broken.