### PR TITLE
metamask: use metamask-style account path derivation

### DIFF
--- a/integration/src/wallets/metamask.ts
+++ b/integration/src/wallets/metamask.ts
@@ -76,7 +76,7 @@ export function selfTest(get: () => core.HDWallet): void {
     expect(await wallet.ethSupportsSecureTransfer()).toEqual(false);
   });
 
-  it("uses correct eth bip44 paths", () => {
+  it("uses metamask-style account derivation paths", () => {
     if (!wallet) return;
     [0, 1, 3, 27].forEach((account) => {
       const paths = wallet.ethGetAccountPaths({
@@ -85,9 +85,9 @@ export function selfTest(get: () => core.HDWallet): void {
       });
       expect(paths).toEqual([
         {
-          addressNList: core.bip32ToAddressNList(`m/44'/60'/${account}'/0/0`),
-          hardenedPath: core.bip32ToAddressNList(`m/44'/60'/${account}'`),
-          relPath: [0, 0],
+          addressNList: core.bip32ToAddressNList(`m/44'/60'/0'/0/${account}`),
+          hardenedPath: core.bip32ToAddressNList(`m/44'/60'/0'`),
+          relPath: [0, account],
           description: "MetaMask",
         },
       ]);
@@ -120,7 +120,7 @@ export function selfTest(get: () => core.HDWallet): void {
 
     expect(
       wallet.describePath({
-        path: core.bip32ToAddressNList("m/44'/60'/3'/0/0"),
+        path: core.bip32ToAddressNList("m/44'/60'/0'/0/3"),
         coin: "Ethereum",
       })
     ).toEqual({
@@ -134,11 +134,11 @@ export function selfTest(get: () => core.HDWallet): void {
 
     expect(
       wallet.describePath({
-        path: core.bip32ToAddressNList("m/44'/60'/0'/0/3"),
+        path: core.bip32ToAddressNList("m/44'/60'/3'/0/0"),
         coin: "Ethereum",
       })
     ).toEqual({
-      verbose: "m/44'/60'/0'/0/3",
+      verbose: "m/44'/60'/3'/0/0",
       coin: "Ethereum",
       isKnown: false,
     });

--- a/packages/hdwallet-metamask/src/ethereum.ts
+++ b/packages/hdwallet-metamask/src/ethereum.ts
@@ -12,9 +12,9 @@ export function ethGetAccountPaths(msg: core.ETHGetAccountPath): Array<core.ETHA
   if (slip44 === undefined) return [];
   return [
     {
-      addressNList: [0x80000000 + 44, 0x80000000 + slip44, 0x80000000 + msg.accountIdx, 0, 0],
-      hardenedPath: [0x80000000 + 44, 0x80000000 + slip44, 0x80000000 + msg.accountIdx],
-      relPath: [0, 0],
+      addressNList: [0x80000000 + 44, 0x80000000 + slip44, 0x80000000, 0, msg.accountIdx],
+      hardenedPath: [0x80000000 + 44, 0x80000000 + slip44, 0x80000000],
+      relPath: [0, msg.accountIdx],
       description: "MetaMask",
     },
   ];

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -54,7 +54,7 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
   }
 
   public describePath(msg: core.DescribePath): core.PathDescription {
-    return core.describePath(msg);
+    return core.describePath(msg, core.ETHAddressDerivationScheme.Metamask);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Requires #420. Has no immediate practical impact since nothing that actually uses `hdwallet-metamask` supports multiple accounts yet.