### PR TITLE
feat: lazy-load various things

### DIFF
--- a/integration/src/wallets/portis.ts
+++ b/integration/src/wallets/portis.ts
@@ -38,19 +38,19 @@ export async function createWallet(): Promise<core.HDWallet> {
 
   // mock web3.eth
   // this feels bad man, would be better to test against a debug verision of Portis should it ever exist
-  wallet.web3 = {
+  wallet.web3 = Promise.resolve({
     eth: {
       accounts: {
-        recover: () => Promise.resolve("0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8"),
+        recover: () => "0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8",
       },
-      getAccounts: () => ["0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8"],
-      sign: () =>
+      getAccounts: async () => ["0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8"],
+      sign: async () =>
         "0x29f7212ecc1c76cea81174af267b67506f754ea8c73f144afa900a0d85b24b21319621aeb062903e856352f38305710190869c3ce5a1425d65ef4fa558d0fc251b",
-      signTransaction: ({ data }: any) => {
+      signTransaction: async ({ data }: any) => {
         return data.length ? mockSignERC20TxResponse : mockSignEthTxResponse;
       },
     },
-  } as any;
+  } as any);
   // end mock
 
   return wallet;

--- a/integration/src/wallets/portis.ts
+++ b/integration/src/wallets/portis.ts
@@ -41,7 +41,7 @@ export async function createWallet(): Promise<core.HDWallet> {
   wallet.web3 = Promise.resolve({
     eth: {
       accounts: {
-        recover: () => "0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8",
+        recover: async () => "0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8",
       },
       getAccounts: async () => ["0x3f2329C9ADFbcCd9A84f52c906E936A42dA18CB8"],
       sign: async () =>

--- a/packages/hdwallet-native-vault/src/index.ts
+++ b/packages/hdwallet-native-vault/src/index.ts
@@ -1,5 +1,3 @@
-import * as native from "@shapeshiftoss/hdwallet-native";
-
 import { Vault } from "./vault";
 import { GENERATE_MNEMONIC, crypto, createMnemonic, entropyToMnemonic } from "./util";
 

--- a/packages/hdwallet-native/src/binance.ts
+++ b/packages/hdwallet-native/src/binance.ts
@@ -1,7 +1,7 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
 import * as bech32 from "bech32";
 import BigNumber from "bignumber.js";
-import * as bnbSdk from "bnb-javascript-sdk-nobroadcast";
+import type * as bnbSdk from "bnb-javascript-sdk-nobroadcast";
 import CryptoJS from "crypto-js";
 
 import { NativeHDWalletBase } from "./native";
@@ -83,6 +83,7 @@ export function MixinNativeBinanceWallet<TBase extends core.Constructor<NativeHD
         if (!tx.sequence) tx.sequence = "0"
         if (!tx.source) tx.source = "0"
 
+        const bnbSdk = await import("bnb-javascript-sdk-nobroadcast")
         const client = new bnbSdk.BncClient(msg.testnet ? "https://testnet-dex.binance.org" : "https://dex.binance.org"); // broadcast not used but available
         await client.chooseNetwork(msg.testnet ? "testnet" : "mainnet");
         const haveAccountNumber = !!msg.tx.account_number && Number.isInteger(Number(msg.tx.account_number));

--- a/packages/hdwallet-native/src/crypto/isolation/adapters/binance.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/adapters/binance.ts
@@ -1,13 +1,15 @@
-import { Transaction, BncClient, crypto } from "bnb-javascript-sdk-nobroadcast";
-import { BIP32, Digest, SecP256K1 } from "../core"
+import type { Transaction, BncClient } from "bnb-javascript-sdk-nobroadcast";
+import { BIP32, SecP256K1 } from "../core"
 
 type SigningDelegate = Parameters<BncClient["setSigningDelegate"]>[0];
+
+const crypto = (async () => (await import("bnb-javascript-sdk-nobroadcast")).crypto)()
 
 export default {
   async create(keyPair: BIP32.Node): Promise<SigningDelegate> {
     return async (tx: Transaction, signMsg?: any): Promise<Transaction> => {
       const signBytes = tx.getSignBytes(signMsg);
-      const pubKey = crypto.getPublicKey(Buffer.from(await keyPair.getPublicKey()).toString("hex"));
+      const pubKey = (await crypto).getPublicKey(Buffer.from(await keyPair.getPublicKey()).toString("hex"));
       const sig = Buffer.from(await SecP256K1.Signature.signCanonically(keyPair, "sha256", signBytes));
       tx.addSignature(pubKey, sig);
       return tx;

--- a/packages/hdwallet-native/src/crypto/isolation/adapters/bitcoin.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/adapters/bitcoin.ts
@@ -1,8 +1,13 @@
-import { ECPairInterface, Network, SignerAsync, crypto as bcrypto, networks } from "@shapeshiftoss/bitcoinjs-lib";
+import type { ECPairInterface, Network, SignerAsync, crypto as bcrypto, networks } from "@shapeshiftoss/bitcoinjs-lib";
 import { SecP256K1, IsolationError } from "../core"
 import { assertType, ByteArray } from "../types";
 
 export type ECPairInterfaceAsync = Omit<ECPairInterface, "sign"> & Pick<SignerAsync, "sign">;
+
+let networksInstance: typeof networks | undefined
+const networksReady = (async () => {
+  networksInstance = (await import("@shapeshiftoss/bitcoinjs-lib")).networks
+})()
 
 export class ECPairAdapter implements SecP256K1.ECDSAKey, SignerAsync, ECPairInterfaceAsync {
     protected readonly _isolatedKey: SecP256K1.ECDSAKey;
@@ -18,11 +23,12 @@ export class ECPairAdapter implements SecP256K1.ECDSAKey, SignerAsync, ECPairInt
     }
 
     static async create(isolatedKey: SecP256K1.ECDSAKey, network?: Network): Promise<ECPairAdapter> {
+        await networksReady
         return new ECPairAdapter(isolatedKey, await isolatedKey.getPublicKey(), network);
     }
 
     get network() {
-        return this._network ?? networks.bitcoin;
+        return this._network ?? networksInstance!.bitcoin;
     }
 
     get ecdsaSign() {

--- a/packages/hdwallet-native/src/crypto/isolation/engines/default/bip32.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/engines/default/bip32.ts
@@ -94,7 +94,7 @@ export class Node extends Revocable(class {}) implements BIP32.Node, SecP256K1.E
         const msgOrDigest = digestAlgorithm === null ? checkType(ByteArray(32), msg) : Digest.Algorithms[digestAlgorithm](checkType(ByteArray(), msg));
         const entropy = (counter === undefined ? undefined : Buffer.alloc(32));
         entropy?.writeUInt32BE(counter ?? 0, 24);
-        return SecP256K1.RecoverableSignature.fromSignature(
+        return await SecP256K1.RecoverableSignature.fromSignature(
             checkType(SecP256K1.Signature, (tinyecc as typeof tinyecc & {
                 signWithEntropy: (message: Buffer, privateKey: Buffer, entropy?: Buffer) => Buffer,
             }).signWithEntropy(Buffer.from(msgOrDigest), this.#privateKey, entropy)),

--- a/packages/hdwallet-portis/src/adapter.ts
+++ b/packages/hdwallet-portis/src/adapter.ts
@@ -1,4 +1,3 @@
-import Portis from "@portis/web3";
 import * as core from "@shapeshiftoss/hdwallet-core";
 
 import { PortisHDWallet } from "./portis";
@@ -60,6 +59,7 @@ export class PortisAdapter {
   }
 
   private async pairPortisDevice(): Promise<core.HDWallet> {
+    const Portis = (await import("@portis/web3")).default;
     this.portis = new Portis(this.portisAppId, "mainnet");
     const wallet = new PortisHDWallet(this.portis);
     await wallet.initialize();


### PR DESCRIPTION
In general, loading the third-party SDKs we need is quite a time-consuming operation (>500ms in dev mode!), and it's not strictly necessary until they need to be actually used. Using dynamic `import()` to pull them in allows this process to be deferred until a convenient moment so that the UI isn't blocked.

Note that the commit to `hdwallet-native-vault` retains a static dependency on `hdwallet-native` because it contains `Revocable`, which somewhat defeats the point. However, this will soon (#400) be refactored out of `hdwallet-native`, which will remove this dependency and realize the performance potential.