### PR TITLE
even-more-async isolation interfaces

### DIFF
--- a/packages/hdwallet-native-vault/src/index.test.ts
+++ b/packages/hdwallet-native-vault/src/index.test.ts
@@ -98,7 +98,10 @@ function testVaultImpl(name: string, Vault: ISealableVaultFactory<IVault>) {
       const mnemonic = (await vault.get("#mnemonic")) as native.crypto.Isolation.Engines.Default.BIP39.Mnemonic;
       expect(mnemonic).toBeInstanceOf(native.crypto.Isolation.Engines.Default.BIP39.Mnemonic);
       expect(
-        Buffer.from((await (await mnemonic.toSeed()).toMasterKey()).publicKey).toString("hex")
+        await mnemonic.toSeed()
+          .then(x => x.toMasterKey())
+          .then(x => x.getPublicKey())
+          .then(x => Buffer.from(x).toString("hex"))
       ).toMatchInlineSnapshot(`"03e3b30e8c21923752a408242e069941fedbaef7db7161f7e2c5f3fdafe7e25ddc"`);
     });
     
@@ -109,7 +112,10 @@ function testVaultImpl(name: string, Vault: ISealableVaultFactory<IVault>) {
       const mnemonic = (await vault.get("#mnemonic")) as native.crypto.Isolation.Engines.Default.BIP39.Mnemonic;
       expect(mnemonic).toBeInstanceOf(native.crypto.Isolation.Engines.Default.BIP39.Mnemonic);
       expect(
-        Buffer.from((await (await mnemonic.toSeed()).toMasterKey()).publicKey).toString("hex")
+        await mnemonic.toSeed()
+          .then(x => x.toMasterKey())
+          .then(x => x.getPublicKey())
+          .then(x => Buffer.from(x).toString("hex"))
       ).toMatchInlineSnapshot(`"03e3b30e8c21923752a408242e069941fedbaef7db7161f7e2c5f3fdafe7e25ddc"`);
     });
 
@@ -171,7 +177,10 @@ function testVaultImpl(name: string, Vault: ISealableVaultFactory<IVault>) {
       const mnemonic = (await vault.get("#mnemonic")) as native.crypto.Isolation.Engines.Default.BIP39.Mnemonic;
       expect(mnemonic).toBeInstanceOf(native.crypto.Isolation.Engines.Default.BIP39.Mnemonic);
       expect(
-        Buffer.from((await (await mnemonic.toSeed()).toMasterKey()).publicKey).toString("hex")
+        await mnemonic.toSeed()
+          .then(x => x.toMasterKey())
+          .then(x => x.getPublicKey())
+          .then(x => Buffer.from(x).toString("hex"))
       ).toMatchInlineSnapshot(`"02576bde4c55b05886e56eeeeff304006352f935b6dfc1c409f7eae521dbc5558e"`);
 
       const unwrappedMnemonic = (await vault.unwrap().get("#mnemonic")) as string;
@@ -186,7 +195,10 @@ function testVaultImpl(name: string, Vault: ISealableVaultFactory<IVault>) {
       const mnemonic = (await vault.get("#mnemonic")) as native.crypto.Isolation.Engines.Default.BIP39.Mnemonic;
       expect(mnemonic).toBeInstanceOf(native.crypto.Isolation.Engines.Default.BIP39.Mnemonic);
       expect(
-        Buffer.from((await (await mnemonic.toSeed()).toMasterKey()).publicKey).toString("hex")
+        await mnemonic.toSeed()
+          .then(x => x.toMasterKey())
+          .then(x => x.getPublicKey())
+          .then(x => Buffer.from(x).toString("hex"))
       ).toMatchInlineSnapshot(`"02576bde4c55b05886e56eeeeff304006352f935b6dfc1c409f7eae521dbc5558e"`);
 
       expect(await vault.unwrap().get("#mnemonic")).toMatchInlineSnapshot(

--- a/packages/hdwallet-native-vault/src/index.ts
+++ b/packages/hdwallet-native-vault/src/index.ts
@@ -14,7 +14,7 @@ Vault.registerValueTransformer("#mnemonic", async (x: unknown) => {
 Vault.registerValueWrapper("#mnemonic", async (x: unknown, addRevoker: (revoke: () => void) => void) => {
   if (typeof x !== "string") throw new TypeError("#mnemonic must be a string");
   const out = await createMnemonic(x);
-  addRevoker(() => out.revoke());
+  addRevoker(() => out.revoke?.());
   return out;
 });
 Vault.extensionRegistrationComplete();

--- a/packages/hdwallet-native/src/binance.ts
+++ b/packages/hdwallet-native/src/binance.ts
@@ -88,7 +88,7 @@ export function MixinNativeBinanceWallet<TBase extends core.Constructor<NativeHD
         await client.chooseNetwork(msg.testnet ? "testnet" : "mainnet");
         const haveAccountNumber = !!msg.tx.account_number && Number.isInteger(Number(msg.tx.account_number));
         if (haveAccountNumber) await client.setAccountNumber(Number(msg.tx.account_number));
-        client.setSigningDelegate(await Isolation.Adapters.Binance.create(keyPair));
+        client.setSigningDelegate(await Isolation.Adapters.Binance.create(keyPair.node));
 
         await client.initChain();
 

--- a/packages/hdwallet-native/src/cosmos.ts
+++ b/packages/hdwallet-native/src/cosmos.ts
@@ -76,7 +76,7 @@ export function MixinNativeCosmosWallet<TBase extends core.Constructor<NativeHDW
     async cosmosSignTx(msg: core.CosmosSignTx): Promise<core.CosmosSignedTx | null> {
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "cosmos");
-        const adapter = await Isolation.Adapters.Cosmos.create(keyPair);
+        const adapter = await Isolation.Adapters.Cosmos.create(keyPair.node);
         const result = await txBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, ATOM_CHAIN);
 
         return txBuilder.createSignedTx(msg.tx, result);

--- a/packages/hdwallet-native/src/crypto/isolation/adapters/bip32.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/adapters/bip32.ts
@@ -17,8 +17,8 @@ export type BIP32InterfaceAsync = Omit<bip32.BIP32Interface, "sign" | "derive" |
     derivePath(path: string): Promise<BIP32InterfaceAsync>;
   };
 
-export class BIP32Adapter extends ECPairAdapter implements BIP32.Node, BIP32InterfaceAsync {
-  protected readonly _isolatedNode: BIP32.Node;
+export class BIP32Adapter extends ECPairAdapter implements BIP32InterfaceAsync {
+  readonly node: BIP32.Node;
   readonly _chainCode: BIP32.ChainCode;
   readonly _publicKey: SecP256K1.CurvePoint;
   readonly index: number;
@@ -27,9 +27,9 @@ export class BIP32Adapter extends ECPairAdapter implements BIP32.Node, BIP32Inte
   _identifier?: Buffer;
   _base58?: string;
 
-  protected constructor(isolatedNode: BIP32.Node, chainCode: BIP32.ChainCode, publicKey: SecP256K1.CurvePoint, networkOrParent?: BIP32Adapter | Network, index?: number) {
-    super(isolatedNode, publicKey, networkOrParent instanceof BIP32Adapter ? networkOrParent.network : networkOrParent);
-    this._isolatedNode = isolatedNode;
+  protected constructor(node: BIP32.Node, chainCode: BIP32.ChainCode, publicKey: SecP256K1.CurvePoint, networkOrParent?: BIP32Adapter | Network, index?: number) {
+    super(node, publicKey, networkOrParent instanceof BIP32Adapter ? networkOrParent.network : networkOrParent);
+    this.node = node;
     this._chainCode = chainCode;
     this._publicKey = publicKey;
     this.index = index ?? 0;
@@ -96,13 +96,13 @@ export class BIP32Adapter extends ECPairAdapter implements BIP32.Node, BIP32Inte
   }
 
   toBase58(): never {
-    throw new IsolationError("xpriv");
+    throw new IsolationError("xprv");
   }
 
   async derive(index: number): Promise<this> {
     let out = this._children.get(index);
     if (!out) {
-      out = (await BIP32Adapter.create(await this._isolatedNode.derive(index), this, index)) as this;
+      out = (await BIP32Adapter.create(await this.node.derive(index), this, index)) as this;
       this._children.set(index, out);
     }
     return out;

--- a/packages/hdwallet-native/src/crypto/isolation/adapters/bitcoin.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/adapters/bitcoin.ts
@@ -9,7 +9,7 @@ const networksReady = (async () => {
   networksInstance = (await import("@shapeshiftoss/bitcoinjs-lib")).networks
 })()
 
-export class ECPairAdapter implements SecP256K1.ECDSAKey, SignerAsync, ECPairInterfaceAsync {
+export class ECPairAdapter implements SignerAsync, ECPairInterfaceAsync {
     protected readonly _isolatedKey: SecP256K1.ECDSAKey;
     readonly _publicKey: SecP256K1.CurvePoint;
     readonly _network: Network | undefined;

--- a/packages/hdwallet-native/src/crypto/isolation/adapters/ethereum.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/adapters/ethereum.ts
@@ -10,16 +10,16 @@ function ethSigFromRecoverableSig(x: SecP256K1.RecoverableSignature): ethers.Sig
 }
 
 export class SignerAdapter extends ethers.Signer {
-  protected readonly _isolatedKey: SecP256K1.ECDSAKey & SecP256K1.ECDHKey;
+  protected readonly _isolatedKey: SecP256K1.ECDSAKey;
   readonly provider?: ethers.providers.Provider
 
-  protected constructor(isolatedKey: SecP256K1.ECDSAKey & SecP256K1.ECDHKey, provider?: ethers.providers.Provider) {
+  protected constructor(isolatedKey: SecP256K1.ECDSAKey, provider?: ethers.providers.Provider) {
     super();
     this._isolatedKey = isolatedKey;
     this.provider = provider;
   }
 
-  static async create(isolatedKey: SecP256K1.ECDSAKey & SecP256K1.ECDHKey, provider?: ethers.providers.Provider): Promise<SignerAdapter> {
+  static async create(isolatedKey: SecP256K1.ECDSAKey, provider?: ethers.providers.Provider): Promise<SignerAdapter> {
     return new SignerAdapter(isolatedKey, provider)
   }
 

--- a/packages/hdwallet-native/src/crypto/isolation/core/bip32/index.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/core/bip32/index.ts
@@ -4,7 +4,11 @@ export * from "./interfaces";
 import { Path } from "./types";
 import { Node } from "./interfaces";
 
-export async function derivePath<T extends Node>(node: T, path: Path): Promise<T> {
+interface Derivable {
+    derive(index: number): Promise<this>
+}
+
+export async function derivePath<T extends Derivable>(node: T, path: Path): Promise<T> {
     // This logic is copied (almost) wholesale from the bip32 package.
     Path.assert(path);
 

--- a/packages/hdwallet-native/src/crypto/isolation/core/bip32/interfaces.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/core/bip32/interfaces.ts
@@ -9,8 +9,8 @@ export interface Seed extends Partial<Revocable> {
 }
 
 export interface Node extends Partial<Revocable>, SecP256K1.ECDSAKey, Partial<SecP256K1.ECDHKey> {
-    getPublicKey(): SecP256K1.CompressedPoint | Promise<SecP256K1.CompressedPoint>;
-    getChainCode(): ChainCode | Promise<ChainCode>;
+    getPublicKey(): Promise<SecP256K1.CompressedPoint>;
+    getChainCode(): Promise<ChainCode>;
     derive(index: number): Promise<this>;
 }
 

--- a/packages/hdwallet-native/src/crypto/isolation/core/secp256k1/interfaces.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/core/secp256k1/interfaces.ts
@@ -3,7 +3,7 @@ import { CurvePoint, RecoverableSignature, Signature } from "./types";
 import * as Digest from "../digest";
 
 export interface ECDSAKey {
-    getPublicKey(): CurvePoint | Promise<CurvePoint>;
+    getPublicKey(): Promise<CurvePoint>;
 
     // Signatures MUST use a determinsitic nonce generation algorithm, which SHOULD be the one specified in RFC6979. The
     // counter parameter is used to generate multiple distinct signatures over the same message, and SHOULD be included as
@@ -26,7 +26,7 @@ export interface ECDSARecoverableKey extends ECDSAKey {
 }
 
 export interface ECDHKey {
-    getPublicKey(): CurvePoint | Promise<CurvePoint>;
+    getPublicKey(): Promise<CurvePoint>;
 
     // Calculates a shared secret field element according to the ECDH key-agreement scheme specified in SEC 1 section 3.3.2,
     // encoded as a 32-byte big-endian integer. The output of this function is not uniformly distributed, and is not safe to

--- a/packages/hdwallet-native/src/crypto/isolation/engines/default/bip39.ts
+++ b/packages/hdwallet-native/src/crypto/isolation/engines/default/bip39.ts
@@ -2,15 +2,16 @@
 
 import * as core from "@shapeshiftoss/hdwallet-core"
 
-export * from "../../core/bip39";
-import * as BIP39 from "../../core/bip39";
-
 import * as bip32crypto from "bip32/src/crypto";
 import { TextEncoder } from "web-encoding";
 
+import * as BIP39 from "../../core/bip39";
+import * as BIP32 from "../../core/bip32";
 import { safeBufferFrom } from "../../types";
-import * as BIP32 from "./bip32";
+import * as BIP32Engine from "./bip32";
 import { revocable, Revocable } from "./revocable";
+
+export * from "../../core/bip39";
 
 // Poor man's single-block PBKDF2 implementation
 //TODO: get something better
@@ -46,7 +47,7 @@ export class Mnemonic extends Revocable(class {}) implements BIP39.Mnemonic {
         this.#mnemonic = mnemonic.normalize("NFKD");
     }
 
-    static async create(mnemonic: string): Promise<Mnemonic> {
+    static async create(mnemonic: string): Promise<BIP39.Mnemonic> {
         const obj = new Mnemonic(mnemonic)
         return revocable(obj, (x) => obj.addRevoker(x));
     }
@@ -57,8 +58,8 @@ export class Mnemonic extends Revocable(class {}) implements BIP39.Mnemonic {
         const mnemonic = this.#mnemonic;
         const salt = new TextEncoder().encode(`mnemonic${passphrase ?? ""}`.normalize("NFKD"));
 
-        const out = await BIP32.Seed.create(pbkdf2_sha512_singleblock(mnemonic, salt, 2048));
-        this.addRevoker(() => out.revoke())
+        const out = await BIP32Engine.Seed.create(pbkdf2_sha512_singleblock(mnemonic, salt, 2048));
+        this.addRevoker(() => out.revoke?.())
         return out
     };
 }

--- a/packages/hdwallet-native/src/ethereum.ts
+++ b/packages/hdwallet-native/src/ethereum.ts
@@ -55,7 +55,7 @@ export function MixinNativeETHWallet<TBase extends core.Constructor<NativeHDWall
     async ethInitializeWallet(masterKey: Isolation.Core.BIP32.Node): Promise<void> {
       const rootNode = await Isolation.Adapters.BIP32.create(masterKey)
       const isolatedSigner = await rootNode.derivePath(ethers.utils.defaultPath);
-      this.#ethSigner = await Isolation.Adapters.Ethereum.create(isolatedSigner);
+      this.#ethSigner = await Isolation.Adapters.Ethereum.create(isolatedSigner.node);
     }
 
     ethWipe() {

--- a/packages/hdwallet-native/src/kava.ts
+++ b/packages/hdwallet-native/src/kava.ts
@@ -75,7 +75,7 @@ export function MixinNativeKavaWallet<TBase extends core.Constructor<NativeHDWal
     async kavaSignTx(msg: core.KavaSignTx): Promise<core.KavaSignedTx | null> {
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "kava");
-        const adapter = await Isolation.Adapters.Cosmos.create(keyPair);
+        const adapter = await Isolation.Adapters.Cosmos.create(keyPair.node);
         const result = await txBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, msg.chain_id);
         return txBuilder.createSignedTx(msg.tx, result);
       });

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -23,8 +23,8 @@ export enum NativeEvents {
   READY = "READY",
 }
 
-function isMnemonicInterface(x: any): x is Isolation.Core.BIP39.Mnemonic {
-  return ["object", "function"].includes(typeof x) && x !== null && "toSeed" in x && typeof x.toSeed === "function";
+function isMnemonicInterface(x: unknown): x is Isolation.Core.BIP39.Mnemonic {
+  return core.isIndexable(x) && typeof x.toSeed === "function";
 }
 
 type LoadDevice = Omit<core.LoadDevice, "mnemonic"> & {

--- a/packages/hdwallet-native/src/osmosis.ts
+++ b/packages/hdwallet-native/src/osmosis.ts
@@ -76,7 +76,7 @@ export function MixinNativeOsmosisWallet<TBase extends core.Constructor<NativeHD
     async osmosisSignTx(msg: core.OsmosisSignTx): Promise<core.OsmosisSignedTx | null> {
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "osmosis");
-        const adapter = await Isolation.Adapters.Cosmos.create(keyPair);
+        const adapter = await Isolation.Adapters.Cosmos.create(keyPair.node);
         const result = await txBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, OSMOSIS_CHAIN);
 
         return txBuilder.createSignedTx(msg.tx, result);

--- a/packages/hdwallet-native/src/secret.ts
+++ b/packages/hdwallet-native/src/secret.ts
@@ -74,7 +74,7 @@ export function MixinNativeSecretWallet<TBase extends core.Constructor<NativeHDW
     async secretSignTx(msg: core.SecretSignTx): Promise<any | null> {
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "secret");
-        const adapter = await Isolation.Adapters.Cosmos.create(keyPair);
+        const adapter = await Isolation.Adapters.Cosmos.create(keyPair.node);
         const result = await txBuilder.sign(msg.tx, adapter, String(msg.sequence), String(msg.account_number), msg.chain_id);
         return txBuilder.createSignedTx(msg.tx, result);
       });

--- a/packages/hdwallet-native/src/terra.ts
+++ b/packages/hdwallet-native/src/terra.ts
@@ -75,7 +75,7 @@ export function MixinNativeTerraWallet<TBase extends core.Constructor<NativeHDWa
     async terraSignTx(msg: core.TerraSignTx): Promise<any | null> {
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "terra");
-        const adapter = await Isolation.Adapters.Cosmos.create(keyPair);
+        const adapter = await Isolation.Adapters.Cosmos.create(keyPair.node);
         const result = await txBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, "terra");
         return txBuilder.createSignedTx(msg.tx, result);
       });

--- a/packages/hdwallet-native/src/thorchain.ts
+++ b/packages/hdwallet-native/src/thorchain.ts
@@ -76,7 +76,7 @@ export function MixinNativeThorchainWallet<TBase extends core.Constructor<Native
     async thorchainSignTx(msg: core.ThorchainSignTx): Promise<core.ThorchainSignedTx | null> {
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "thorchain");
-        const adapter = await Isolation.Adapters.Cosmos.create(keyPair);
+        const adapter = await Isolation.Adapters.Cosmos.create(keyPair.node);
         const result = await txBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, THOR_CHAIN);
         return txBuilder.createSignedTx(msg.tx, result);
       });


### PR DESCRIPTION
The last few properties on the crypto isolation interfaces are now async, enabling them to be used as-is with comlink.