### PR TITLE
fix: gas limit parameter for MetaMask

### DIFF
--- a/packages/hdwallet-metamask/src/ethereum.ts
+++ b/packages/hdwallet-metamask/src/ethereum.ts
@@ -63,6 +63,10 @@ export async function ethSendTx(msg: core.ETHSignTx, ethereum: any, from: string
       data: msg.data,
       chainId: msg.chainId,
       nonce: msg.nonce,
+      // MetaMask, like other Web3 libraries, derives its transaction schema from Ethereum's official JSON-RPC API specification
+      // (https://github.com/ethereum/execution-apis/blob/d63d2a02bcd2a8cef54ae2fc5bbff8b4fac944eb/src/schemas/transaction.json).
+      // That schema defines the use of the label `gas` to set the transaction's gas limit and not `gasLimit` as used in other
+      // libraries and as stated in the official yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf).
       gas: msg.gasLimit,
     };
 

--- a/packages/hdwallet-metamask/src/ethereum.ts
+++ b/packages/hdwallet-metamask/src/ethereum.ts
@@ -63,7 +63,7 @@ export async function ethSendTx(msg: core.ETHSignTx, ethereum: any, from: string
       data: msg.data,
       chainId: msg.chainId,
       nonce: msg.nonce,
-      gasLimit: msg.gasLimit,
+      gas: msg.gasLimit,
     };
 
     const utx = msg.maxFeePerGas


### PR DESCRIPTION
Fixed Metamask parameter for `gasLimit`.

Metamask and other web3 libraries (i.e. `geth console`, `web3.js`, etc.) use `transaction.gas` property for transaction's gas limit, instead of the canonical `transaction.gasLimit` as mentioned in the [yellow paper](https://ethereum.github.io/yellowpaper/paper.pdf). This implies Metamask does not read any value for gas limit from the JSON object, and so it chooses one on its own. This behavior can lead to inconsistencies between clients and the wallet, for example when forecasting the transaction's cost (see https://github.com/shapeshift/web/issues/526).