### PR TITLE
suppress a few dumb coverage collection errors

### DIFF
--- a/integration/src/wallets/portis.ts
+++ b/integration/src/wallets/portis.ts
@@ -50,7 +50,7 @@ export async function createWallet(): Promise<core.HDWallet> {
         return data.length ? mockSignERC20TxResponse : mockSignEthTxResponse;
       },
     },
-  };
+  } as any;
   // end mock
 
   return wallet;

--- a/packages/hdwallet-ledger-webusb/src/adapter.ts
+++ b/packages/hdwallet-ledger-webusb/src/adapter.ts
@@ -73,7 +73,7 @@ export class WebUSBLedgerAdapter {
 
       const ledgerTransport = await openTransport(device);
 
-      const wallet = ledger.create(new LedgerWebUsbTransport(device, ledgerTransport, this.keyring));
+      const wallet = ledger.create(new LedgerWebUsbTransport(device, ledgerTransport, this.keyring) as ledger.LedgerTransport);
 
       this.keyring.add(wallet, device.serialNumber);
     }

--- a/packages/hdwallet-trezor-connect/src/transport.ts
+++ b/packages/hdwallet-trezor-connect/src/transport.ts
@@ -124,7 +124,7 @@ export class TrezorConnectTransport extends trezor.TrezorTransport {
       await TrezorConnectTransport.cancellable(TrezorConnectTransport.callInProgress);
 
       try {
-        let result = await TrezorConnect[method]({ device, ...msg });
+        let result = await (TrezorConnect as any)[method]({ device, ...msg });
         if (
           result.payload.error === "Popup closed" ||
           result.payload.error === "Cancelled" ||


### PR DESCRIPTION
This reduces the amount of log spam tests produce.