### PR TITLE
Work around bad Buffer.concat polyfills

### DIFF
--- a/packages/hdwallet-core/src/utils.ts
+++ b/packages/hdwallet-core/src/utils.ts
@@ -186,3 +186,24 @@ export function untouchable(message: string): any {
   }})) as any;
   return out;
 }
+
+// Webpack 4's Buffer.concat() polyfill requires Buffer[] instead of Uint8Array[]. This is a
+// kludgy compatibility hack until everything gets bumped to Webpack 5.
+let needCompatibleBufferConcat: boolean | undefined = undefined;
+
+export function checkBufferConcat(): boolean {
+  if (needCompatibleBufferConcat === undefined) {
+    try {
+      Buffer.concat([new Uint8Array()]);
+      needCompatibleBufferConcat = false;
+    } catch {
+      needCompatibleBufferConcat = true;
+    }
+  }
+  return needCompatibleBufferConcat;
+}
+
+export function compatibleBufferConcat(list: Uint8Array[]): Buffer {
+  if (!checkBufferConcat()) return Buffer.concat(list);
+  return Buffer.concat(list.map(x => Buffer.isBuffer(x) ? x : Buffer.from(x)));
+}

--- a/packages/hdwallet-keepkey/src/eos.ts
+++ b/packages/hdwallet-keepkey/src/eos.ts
@@ -29,11 +29,11 @@ function eosSigFormatter(r: Uint8Array, s: Uint8Array, v: number): string {
   console.log(check);
 
   console.log("hash");
-  console.log(createHash("ripemd160").update(Buffer.concat(check)).digest());
-  const chksum = createHash("ripemd160").update(Buffer.concat(check)).digest().slice(0, 4);
+  console.log(createHash("ripemd160").update(core.compatibleBufferConcat(check)).digest());
+  const chksum = createHash("ripemd160").update(core.compatibleBufferConcat(check)).digest().slice(0, 4);
 
   console.log(chksum);
-  signature = signature.concat(base58.encode(Buffer.concat([keyBuffer, chksum])));
+  signature = signature.concat(base58.encode(core.compatibleBufferConcat([keyBuffer, chksum])));
 
   console.log(signature);
 

--- a/packages/hdwallet-ledger/src/utils.ts
+++ b/packages/hdwallet-ledger/src/utils.ts
@@ -64,7 +64,7 @@ export const compressPublicKey = (publicKey: Uint8Array) => {
   if ([0x02, 0x03].includes(publicKey[0]) && publicKey.length === 33) return Buffer.from(publicKey);
   if (!(publicKey[0] === 0x04 && publicKey.length === 65)) throw new Error("Invalid public key format");
 
-  return Buffer.concat([
+  return core.compatibleBufferConcat([
     Buffer.from([((publicKey[64] & 0x01) === 0x00 ? 0x02 : 0x03)]),
     publicKey.slice(1,33),
   ]);
@@ -78,7 +78,7 @@ export const createXpub = (depth: number, parentFp: number, childNum: number, ch
   headerView.setUint32(5, parentFp);
   headerView.setUint32(9, childNum);
   return bs58check.encode(
-    Buffer.concat([
+    core.compatibleBufferConcat([
       header,
       chainCode,
       publicKey,

--- a/packages/hdwallet-native/src/crypto/isolation/adapters/ethereum.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/adapters/ethereum.ts
@@ -1,5 +1,6 @@
 import { SigningKey as ETHSigningKey } from "@ethersproject/signing-key";
 import { splitSignature, BytesLike, Signature as ethSignature, arrayify } from "@ethersproject/bytes";
+import * as core from "@shapeshiftoss/hdwallet-core"
 import * as tinyecc from "tiny-secp256k1";
 
 import { SecP256K1 } from "../core";
@@ -34,7 +35,7 @@ export class SigningKeyAdapter implements ETHSigningKey {
   }
   signDigest(digest: BytesLike): ethSignature {
     const rawSig = SecP256K1.RecoverableSignature.signCanonically(this._isolatedKey, digest instanceof Uint8Array ? digest : arrayify(digest));
-    return splitSignature(Buffer.concat([rawSig, Buffer.from([rawSig.recoveryParam])]));
+    return splitSignature(core.compatibleBufferConcat([rawSig, Buffer.from([rawSig.recoveryParam])]));
   }
   signTx(txData: BytesLike): ethSignature {
     const txBuf = arrayify(txData);
@@ -45,7 +46,7 @@ export class SigningKeyAdapter implements ETHSigningKey {
       typeof messageData === "string"
         ? Buffer.from(messageData.normalize("NFKD"), "utf8")
         : Buffer.from(arrayify(messageData));
-    const messageBuf = Buffer.concat([Buffer.from(`\x19Ethereum Signed Message:\n${messageDataBuf.length}`, "utf8"), messageDataBuf]);
+    const messageBuf = core.compatibleBufferConcat([Buffer.from(`\x19Ethereum Signed Message:\n${messageDataBuf.length}`, "utf8"), messageDataBuf]);
     return this.signDigest(Isolation.Digest.Algorithms["keccak256"](messageBuf));
   }
   computeSharedSecret(otherKey: BytesLike): string {

--- a/packages/hdwallet-native/src/crypto/isolation/adapters/fio.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/adapters/fio.ts
@@ -1,4 +1,5 @@
 import { ExternalPrivateKey as FIOExternalPrivateKey } from "@shapeshiftoss/fiojs";
+import * as core from "@shapeshiftoss/hdwallet-core"
 import bs58 from "bs58"
 
 import { SecP256K1 } from "..";
@@ -7,8 +8,8 @@ import { checkType } from "../types";
 
 function bs58FioEncode(raw: Uint8Array, keyType: string = ""): string {
     const typeBuf = Buffer.from(keyType, "utf8");
-    const checksum = Digest.Algorithms["ripemd160"](Buffer.concat([raw, typeBuf])).slice(0, 4);
-    return bs58.encode(Buffer.concat([raw, checksum]));
+    const checksum = Digest.Algorithms["ripemd160"](core.compatibleBufferConcat([raw, typeBuf])).slice(0, 4);
+    return bs58.encode(core.compatibleBufferConcat([raw, checksum]));
 }
 
 type IsolatedKey = SecP256K1.ECDSAKeyInterface & SecP256K1.ECDHKeyInterface;
@@ -24,7 +25,7 @@ export class ExternalSignerAdapter implements FIOExternalPrivateKey {
     sign(signBuf: Uint8Array): string {
         const signBufHash = Digest.Algorithms["sha256"](signBuf);
         const sig = SecP256K1.RecoverableSignature.fromSignature(this._isolatedKey.ecdsaSign(signBufHash), signBufHash, this._isolatedKey.publicKey);
-        const fioSigBuf = Buffer.concat([Buffer.from([sig.recoveryParam + 4 + 27]), SecP256K1.RecoverableSignature.r(sig), SecP256K1.RecoverableSignature.s(sig)]);
+        const fioSigBuf = core.compatibleBufferConcat([Buffer.from([sig.recoveryParam + 4 + 27]), SecP256K1.RecoverableSignature.r(sig), SecP256K1.RecoverableSignature.s(sig)]);
         return `SIG_K1_${bs58FioEncode(fioSigBuf, "K1")}`;
     }
     getSharedSecret(publicKey: any): Buffer {

--- a/packages/hdwallet-native/src/crypto/isolation/core/secp256k1/types.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/core/secp256k1/types.ts
@@ -1,3 +1,5 @@
+
+import * as core from "@shapeshiftoss/hdwallet-core"
 import * as tinyecc from "tiny-secp256k1";
 import { Literal, Partial, Object as Obj, Static, Union } from "funtypes";
 import { recoverPublicKey as ethRecoverPublicKey } from "@ethersproject/signing-key";
@@ -167,7 +169,7 @@ const recoverableSignatureStatic = {
     },
     recoverPublicKey: (x: RecoverableSignature, message: Message): CurvePoint => {
       // TODO: do this better
-      const ethSigBytes = Buffer.concat([x, Buffer.from([x.recoveryParam])]);
+      const ethSigBytes = core.compatibleBufferConcat([x, Buffer.from([x.recoveryParam])]);
       const ethRecovered = ethRecoverPublicKey(message, ethSplitSignature(ethSigBytes));
       return checkType(UncompressedPoint, Buffer.from(ethRecovered.slice(2), "hex"));
     },

--- a/packages/hdwallet-native/src/crypto/isolation/engines/dummy/bip39.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/engines/dummy/bip39.ts
@@ -1,5 +1,7 @@
 /// <reference types="bip32/types/crypto" />
 
+import * as core from "@shapeshiftoss/hdwallet-core"
+
 export * from "../../core/bip39";
 import * as BIP39 from "../../core/bip39";
 
@@ -24,7 +26,7 @@ function pbkdf2_sha512_singleblock(
 
     const pwBuffer = safeBufferFrom(new TextEncoder().encode(password));
 
-    let out = bip32crypto.hmacSHA512(pwBuffer, Buffer.concat([salt, be32Buf(1)])) as Buffer & { length: 64 };
+    let out = bip32crypto.hmacSHA512(pwBuffer, core.compatibleBufferConcat([salt, be32Buf(1)])) as Buffer & { length: 64 };
     let lastU = out;
     for (let i = 2; i <= iterations; i++) {
     let newU = bip32crypto.hmacSHA512(pwBuffer, lastU) as Buffer & { length: 64 };


### PR DESCRIPTION
Webpack 4's `Buffer.concat()` polyfill requires `Buffer[]` instead of `Uint8Array[]`. This is a kludgy compatibility hack until everything gets bumped to Webpack 5.