### PR TITLE
remove unnecessary transports from portis & xdefi

### DIFF
--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -3,17 +3,6 @@ import _ from "lodash";
 
 import * as eth from "./ethereum";
 
-class MetaMaskTransport extends core.Transport {
-  public async getDeviceID() {
-    return "metamask:0";
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public call(...args: any[]): Promise<any> {
-    return Promise.resolve();
-  }
-}
-
 export function isMetaMask(wallet: core.HDWallet): wallet is MetaMaskHDWallet {
   return _.isObject(wallet) && (wallet as any)._isMetaMask;
 }
@@ -129,7 +118,6 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
   readonly _supportsTerra = false;
   readonly _supportsTerraInfo = false;
 
-  transport: core.Transport = new MetaMaskTransport(new core.Keyring());
   info: MetaMaskHDWalletInfo & core.HDWalletInfo;
   ethAddress?: string | null;
   provider: any;

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -6,18 +6,6 @@ import type Web3 from "web3";
 import * as btc from "./bitcoin";
 import * as eth from "./ethereum";
 
-// We might not need this. Leaving it for now to debug further
-class PortisTransport extends core.Transport {
-  public async getDeviceID() {
-    return "portis:0";
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public call(...args: any[]): Promise<any> {
-    return Promise.resolve();
-  }
-}
-
 export function isPortis(wallet: core.HDWallet): wallet is PortisHDWallet {
   return _.isObject(wallet) && (wallet as any)._isPortis;
 }
@@ -136,8 +124,6 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
   readonly _supportsBTCInfo = true;
   readonly _supportsBTC = true;
   readonly _isPortis = true;
-
-  transport: core.Transport = new PortisTransport(new core.Keyring());
 
   portis: Portis;
   web3: Promise<Web3>;

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -3,15 +3,6 @@ import isObject from "lodash/isObject";
 
 import * as eth from "./ethereum";
 
-class XDeFiTransport extends core.Transport {
-  public async getDeviceID() {
-    return "xdefi:0";
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-  public async call(...args: any[]): Promise<any> {}
-}
-
 export function isXDeFi(wallet: core.HDWallet): wallet is XDeFiHDWallet {
   return isObject(wallet) && (wallet as any)._isXDeFi;
 }
@@ -92,7 +83,6 @@ export class XDeFiHDWallet implements core.HDWallet, core.ETHWallet {
   readonly _supportsETHInfo = true;
   readonly _isXDeFi = true;
 
-  transport: core.Transport = new XDeFiTransport(new core.Keyring());
   info: XDeFiHDWalletInfo & core.HDWalletInfo;
   ethAddress?: string | null;
   provider: any;


### PR DESCRIPTION
Fixes #458. Neither axiom nor webv2 accesses a wallet's transports, so this should be safe.