### PR TITLE
a couple keepkey fixes

### DIFF
--- a/packages/hdwallet-keepkey/src/ethereum.ts
+++ b/packages/hdwallet-keepkey/src/ethereum.ts
@@ -51,7 +51,6 @@ export async function ethSignTx(transport: Transport, msg: core.ETHSignTx): Prom
     est.setGasLimit(core.arrayify(msg.gasLimit));
     if (msg.gasPrice) {
       est.setGasPrice(core.arrayify(msg.gasPrice));
-      est.setType(core.ETHTransactionType.ETH_TX_TYPE_LEGACY);
     }
     if (msg.maxFeePerGas) {
       est.setMaxFeePerGas(core.arrayify(msg.maxFeePerGas));

--- a/packages/hdwallet-keepkey/src/ethereum.ts
+++ b/packages/hdwallet-keepkey/src/ethereum.ts
@@ -21,10 +21,6 @@ export function ethSupportsNativeShapeShift(): boolean {
   return true;
 }
 
-export async function ethSupportsEIP1559(): Promise<boolean> {
-  return await this.ethSupportsEIP1559();
-}
-
 export function ethGetAccountPaths(msg: core.ETHGetAccountPath): Array<core.ETHAccountPath> {
   const slip44 = core.slip44ByCoin(msg.coin);
   if (slip44 === undefined) return [];

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -413,7 +413,7 @@ export class KeepKeyHDWalletInfo
   }
 
   public async ethSupportsEIP1559(): Promise<boolean> {
-    return await Eth.ethSupportsEIP1559();
+    return true;
   }
 
   public ethGetAccountPaths(msg: core.ETHGetAccountPath): Array<core.ETHAccountPath> {


### PR DESCRIPTION
- By at least FW v7.2.1, setting the Ethereum TX type to ETH_TX_TYPE_LEGACY causes a failure (which makes sense because the relevant field in the TX is supposed to be omitted rather than set to 0). Integration tests didn't catch it, probably because they're using an older emulator version without 1559 support.
- Calling `ethSupportsEIP1559()` on `KeepKeyHDWalletInfo` would result in a recursion loop due to shenanigans with the value of `this`. Fortunately, this shouldn't happen in practice, since the `KeepKeyHDWalletInfo::ethSupportsEIP1559` is usually shadowed by `KeepKeyHDWallet::ethSupportsEIP1559`.