### PR TITLE
drop legacy shapeshift MX support

### DIFF
--- a/integration/src/bitcoin/bitcoin.ts
+++ b/integration/src/bitcoin/bitcoin.ts
@@ -463,19 +463,6 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
     );
 
     test(
-      "btcSupportsNativeShapeShift()",
-      async () => {
-        if (!wallet) return;
-        expect(typeof wallet.btcSupportsNativeShapeShift() === typeof true);
-        if (wallet.btcSupportsNativeShapeShift()) {
-          expect(info.btcSupportsNativeShapeShift()).toBeTruthy();
-        }
-        // TODO: write a testcase that exercises native shapeshift, if the wallet claims to support it.
-      },
-      TIMEOUT
-    );
-
-    test(
       "btcGetAccountPaths()",
       async () => {
         await each(

--- a/integration/src/ethereum/ethereum.ts
+++ b/integration/src/ethereum/ethereum.ts
@@ -40,16 +40,6 @@ export function ethereumTests(get: () => { wallet: core.HDWallet; info: core.HDW
     );
 
     test(
-      "ethSupportsNativeShapeShift()",
-      async () => {
-        if (!wallet) return;
-        // TODO: add a test that pays a ShapeShift conduit
-        expect(typeof wallet.ethSupportsNativeShapeShift() === typeof true).toBeTruthy();
-      },
-      TIMEOUT
-    );
-
-    test(
       "ethSupportsSecureTransfer()",
       async () => {
         if (!wallet) return;

--- a/integration/src/wallets/keepkey.ts
+++ b/integration/src/wallets/keepkey.ts
@@ -94,11 +94,6 @@ export function selfTest(get: () => core.HDWallet): void {
     await expect(wallet.ethSupportsNetwork(1)).resolves.toEqual(true);
   });
 
-  it("supports ShapeShift", async () => {
-    if (!wallet) return;
-    expect(wallet.ethSupportsNativeShapeShift()).toEqual(true);
-  });
-
   it("supports Secure Transfer", async () => {
     if (!wallet) return;
     await expect(wallet.ethSupportsSecureTransfer()).resolves.toEqual(true);

--- a/integration/src/wallets/ledger.ts
+++ b/integration/src/wallets/ledger.ts
@@ -234,12 +234,6 @@ export function selfTest(get: () => core.HDWallet): void {
     expect(await wallet.ethSupportsNetwork(1)).toEqual(true);
   });
 
-  it("does not support Native ShapeShift", async () => {
-    if (!wallet) return;
-    expect(wallet.ethSupportsNativeShapeShift()).toEqual(false);
-    expect(wallet.btcSupportsNativeShapeShift()).toEqual(false);
-  });
-
   it("does not support Secure Transfer", async () => {
     if (!wallet) return;
     expect(await wallet.ethSupportsSecureTransfer()).toEqual(false);

--- a/integration/src/wallets/metamask.ts
+++ b/integration/src/wallets/metamask.ts
@@ -38,11 +38,6 @@ export function selfTest(get: () => core.HDWallet): void {
     expect(core.supportsBTC(wallet)).toBe(false);
   });
 
-  it("does not support Native ShapeShift", async () => {
-    if (!wallet) return;
-    expect(wallet.ethSupportsNativeShapeShift()).toEqual(false);
-  });
-
   it("does not support EIP1559", async () => {
     if (!wallet) return;
     expect(await wallet.ethSupportsEIP1559()).toEqual(false);

--- a/integration/src/wallets/native.ts
+++ b/integration/src/wallets/native.ts
@@ -191,12 +191,6 @@ export function selfTest(get: () => core.HDWallet): void {
     expect(await wallet.ethSupportsNetwork()).toEqual(true);
   });
 
-  it("does not support Native ShapeShift", async () => {
-    if (!wallet) return;
-    expect(wallet.ethSupportsNativeShapeShift()).toEqual(false);
-    expect(wallet.btcSupportsNativeShapeShift()).toEqual(false);
-  });
-
   it("does not support Secure Transfer", async () => {
     if (!wallet) return;
     expect(await wallet.ethSupportsSecureTransfer()).toEqual(false);

--- a/integration/src/wallets/trezor.ts
+++ b/integration/src/wallets/trezor.ts
@@ -376,12 +376,6 @@ export function selfTest(get: () => core.HDWallet): void {
     expect(await wallet.ethSupportsNetwork(1)).toEqual(true);
   });
 
-  it("does not support Native ShapeShift", async () => {
-    if (!wallet) return;
-    expect(wallet.ethSupportsNativeShapeShift()).toEqual(false);
-    expect(wallet.btcSupportsNativeShapeShift()).toEqual(false);
-  });
-
   it("does not support Secure Transfer", async () => {
     if (!wallet) return;
     expect(await wallet.ethSupportsSecureTransfer()).toEqual(false);

--- a/packages/hdwallet-core/src/bitcoin.ts
+++ b/packages/hdwallet-core/src/bitcoin.ts
@@ -1,7 +1,7 @@
 import * as ta from "type-assertions";
 
 import { addressNListToBIP32, slip44ByCoin } from "./utils";
-import { BIP32Path, Coin, ExchangeType, HDWallet, HDWalletInfo, PathDescription } from "./wallet";
+import { BIP32Path, Coin, HDWallet, HDWalletInfo, PathDescription } from "./wallet";
 
 // GuardedUnion<T> will ensure a static typechecking error if any properties are set that aren't supposed
 // to be present on the specific union member being passed in. (This also helps the compiler with type inference.)
@@ -201,15 +201,6 @@ export type BTCSignTxOutputChange = {
   isChange: true;
 };
 
-export type BTCSignTxOutputExchange = {
-  /**
-   * Device must `btcSupportsNativeShapeShift()`
-   */
-  addressType: BTCOutputAddressType.Exchange;
-  amount: string;
-  exchangeType: ExchangeType;
-};
-
 export type BTCSignTxOutputMemo = {
   addressType?: BTCOutputAddressType.Spend;
   amount?: "0";
@@ -223,7 +214,6 @@ export type BTCSignTxOutput = GuardedUnion<
   | BTCSignTxOutputSpendP2WPKH
   | BTCSignTxOutputTransfer
   | BTCSignTxOutputChange
-  | BTCSignTxOutputExchange
   | BTCSignTxOutputMemo
 >;
 
@@ -272,7 +262,6 @@ export enum BTCOutputAddressType {
   Spend = "spend",
   Transfer = "transfer",
   Change = "change",
-  Exchange = "exchange",
 }
 
 export interface BTCSignMessage {
@@ -325,11 +314,6 @@ export interface BTCWalletInfo extends HDWalletInfo {
    * confirm the destination address?
    */
   btcSupportsSecureTransfer(): Promise<boolean>;
-
-  /**
-   * Does the device support `/sendamountProto2` style ShapeShift trades?
-   */
-  btcSupportsNativeShapeShift(): boolean;
 
   /**
    * Returns a list of bip32 paths for a given account index in preferred order

--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -1,5 +1,5 @@
 import { addressNListToBIP32, slip44ByCoin } from "./utils";
-import { ExchangeType, BIP32Path, HDWallet, HDWalletInfo, PathDescription } from "./wallet";
+import { BIP32Path, HDWallet, HDWalletInfo, PathDescription } from "./wallet";
 
 export enum ETHTransactionType {
   ETH_TX_TYPE_LEGACY = 0,
@@ -54,10 +54,6 @@ export interface ETHSignTx {
   data: string;
   /** mainnet: 1, ropsten: 3, kovan: 42 */
   chainId: number;
-  /**
-   * Device must `ethSupportsNativeShapeShift()`
-   */
-  exchangeType?: ExchangeType;
 }
 
 export interface ETHTxHash {
@@ -104,11 +100,6 @@ export interface ETHWalletInfo extends HDWalletInfo {
    * confirm the destination address?
    */
   ethSupportsSecureTransfer(): Promise<boolean>;
-
-  /**
-   * Does the device support `/sendamountProto2` style ShapeShift trades?
-   */
-  ethSupportsNativeShapeShift(): boolean;
 
   /**
    *

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -74,16 +74,6 @@ export interface LoadDevice {
   skipChecksum?: boolean;
 }
 
-export interface ExchangeType {
-  /** `SignedExchangeResponse` from the `/sendamountProto2` ShapeShift endpoint, base64 encoded */
-  signedExchangeResponse: string;
-  withdrawalCoinName: string;
-  withdrawalAddressNList: BIP32Path;
-  withdrawalScriptType?: BTCInputScriptType;
-  returnAddressNList: BIP32Path;
-  returnScriptType?: BTCInputScriptType;
-}
-
 export interface DescribePath {
   path: BIP32Path;
   coin: Coin;
@@ -245,12 +235,6 @@ export interface HDWalletInfo {
    * the device.
    */
   hasOnDeviceRecovery(): boolean;
-
-  /**
-   * Does the device support `/sendamountProto2` style native ShapeShift
-   * integration for the given pair?
-   */
-  hasNativeShapeShift(srcCoin: Coin, dstCoin: Coin): boolean;
 
   /**
    * Will the device allow for transactions to be signed offline to be

--- a/packages/hdwallet-keepkey/src/bitcoin.ts
+++ b/packages/hdwallet-keepkey/src/bitcoin.ts
@@ -1,4 +1,3 @@
-import * as Exchange from "@keepkey/device-protocol/lib/exchange_pb";
 import * as Messages from "@keepkey/device-protocol/lib/messages_pb";
 import * as Types from "@keepkey/device-protocol/lib/types_pb";
 import * as core from "@shapeshiftoss/hdwallet-core";
@@ -71,36 +70,7 @@ function prepareSignTx(
     const output: core.BTCSignTxOutput = o;
     const newOutput = new Types.TxOutputType();
     newOutput.setAmount(Number(output.amount));
-    if (output.exchangeType) {
-      // BTCSignTxOutputExchange
-      // convert the base64 encoded signedExchangeResponse message into the correct object
-      const signedHex = core.base64toHEX(output.exchangeType.signedExchangeResponse);
-      const signedExchange = Exchange.SignedExchangeResponse.deserializeBinary(core.arrayify(signedHex));
-
-      // decode the deposit amount from a little-endian Uint8Array into an unsigned uint64
-      let depAmt = core.mustBeDefined(signedExchange.getResponsev2()).getDepositAmount_asU8();
-      let val = 0;
-      for (let jj = depAmt.length - 1; jj >= 0; jj--) {
-        val += depAmt[jj] * Math.pow(2, 8 * (depAmt.length - jj - 1));
-        // TODO validate is uint64
-      }
-      const outExchangeType = new Types.ExchangeType();
-      outExchangeType.setSignedExchangeResponse(signedExchange);
-      outExchangeType.setWithdrawalCoinName(output.exchangeType.withdrawalCoinName);
-      outExchangeType.setWithdrawalAddressNList(output.exchangeType.withdrawalAddressNList);
-      outExchangeType.setWithdrawalScriptType(
-        translateInputScriptType(output.exchangeType.withdrawalScriptType || core.BTCInputScriptType.SpendAddress)
-      );
-      outExchangeType.setReturnAddressNList(output.exchangeType.returnAddressNList);
-      outExchangeType.setReturnScriptType(
-        translateInputScriptType(output.exchangeType.returnScriptType || core.BTCInputScriptType.SpendAddress)
-      );
-      newOutput.setAmount(val);
-      newOutput.setAddress(core.mustBeDefined(signedExchange.toObject().responsev2?.depositAddress?.address));
-      newOutput.setScriptType(Types.OutputScriptType.PAYTOADDRESS);
-      newOutput.setAddressType(Types.OutputAddressType.EXCHANGE);
-      newOutput.setExchangeType(outExchangeType);
-    } else if (output.isChange || output.addressType === core.BTCOutputAddressType.Transfer) {
+    if (output.isChange || output.addressType === core.BTCOutputAddressType.Transfer) {
       // BTCSignTxOutputTranfer ||  BTCSignTxOutputChange
       newOutput.setScriptType(translateOutputScriptType(output.scriptType));
       newOutput.setAddressNList(output.addressNList);
@@ -500,10 +470,6 @@ export async function btcSignTx(
 }
 
 export async function btcSupportsSecureTransfer(): Promise<boolean> {
-  return true;
-}
-
-export function btcSupportsNativeShapeShift(): boolean {
   return true;
 }
 

--- a/packages/hdwallet-keepkey/src/ethereum.ts
+++ b/packages/hdwallet-keepkey/src/ethereum.ts
@@ -1,4 +1,3 @@
-import * as Exchange from "@keepkey/device-protocol/lib/exchange_pb";
 import * as Messages from "@keepkey/device-protocol/lib/messages_pb";
 import * as Types from "@keepkey/device-protocol/lib/types_pb";
 import * as core from "@shapeshiftoss/hdwallet-core";
@@ -6,7 +5,7 @@ import Common from "@ethereumjs/common";
 import { FeeMarketEIP1559Transaction, Transaction } from "@ethereumjs/tx";
 import * as eip55 from "eip55";
 
-import { toUTF8Array, translateInputScriptType } from "./utils";
+import { toUTF8Array } from "./utils";
 import { Transport } from "./transport";
 
 export async function ethSupportsNetwork(chain_id: number): Promise<boolean> {
@@ -14,10 +13,6 @@ export async function ethSupportsNetwork(chain_id: number): Promise<boolean> {
 }
 
 export async function ethSupportsSecureTransfer(): Promise<boolean> {
-  return true;
-}
-
-export function ethSupportsNativeShapeShift(): boolean {
   return true;
 }
 
@@ -63,23 +58,6 @@ export async function ethSignTx(transport: Transport, msg: core.ETHSignTx): Prom
     if (msg.toAddressNList) {
       est.setAddressType(Types.OutputAddressType.SPEND);
       est.setToAddressNList(msg.toAddressNList);
-    } else if (msg.exchangeType) {
-      est.setAddressType(Types.OutputAddressType.EXCHANGE);
-
-      const signedHex = core.base64toHEX(msg.exchangeType.signedExchangeResponse);
-      const signedExchangeOut = Exchange.SignedExchangeResponse.deserializeBinary(core.arrayify(signedHex));
-      const exchangeType = new Types.ExchangeType();
-      exchangeType.setSignedExchangeResponse(signedExchangeOut);
-      exchangeType.setWithdrawalCoinName(msg.exchangeType.withdrawalCoinName); // KeepKey firmware will complain if this doesn't match signed exchange response
-      exchangeType.setWithdrawalAddressNList(msg.exchangeType.withdrawalAddressNList);
-      exchangeType.setWithdrawalScriptType(
-        translateInputScriptType(msg.exchangeType.withdrawalScriptType || core.BTCInputScriptType.SpendAddress)
-      );
-      exchangeType.setReturnAddressNList(msg.exchangeType.returnAddressNList);
-      exchangeType.setReturnScriptType(
-        translateInputScriptType(msg.exchangeType.returnScriptType || core.BTCInputScriptType.SpendAddress)
-      );
-      est.setExchangeType(exchangeType);
     } else {
       est.setAddressType(Types.OutputAddressType.SPEND);
     }

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -396,10 +396,6 @@ export class KeepKeyHDWalletInfo
     return Btc.btcSupportsSecureTransfer();
   }
 
-  public btcSupportsNativeShapeShift(): boolean {
-    return Btc.btcSupportsNativeShapeShift();
-  }
-
   public btcGetAccountPaths(msg: core.BTCGetAccountPaths): Array<core.BTCAccountPath> {
     return Btc.btcGetAccountPaths(msg);
   }
@@ -414,10 +410,6 @@ export class KeepKeyHDWalletInfo
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return Eth.ethSupportsSecureTransfer();
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
-    return Eth.ethSupportsNativeShapeShift();
   }
 
   public async ethSupportsEIP1559(): Promise<boolean> {
@@ -462,10 +454,6 @@ export class KeepKeyHDWalletInfo
 
   public hasOnDeviceRecovery(): boolean {
     return false;
-  }
-
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    return true;
   }
 
   public supportsOfflineSigning(): boolean {
@@ -804,10 +792,6 @@ export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHW
 
   public hasOnDeviceRecovery(): boolean {
     return false;
-  }
-
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    return true;
   }
 
   public supportsOfflineSigning(): boolean {
@@ -1149,10 +1133,6 @@ export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHW
     return this.info.btcSupportsSecureTransfer();
   }
 
-  public btcSupportsNativeShapeShift(): boolean {
-    return this.info.btcSupportsNativeShapeShift();
-  }
-
   public async ethSupportsEIP1559(): Promise<boolean> {
     // EIP1559 support starts in v7.2.1
     return semver.gte(await this.getFirmwareVersion(), "v7.2.1");
@@ -1201,10 +1181,6 @@ export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHW
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return this.info.ethSupportsSecureTransfer();
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
-    return this.info.ethSupportsNativeShapeShift();
   }
 
   public ethGetAccountPaths(msg: core.ETHGetAccountPath): Array<core.ETHAccountPath> {

--- a/packages/hdwallet-ledger/src/bitcoin.ts
+++ b/packages/hdwallet-ledger/src/bitcoin.ts
@@ -142,7 +142,6 @@ export async function btcSignTx(
   transport: LedgerTransport,
   msg: core.BTCSignTxLedger
 ): Promise<core.BTCSignedTx> {
-  let supportsShapeShift = wallet.btcSupportsNativeShapeShift();
   let supportsSecureTransfer = await wallet.btcSupportsSecureTransfer();
   let slip44 = core.mustBeDefined(core.slip44ByCoin(msg.coin));
   let txBuilder = new bitcoin.TransactionBuilder(networksUtil[slip44].bitcoinjs as any);
@@ -153,8 +152,6 @@ export async function btcSignTx(
 
   //bitcoinjs-lib
   msg.outputs.map((output) => {
-    if (output.exchangeType && !supportsShapeShift) throw new Error("Ledger does not support Native ShapeShift");
-
     if (output.addressNList !== undefined) {
       if (output.addressType === core.BTCOutputAddressType.Transfer && !supportsSecureTransfer)
         throw new Error("Ledger does not support SecureTransfer");
@@ -238,10 +235,6 @@ export async function btcSignTx(
 }
 
 export async function btcSupportsSecureTransfer(): Promise<boolean> {
-  return false;
-}
-
-export function btcSupportsNativeShapeShift(): boolean {
   return false;
 }
 

--- a/packages/hdwallet-ledger/src/ethereum.ts
+++ b/packages/hdwallet-ledger/src/ethereum.ts
@@ -113,10 +113,6 @@ export async function ethSupportsSecureTransfer(): Promise<boolean> {
   return false;
 }
 
-export function ethSupportsNativeShapeShift(): boolean {
-  return false;
-}
-
 export function ethSupportsEIP1559(): boolean {
   return false;
 }

--- a/packages/hdwallet-ledger/src/ledger.ts
+++ b/packages/hdwallet-ledger/src/ledger.ts
@@ -154,10 +154,6 @@ export class LedgerHDWalletInfo implements core.HDWalletInfo, core.BTCWalletInfo
     return btc.btcSupportsSecureTransfer();
   }
 
-  public btcSupportsNativeShapeShift(): boolean {
-    return btc.btcSupportsNativeShapeShift();
-  }
-
   public btcGetAccountPaths(msg: core.BTCGetAccountPaths): Array<core.BTCAccountPath> {
     return btc.btcGetAccountPaths(msg);
   }
@@ -174,20 +170,12 @@ export class LedgerHDWalletInfo implements core.HDWalletInfo, core.BTCWalletInfo
     return eth.ethSupportsSecureTransfer();
   }
 
-  public ethSupportsNativeShapeShift(): boolean {
-    return eth.ethSupportsNativeShapeShift();
-  }
-
   public async ethSupportsEIP1559(): Promise<boolean> {
     return eth.ethSupportsEIP1559();
   }
 
   public ethGetAccountPaths(msg: core.ETHGetAccountPath): Array<core.ETHAccountPath> {
     return eth.ethGetAccountPaths(msg);
-  }
-
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    return false;
   }
 
   public supportsOfflineSigning(): boolean {
@@ -404,10 +392,6 @@ export class LedgerHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
     }
   }
 
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    return false;
-  }
-
   public supportsOfflineSigning(): boolean {
     return true;
   }
@@ -495,10 +479,6 @@ export class LedgerHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
     return this.info.btcSupportsSecureTransfer();
   }
 
-  public btcSupportsNativeShapeShift(): boolean {
-    return this.info.btcSupportsNativeShapeShift();
-  }
-
   public async btcSignMessage(msg: core.BTCSignMessage): Promise<core.BTCSignedMessage> {
     await this.validateCurrentApp(msg.coin);
     return btc.btcSignMessage(this, this.transport, msg);
@@ -541,10 +521,6 @@ export class LedgerHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return this.info.ethSupportsSecureTransfer();
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
-    return this.info.ethSupportsNativeShapeShift();
   }
 
   public async ethSupportsEIP1559(): Promise<boolean> {

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -103,10 +103,6 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
     return this.info.hasOnDeviceRecovery();
   }
 
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    return this.info.hasNativeShapeShift(srcCoin, dstCoin);
-  }
-
   public supportsOfflineSigning(): boolean {
     return false;
   }
@@ -189,10 +185,6 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
-    return false;
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
     return false;
   }
 
@@ -283,11 +275,6 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
     return true;
   }
 
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    // It doesn't... yet?
-    return false;
-  }
-
   public supportsOfflineSigning(): boolean {
     return false;
   }
@@ -315,10 +302,6 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
-    return false;
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
     return false;
   }
 

--- a/packages/hdwallet-native/src/binance.test.ts
+++ b/packages/hdwallet-native/src/binance.test.ts
@@ -84,7 +84,6 @@ describe("NativeBinanceWalletInfo", () => {
   it("should return some static metadata", async () => {
     expect(await untouchable.call(info, "binanceSupportsNetwork")).toBe(true);
     expect(await untouchable.call(info, "binanceSupportsSecureTransfer")).toBe(false);
-    expect(untouchable.call(info, "binanceSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return the correct account paths", async () => {

--- a/packages/hdwallet-native/src/binance.ts
+++ b/packages/hdwallet-native/src/binance.ts
@@ -20,10 +20,6 @@ export function MixinNativeBinanceWalletInfo<TBase extends core.Constructor<core
       return false;
     }
 
-    binanceSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     binanceGetAccountPaths(msg: core.BinanceGetAccountPaths): Array<core.BinanceAccountPath> {
       const slip44 = core.slip44ByCoin("Binance");
       return [

--- a/packages/hdwallet-native/src/bitcoin.test.ts
+++ b/packages/hdwallet-native/src/bitcoin.test.ts
@@ -139,7 +139,6 @@ describe("NativeBTCWalletInfo", () => {
   it("should return some static metadata", async () => {
     expect((info as any)["btcSupportsNetwork"]).not.toBeDefined();
     expect(await untouchable.call(info, "btcSupportsSecureTransfer")).toBe(false);
-    expect(untouchable.call(info, "btcSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return some dynamic metadata", async () => {

--- a/packages/hdwallet-native/src/bitcoin.ts
+++ b/packages/hdwallet-native/src/bitcoin.ts
@@ -68,10 +68,6 @@ export function MixinNativeBTCWalletInfo<TBase extends core.Constructor<core.HDW
       return false;
     }
 
-    btcSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     btcGetAccountPaths(msg: core.BTCGetAccountPaths): Array<core.BTCAccountPath> {
       const slip44 = core.slip44ByCoin(msg.coin);
       if (slip44 === undefined) return [];

--- a/packages/hdwallet-native/src/cosmos.test.ts
+++ b/packages/hdwallet-native/src/cosmos.test.ts
@@ -15,7 +15,6 @@ describe("NativeCosmosWalletInfo", () => {
   it("should return some static metadata", async () => {
     expect(await untouchable.call(info, "cosmosSupportsNetwork")).toBe(true);
     expect(await untouchable.call(info, "cosmosSupportsSecureTransfer")).toBe(false);
-    expect(untouchable.call(info, "cosmosSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return the correct account paths", async () => {

--- a/packages/hdwallet-native/src/cosmos.ts
+++ b/packages/hdwallet-native/src/cosmos.ts
@@ -20,10 +20,6 @@ export function MixinNativeCosmosWalletInfo<TBase extends core.Constructor<core.
       return false;
     }
 
-    cosmosSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     cosmosGetAccountPaths(msg: core.CosmosGetAccountPaths): Array<core.CosmosAccountPath> {
       const slip44 = core.slip44ByCoin("Atom")
       return [

--- a/packages/hdwallet-native/src/ethereum.test.ts
+++ b/packages/hdwallet-native/src/ethereum.test.ts
@@ -17,7 +17,6 @@ describe("NativeETHWalletInfo", () => {
   it("should return some static metadata", async () => {
     expect(await untouchable.call(info, "ethSupportsNetwork")).toBe(true);
     expect(await untouchable.call(info, "ethSupportsSecureTransfer")).toBe(false);
-    expect(untouchable.call(info, "ethSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return the correct account paths", async () => {

--- a/packages/hdwallet-native/src/ethereum.ts
+++ b/packages/hdwallet-native/src/ethereum.ts
@@ -17,10 +17,6 @@ export function MixinNativeETHWalletInfo<TBase extends core.Constructor<core.HDW
       return false;
     }
 
-    ethSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     async ethSupportsEIP1559(): Promise<boolean> {
       return true;
     }

--- a/packages/hdwallet-native/src/fio.test.ts
+++ b/packages/hdwallet-native/src/fio.test.ts
@@ -123,7 +123,6 @@ describe("NativeFioWalletInfo", () => {
   it("should return some static metadata", async () => {
     expect(await untouchable.call(info, "fioSupportsNetwork")).toBe(true);
     expect(await untouchable.call(info, "fioSupportsSecureTransfer")).toBe(false);
-    expect(untouchable.call(info, "fioSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return the correct account paths", async () => {

--- a/packages/hdwallet-native/src/fio.ts
+++ b/packages/hdwallet-native/src/fio.ts
@@ -27,10 +27,6 @@ export function MixinNativeFioWalletInfo<TBase extends core.Constructor<core.HDW
       return false;
     }
 
-    fioSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     fioGetAccountPaths(msg: core.FioGetAccountPaths): Array<core.FioAccountPath> {
       return [
         {

--- a/packages/hdwallet-native/src/kava.test.ts
+++ b/packages/hdwallet-native/src/kava.test.ts
@@ -15,7 +15,6 @@ describe("NativeKavaWalletInfo", () => {
   it("should return some static metadata", async () => {
     await expect(untouchable.call(info, "kavaSupportsNetwork")).resolves.toBe(true);
     await expect(untouchable.call(info, "kavaSupportsSecureTransfer")).resolves.toBe(false);
-    expect(untouchable.call(info, "kavaSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return the correct account paths", async () => {

--- a/packages/hdwallet-native/src/kava.ts
+++ b/packages/hdwallet-native/src/kava.ts
@@ -19,10 +19,6 @@ export function MixinNativeKavaWalletInfo<TBase extends core.Constructor<core.HD
       return false;
     }
 
-    kavaSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     kavaGetAccountPaths(msg: core.KavaGetAccountPaths): Array<core.KavaAccountPath> {
       const slip44 = core.slip44ByCoin("Kava")
       return [

--- a/packages/hdwallet-native/src/native.test.ts
+++ b/packages/hdwallet-native/src/native.test.ts
@@ -21,7 +21,6 @@ describe("NativeHDWalletInfo", () => {
   });
   it("should produce correct path descriptions", () => {
     const info = native.info();
-    expect(info.hasNativeShapeShift()).toBe(false);
     [
       {
         msg: { coin: "bitcoin", path: [1, 2, 3] },

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -59,10 +59,6 @@ export class NativeHDWalletInfoBase implements core.HDWalletInfo {
     return false;
   }
 
-  hasNativeShapeShift(): boolean {
-    return false;
-  }
-
   public supportsOfflineSigning(): boolean {
     return true;
   }

--- a/packages/hdwallet-native/src/osmosis.test.ts
+++ b/packages/hdwallet-native/src/osmosis.test.ts
@@ -15,7 +15,6 @@ describe("NativeOsmosisWalletInfo", () => {
   it("should return some static metadata", async () => {
     expect(await untouchable.call(info, "osmosisSupportsNetwork")).toBe(true);
     expect(await untouchable.call(info, "osmosisSupportsSecureTransfer")).toBe(false);
-    expect(untouchable.call(info, "osmosisSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return the correct account paths", async () => {

--- a/packages/hdwallet-native/src/osmosis.ts
+++ b/packages/hdwallet-native/src/osmosis.ts
@@ -20,10 +20,6 @@ export function MixinNativeOsmosisWalletInfo<TBase extends core.Constructor<core
       return false;
     }
 
-    osmosisSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     osmosisGetAccountPaths(msg: core.OsmosisGetAccountPaths): Array<core.OsmosisAccountPath> {
       const slip44 = core.slip44ByCoin("Osmo")
       return [

--- a/packages/hdwallet-native/src/secret.test.ts
+++ b/packages/hdwallet-native/src/secret.test.ts
@@ -15,7 +15,6 @@ describe("NativeSecretWalletInfo", () => {
   it("should return some static metadata", async () => {
     await expect(untouchable.call(info, "secretSupportsNetwork")).resolves.toBe(true);
     await expect(untouchable.call(info, "secretSupportsSecureTransfer")).resolves.toBe(false);
-    expect(untouchable.call(info, "secretSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return the correct account paths", async () => {

--- a/packages/hdwallet-native/src/secret.ts
+++ b/packages/hdwallet-native/src/secret.ts
@@ -18,10 +18,6 @@ export function MixinNativeSecretWalletInfo<TBase extends core.Constructor<core.
       return false;
     }
 
-    secretSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     secretGetAccountPaths(msg: core.SecretGetAccountPaths): Array<core.SecretAccountPath> {
       const slip44 = core.slip44ByCoin("Secret")
       return [

--- a/packages/hdwallet-native/src/terra.test.ts
+++ b/packages/hdwallet-native/src/terra.test.ts
@@ -15,7 +15,6 @@ describe("NativeTerraWalletInfo", () => {
   it("should return some static metadata", async () => {
     await expect(untouchable.call(info, "terraSupportsNetwork")).resolves.toBe(true);
     await expect(untouchable.call(info, "terraSupportsSecureTransfer")).resolves.toBe(false);
-    expect(untouchable.call(info, "terraSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return the correct account paths", async () => {

--- a/packages/hdwallet-native/src/terra.ts
+++ b/packages/hdwallet-native/src/terra.ts
@@ -19,10 +19,6 @@ export function MixinNativeTerraWalletInfo<TBase extends core.Constructor<core.H
       return false;
     }
 
-    terraSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     terraGetAccountPaths(msg: core.TerraGetAccountPaths): Array<core.TerraAccountPath> {
       const slip44 = core.slip44ByCoin("Terra")
       return [

--- a/packages/hdwallet-native/src/thorchain.test.ts
+++ b/packages/hdwallet-native/src/thorchain.test.ts
@@ -15,7 +15,6 @@ describe("NativeThorchainWalletInfo", () => {
   it("should return some static metadata", async () => {
     await expect(untouchable.call(info, "thorchainSupportsNetwork")).resolves.toBe(true);
     await expect(untouchable.call(info, "thorchainSupportsSecureTransfer")).resolves.toBe(false);
-    expect(untouchable.call(info, "thorchainSupportsNativeShapeShift")).toBe(false);
   });
 
   it("should return the correct account paths", async () => {

--- a/packages/hdwallet-native/src/thorchain.ts
+++ b/packages/hdwallet-native/src/thorchain.ts
@@ -20,10 +20,6 @@ export function MixinNativeThorchainWalletInfo<TBase extends core.Constructor<co
       return false;
     }
 
-    thorchainSupportsNativeShapeShift(): boolean {
-      return false;
-    }
-
     thorchainGetAccountPaths(msg: core.ThorchainGetAccountPaths): Array<core.ThorchainAccountPath> {
       const slip44 = core.slip44ByCoin("Thorchain")
       return [

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -92,10 +92,6 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
     return this.info.hasOnDeviceRecovery();
   }
 
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    return this.info.hasNativeShapeShift(srcCoin, dstCoin);
-  }
-
   public supportsOfflineSigning(): boolean {
     return true;
   }
@@ -221,10 +217,6 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
     return this.info.btcSupportsSecureTransfer();
   }
 
-  public btcSupportsNativeShapeShift(): boolean {
-    return this.info.btcSupportsNativeShapeShift();
-  }
-
   public btcGetAccountPaths(msg: core.BTCGetAccountPaths): Array<core.BTCAccountPath> {
     return this.info.btcGetAccountPaths(msg);
   }
@@ -243,10 +235,6 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return this.info.ethSupportsSecureTransfer();
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
-    return this.info.ethSupportsNativeShapeShift();
   }
 
   public async ethSupportsEIP1559(): Promise<boolean> {
@@ -322,11 +310,6 @@ export class PortisHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo
     return true;
   }
 
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    // It doesn't... yet?
-    return false;
-  }
-
   public supportsOfflineSigning(): boolean {
     return true;
   }
@@ -358,10 +341,6 @@ export class PortisHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo
     return Promise.resolve(false);
   }
 
-  public btcSupportsNativeShapeShift(): boolean {
-    return false;
-  }
-
   public btcGetAccountPaths(msg: core.BTCGetAccountPaths): Array<core.BTCAccountPath> {
     return btc.btcGetAccountPaths(msg);
   }
@@ -384,10 +363,6 @@ export class PortisHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
-    return false;
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
     return false;
   }
 

--- a/packages/hdwallet-trezor/src/bitcoin.ts
+++ b/packages/hdwallet-trezor/src/bitcoin.ts
@@ -82,7 +82,6 @@ export async function btcGetAddress(transport: TrezorTransport, msg: core.BTCGet
 }
 
 export async function btcSignTx(wallet: core.BTCWallet, transport: TrezorTransport, msg: core.BTCSignTxTrezor): Promise<core.BTCSignedTx> {
-  let supportsShapeShift = wallet.btcSupportsNativeShapeShift();
   let supportsSecureTransfer = await wallet.btcSupportsSecureTransfer();
 
   let inputs = msg.inputs.map((input) => {
@@ -96,8 +95,6 @@ export async function btcSignTx(wallet: core.BTCWallet, transport: TrezorTranspo
   });
 
   let outputs: BTCTrezorSignTxOutput[] = msg.outputs.map((output) => {
-    if (output.exchangeType && !supportsShapeShift) throw new Error("Trezor does not support Native ShapeShift");
-
     if (output.addressNList) {
       if (output.addressType === core.BTCOutputAddressType.Transfer && !supportsSecureTransfer)
         throw new Error("Trezor does not support SecureTransfer");
@@ -149,10 +146,6 @@ export async function btcSignTx(wallet: core.BTCWallet, transport: TrezorTranspo
 }
 
 export async function btcSupportsSecureTransfer(): Promise<boolean> {
-  return false;
-}
-
-export function btcSupportsNativeShapeShift(): boolean {
   return false;
 }
 

--- a/packages/hdwallet-trezor/src/ethereum.ts
+++ b/packages/hdwallet-trezor/src/ethereum.ts
@@ -30,9 +30,6 @@ export async function ethSignTx(
   if (msg.toAddressNList !== undefined && !(await ethSupportsSecureTransfer()))
     throw new Error("Trezor does not support SecureTransfer");
 
-  if (msg.exchangeType !== undefined && !ethSupportsNativeShapeShift())
-    throw new Error("Trezor does not support Native ShapeShift");
-
   const utx = {
     to: msg.to,
     value: msg.value,
@@ -87,10 +84,6 @@ export async function ethVerifyMessage(transport: TrezorTransport, msg: core.ETH
 }
 
 export async function ethSupportsSecureTransfer(): Promise<boolean> {
-  return false;
-}
-
-export function ethSupportsNativeShapeShift(): boolean {
   return false;
 }
 

--- a/packages/hdwallet-trezor/src/trezor.ts
+++ b/packages/hdwallet-trezor/src/trezor.ts
@@ -142,10 +142,6 @@ export class TrezorHDWalletInfo implements core.HDWalletInfo, core.BTCWalletInfo
     return Btc.btcSupportsSecureTransfer();
   }
 
-  public btcSupportsNativeShapeShift(): boolean {
-    return Btc.btcSupportsNativeShapeShift();
-  }
-
   public btcGetAccountPaths(msg: core.BTCGetAccountPaths): Array<core.BTCAccountPath> {
     return Btc.btcGetAccountPaths(msg);
   }
@@ -160,10 +156,6 @@ export class TrezorHDWalletInfo implements core.HDWalletInfo, core.BTCWalletInfo
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return Eth.ethSupportsSecureTransfer();
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
-    return Eth.ethSupportsNativeShapeShift();
   }
 
   public async ethSupportsEIP1559(): Promise<boolean> {
@@ -189,11 +181,6 @@ export class TrezorHDWalletInfo implements core.HDWalletInfo, core.BTCWalletInfo
   public hasOnDeviceRecovery(): boolean {
     // Not really meaningful since TrezorConnect doesn't expose recovery yet
     return true;
-  }
-
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    // It doesn't... yet?
-    return false;
   }
 
   public supportsOfflineSigning(): boolean {
@@ -454,11 +441,6 @@ export class TrezorHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
     return this.transport.hasPopup;
   }
 
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    // It doesn't... yet?
-    return false;
-  }
-
   public supportsOfflineSigning(): boolean {
     return true;
   }
@@ -485,10 +467,6 @@ export class TrezorHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
 
   public async btcSupportsSecureTransfer(): Promise<boolean> {
     return this.info.btcSupportsSecureTransfer();
-  }
-
-  public btcSupportsNativeShapeShift(): boolean {
-    return this.info.btcSupportsNativeShapeShift();
   }
 
   public async btcSignMessage(msg: core.BTCSignMessage): Promise<core.BTCSignedMessage> {
@@ -529,10 +507,6 @@ export class TrezorHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return this.info.ethSupportsSecureTransfer();
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
-    return this.info.ethSupportsNativeShapeShift();
   }
 
   public async ethSupportsEIP1559(): Promise<boolean> {

--- a/packages/hdwallet-xdefi/src/xdefi.test.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.test.ts
@@ -13,14 +13,12 @@ describe("XDeFIHDWalletInfo", () => {
     expect(info.hasOnDeviceRecovery()).toBe(false);
     expect(await info.ethSupportsNetwork(1)).toBe(true);
     expect(await info.ethSupportsSecureTransfer()).toBe(false);
-    expect(info.ethSupportsNativeShapeShift()).toBe(false);
     expect(await info.ethSupportsEIP1559()).toBe(true);
     expect(await info.supportsOfflineSigning()).toBe(false);
     expect(await info.supportsBroadcast()).toBe(true);
   });
   it("should produce correct path descriptions", () => {
     const info = xdefi.info();
-    expect(info.hasNativeShapeShift()).toBe(false);
     [
       {
         msg: { coin: "Ethereum", path: [44 + 0x80000000, 60 + 0x80000000, 0 + 0x80000000, 0, 0] },
@@ -46,7 +44,6 @@ describe("XDeFiWHDWallet", () => {
     expect(wallet.hasOnDeviceRecovery()).toBe(false);
     expect(await wallet.ethSupportsNetwork(1)).toBe(true);
     expect(await wallet.ethSupportsSecureTransfer()).toBe(false);
-    expect(wallet.ethSupportsNativeShapeShift()).toBe(false);
     expect(await wallet.ethSupportsEIP1559()).toBe(true);
     expect(await wallet.supportsOfflineSigning()).toBe(false);
     expect(await wallet.supportsBroadcast()).toBe(true);

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -71,10 +71,6 @@ export class XDeFiHDWallet implements core.HDWallet, core.ETHWallet {
     return this.info.hasOnDeviceRecovery();
   }
 
-  public hasNativeShapeShift(srcCoin: core.Coin, dstCoin: core.Coin): boolean {
-    return this.info.hasNativeShapeShift(srcCoin, dstCoin);
-  }
-
   public supportsOfflineSigning(): boolean {
     return false;
   }
@@ -144,10 +140,6 @@ export class XDeFiHDWallet implements core.HDWallet, core.ETHWallet {
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
-    return false;
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
     return false;
   }
 
@@ -228,10 +220,6 @@ export class XDeFiHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
     return false;
   }
 
-  public hasNativeShapeShift(): boolean {
-    return false;
-  }
-
   public supportsOfflineSigning(): boolean {
     return false;
   }
@@ -259,10 +247,6 @@ export class XDeFiHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
-    return false;
-  }
-
-  public ethSupportsNativeShapeShift(): boolean {
     return false;
   }
 


### PR DESCRIPTION
removes `(supports|has)NativeShapeShift` from everything, as well as `BTCSignTxOutputExchange`, `BTCOutputAddressType.Exchange`, `ExchangeType`, and the KK code for encoding and processing such outputs.

Context for posterity: the legacy ShapeShift US "market exchange" (MX) is dead. These features were designed to allow wallets to interact with it, and required a signature from the MX's keys to be processed. That means that literally no new outputs of these types will ever be created and this code is useless to everyone forever.