### PR TITLE
bugfix:  Pairing flow and btcSignTx

### DIFF
--- a/packages/hdwallet-ledger-webusb/src/transport.ts
+++ b/packages/hdwallet-ledger-webusb/src/transport.ts
@@ -42,7 +42,7 @@ export async function getTransport(): Promise<TransportWebUSB> {
   if (!(window && window.navigator.usb)) throw new core.WebUSBNotAvailable();
 
   try {
-    return (await TransportWebUSB.create()) as TransportWebUSB;
+    return (await TransportWebUSB.request()) as TransportWebUSB;
   } catch (err) {
     if (err.name === "TransportInterfaceNotAvailable") {
       throw new core.ConflictingApp("Ledger");


### PR DESCRIPTION
Pairing: Need to call `transport.request()` or else it errors out because there is no "user interaction"
btcSignTx: `txArgs.sigHashType` cannot be explicity set to `undefined` or else Ledger errors out with "invalid data received"