### PR TITLE
use async functions for portis/metamask

### DIFF
--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -139,12 +139,12 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
     return "MetaMask";
   }
 
-  public getModel(): Promise<string> {
-    return Promise.resolve("MetaMask");
+  public async getModel(): Promise<string> {
+    return "MetaMask";
   }
 
-  public getLabel(): Promise<string> {
-    return Promise.resolve("MetaMask");
+  public async getLabel(): Promise<string> {
+    return "MetaMask";
   }
 
   public async initialize(): Promise<void> {
@@ -183,59 +183,49 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
     // TODO: Can we lock MetaMask from here?
   }
 
-  public ping(msg: core.Ping): Promise<core.Pong> {
+  public async ping(msg: core.Ping): Promise<core.Pong> {
     // no ping function for MetaMask, so just returning Core.Pong
-    return Promise.resolve({ msg: msg.msg });
+    return { msg: msg.msg };
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public sendPin(pin: string): Promise<void> {
+  public async sendPin(pin: string): Promise<void> {
     // no concept of pin in MetaMask
-    return Promise.resolve();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public sendPassphrase(passphrase: string): Promise<void> {
+  public async sendPassphrase(passphrase: string): Promise<void> {
     // cannot send passphrase to MetaMask. Could show the widget?
-    return Promise.resolve();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public sendCharacter(charater: string): Promise<void> {
+  public async sendCharacter(charater: string): Promise<void> {
     // no concept of sendCharacter in MetaMask
-    return Promise.resolve();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public sendWord(word: string): Promise<void> {
+  public async sendWord(word: string): Promise<void> {
     // no concept of sendWord in MetaMask
-    return Promise.resolve();
   }
 
-  public cancel(): Promise<void> {
+  public async cancel(): Promise<void> {
     // no concept of cancel in MetaMask
-    return Promise.resolve();
   }
 
-  public wipe(): Promise<void> {
-    return Promise.resolve();
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public async wipe(): Promise<void> {}
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public reset(msg: core.ResetDevice): Promise<void> {
-    return Promise.resolve();
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
+  public async reset(msg: core.ResetDevice): Promise<void> {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public recover(msg: core.RecoverDevice): Promise<void> {
+  public async recover(msg: core.RecoverDevice): Promise<void> {
     // no concept of recover in MetaMask
-    return Promise.resolve();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public loadDevice(msg: core.LoadDevice): Promise<void> {
+  public async loadDevice(msg: core.LoadDevice): Promise<void> {
     // TODO: Does MetaMask allow this to be done programatically?
-    return Promise.resolve();
   }
 
   public describePath(msg: core.DescribePath): core.PathDescription {
@@ -252,9 +242,8 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
     return true;
   }
 
-  public disconnect(): Promise<void> {
-    return Promise.resolve();
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public async disconnect(): Promise<void> {}
 
   public async ethSupportsNetwork(chainId = 1): Promise<boolean> {
     return chainId === 1;

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -70,7 +70,7 @@ export class PortisHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo
   }
 
   public async btcSupportsSecureTransfer(): Promise<boolean> {
-    return Promise.resolve(false);
+    return false;
   }
 
   public btcSupportsNativeShapeShift(): boolean {
@@ -131,7 +131,7 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
   ethAddress?: string;
 
   // used as a mutex to ensure calls to portis.getExtendedPublicKey cannot happen before a previous call has resolved
-  portisCallInProgress: Promise<any> = Promise.resolve();
+  protected portisCallInProgress: Promise<void> = Promise.resolve();
 
   constructor(portis: Portis) {
     this.portis = portis;
@@ -162,10 +162,9 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
     return "Portis";
   }
 
-  public initialize(): Promise<any> {
+  public async initialize(): Promise<void> {
     // no means to reset the state of the Portis widget
     // while it's in the middle of execution
-    return Promise.resolve();
   }
 
   public hasOnDevicePinEntry(): boolean {
@@ -200,53 +199,44 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
     await this.portis.logout();
   }
 
-  public ping(msg: core.Ping): Promise<core.Pong> {
+  public async ping(msg: core.Ping): Promise<core.Pong> {
     // no ping function for Portis, so just returning Core.Pong
-    return Promise.resolve({ msg: msg.msg });
+    return { msg: msg.msg };
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public sendPin(pin: string): Promise<void> {
+  public async sendPin(pin: string): Promise<void> {
     // no concept of pin in Portis
-    return Promise.resolve();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public sendPassphrase(passphrase: string): Promise<void> {
+  public async sendPassphrase(passphrase: string): Promise<void> {
     // cannot send passphrase to Portis. Could show the widget?
-    return Promise.resolve();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public sendCharacter(charater: string): Promise<void> {
+  public async sendCharacter(charater: string): Promise<void> {
     // no concept of sendCharacter in Portis
-    return Promise.resolve();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public sendWord(word: string): Promise<void> {
+  public async sendWord(word: string): Promise<void> {
     // no concept of sendWord in Portis
-    return Promise.resolve();
   }
 
-  public cancel(): Promise<void> {
+  public async cancel(): Promise<void> {
     // no concept of cancel in Portis
-    return Promise.resolve();
   }
 
-  public wipe(): Promise<void> {
-    return Promise.resolve();
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public async wipe(): Promise<void> {}
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public reset(msg: core.ResetDevice): Promise<void> {
-    return Promise.resolve();
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars
+  public async reset(msg: core.ResetDevice): Promise<void> {}
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public recover(msg: core.RecoverDevice): Promise<void> {
+  public async recover(msg: core.RecoverDevice): Promise<void> {
     // no concept of recover in Portis
-    return Promise.resolve();
   }
 
   public loadDevice(msg: core.LoadDevice): Promise<void> {
@@ -259,12 +249,7 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
 
   public async getPublicKeys(msg: Array<core.GetPublicKey>): Promise<Array<core.PublicKey | null>> {
     const publicKeys: { xpub: string }[] = [];
-    this.portisCallInProgress = (async () => {
-      try {
-        await this.portisCallInProgress;
-      } catch (e) {
-        console.error(e);
-      }
+    const out = this.portisCallInProgress.then(async () => {
       for (let i = 0; i < msg.length; i++) {
         const { addressNList } = msg[i];
         const bitcoinSlip44 = 0x80000000 + core.slip44ByCoin("Bitcoin");
@@ -278,17 +263,18 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
         publicKeys.push({ xpub: result });
       }
       return publicKeys;
-    })();
-    return this.portisCallInProgress;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    this.portisCallInProgress = out.then(() => {});
+    return out;
   }
 
   public async isInitialized(): Promise<boolean> {
     return true;
   }
 
-  public disconnect(): Promise<void> {
-    return Promise.resolve();
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public async disconnect(): Promise<void> {}
 
   public async btcGetAddress(msg: core.BTCGetAddress): Promise<string> {
     return btc.btcGetAddress(msg, this.portis);


### PR DESCRIPTION
this modernizes `hdwallet-portis` and `hdwallet-metamask` to use async functions instead of `return Promise.resolve()` everywhere.