### PR TITLE
remove some obsolete apis

### DIFF
--- a/integration/src/wallets/keepkey.ts
+++ b/integration/src/wallets/keepkey.ts
@@ -63,9 +63,7 @@ export async function createWallet(): Promise<core.HDWallet> {
   if (!wallet) throw new Error("No suitable test KeepKey found");
 
   wallet.transport?.on(core.Events.BUTTON_REQUEST, async () => {
-    if (autoButton && core.supportsDebugLink(wallet)) {
-      await wallet.pressYes();
-    }
+    if (autoButton) await wallet.pressYes();
   });
 
   wallet.transport?.onAny((event: string | string[], ...values: any[]) => {

--- a/integration/src/wallets/native.ts
+++ b/integration/src/wallets/native.ts
@@ -365,13 +365,13 @@ export function selfTest(get: () => core.HDWallet): void {
       wallet.describePath({
         path: core.bip32ToAddressNList("m/84'/0'/0'/0/0"),
         coin: "Bitcoin",
-        scriptType: core.BTCInputScriptType.Bech32,
+        scriptType: core.BTCInputScriptType.SpendWitness,
       })
     ).toEqual({
       verbose: "Bitcoin Account #0, Address #0 (Segwit Native)",
       coin: "Bitcoin",
       isKnown: true,
-      scriptType: core.BTCInputScriptType.Bech32,
+      scriptType: core.BTCInputScriptType.SpendWitness,
       accountIdx: 0,
       addressIdx: 0,
       wholeAccount: false,

--- a/packages/hdwallet-core/src/bitcoin.ts
+++ b/packages/hdwallet-core/src/bitcoin.ts
@@ -249,10 +249,8 @@ export interface BTCSignedTx {
   serializedTx: string;
 }
 
-// Bech32 info https://en.bitcoin.it/wiki/BIP_0173
 export enum BTCInputScriptType {
   CashAddr = "cashaddr", // for Bitcoin Cash
-  Bech32 = "bech32",
   SpendAddress = "p2pkh",
   SpendMultisig = "p2sh",
   External = "external",
@@ -263,7 +261,6 @@ export enum BTCInputScriptType {
 export enum BTCOutputScriptType {
   PayToAddress = "p2pkh",
   PayToMultisig = "p2sh",
-  Bech32 = "bech32",
   PayToWitness = "p2wpkh",
   PayToP2SHWitness = "p2sh-p2wpkh",
 }
@@ -396,14 +393,15 @@ export function describeUTXOPath(path: BIP32Path, coin: Coin, scriptType: BTCInp
 
   if (purpose === 49 && scriptType !== BTCInputScriptType.SpendP2SHWitness) return unknown;
 
+  if (purpose === 84 && scriptType !== BTCInputScriptType.SpendWitness) return unknown;
+
   let wholeAccount = path.length === 3;
 
   let script = (
     {
       [BTCInputScriptType.SpendAddress]: ["Legacy"],
       [BTCInputScriptType.SpendP2SHWitness]: [],
-      [BTCInputScriptType.SpendWitness]: ["Segwit"],
-      [BTCInputScriptType.Bech32]: ["Segwit Native"],
+      [BTCInputScriptType.SpendWitness]: ["Segwit Native"],
     } as Partial<Record<BTCInputScriptType, string[]>>
   )[scriptType];
 

--- a/packages/hdwallet-core/src/debuglink.ts
+++ b/packages/hdwallet-core/src/debuglink.ts
@@ -1,9 +1,0 @@
-import { HDWallet } from "./wallet";
-
-export interface DebugLinkWallet extends HDWallet {
-  readonly _supportsDebugLink: boolean;
-
-  pressYes(): Promise<void>;
-  pressNo(): Promise<void>;
-  press(isYes: boolean): Promise<void>;
-}

--- a/packages/hdwallet-core/src/index.ts
+++ b/packages/hdwallet-core/src/index.ts
@@ -2,7 +2,6 @@ export * from "./binance";
 export * from "./bitcoin";
 export * from "./cosmos";
 export * from "./osmosis";
-export * from "./debuglink";
 export * from "./eos";
 export * from "./ethereum";
 export * from "./event";

--- a/packages/hdwallet-core/src/wallet.test.ts
+++ b/packages/hdwallet-core/src/wallet.test.ts
@@ -1,7 +1,7 @@
-import { infoBTC, infoETH, supportsBTC, supportsETH, supportsDebugLink, HDWallet } from "./wallet";
+import { infoBTC, infoETH, supportsBTC, supportsETH, HDWallet } from "./wallet";
 
 describe("wallet : guards", () => {
-  it.each([infoBTC, infoETH, supportsBTC, supportsETH, supportsDebugLink])(
+  it.each([infoBTC, infoETH, supportsBTC, supportsETH])(
     "should return falsy for `null`",
     (method) => {
       expect(method(undefined as any)).toBeFalsy();
@@ -14,6 +14,4 @@ describe("wallet : guards", () => {
   it("infoETH should be truthy", () => expect(infoETH({ _supportsETHInfo: true } as unknown as HDWallet)).toBeTruthy());
   it("supportsBTC should be truthy", () => expect(supportsBTC({ _supportsBTC: true } as unknown as HDWallet)).toBeTruthy());
   it("supportsETH should be truthy", () => expect(supportsETH({ _supportsETH: true } as unknown as HDWallet)).toBeTruthy());
-  it("supportsDebugLink should be truthy", () =>
-    expect(supportsDebugLink({ _supportsDebugLink: true } as unknown as HDWallet)).toBeTruthy());
 });

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -4,7 +4,6 @@ import { BinanceWallet, BinanceWalletInfo } from "./binance";
 import { BTCInputScriptType, BTCWallet, BTCWalletInfo } from "./bitcoin";
 import { CosmosWallet, CosmosWalletInfo } from "./cosmos";
 import { OsmosisWallet, OsmosisWalletInfo } from "./osmosis";
-import { DebugLinkWallet } from "./debuglink";
 import { EosWallet, EosWalletInfo } from "./eos";
 import { ETHWallet, ETHWalletInfo } from "./ethereum";
 import { FioWallet, FioWalletInfo } from "./fio";
@@ -211,10 +210,6 @@ export function supportsBinance(wallet: HDWallet): wallet is BinanceWallet {
 
 export function infoBinance(info: HDWalletInfo): info is BinanceWalletInfo {
   return _.isObject(info) && (info as any)._supportsBinanceInfo;
-}
-
-export function supportsDebugLink(wallet: HDWallet): wallet is DebugLinkWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsDebugLink;
 }
 
 export interface HDWalletInfo {

--- a/packages/hdwallet-keepkey/src/adapter.ts
+++ b/packages/hdwallet-keepkey/src/adapter.ts
@@ -142,7 +142,7 @@ export class Adapter<DelegateType extends AdapterDelegate<any>> {
     return await this.delegate.getTransportDelegate(device);
   }
 
-  async pairDevice(serialNumber?: string, tryDebugLink?: boolean): Promise<core.HDWallet> {
+  async pairDevice(serialNumber?: string, tryDebugLink?: boolean): Promise<KeepKeyHDWallet> {
     const device = await this.getDevice(serialNumber);
     if (!device)
       throw new Error(
@@ -153,8 +153,8 @@ export class Adapter<DelegateType extends AdapterDelegate<any>> {
     return this.pairRawDevice(device, tryDebugLink);
   }
 
-  async pairRawDevice(device: DeviceType<DelegateType>, tryDebugLink?: boolean): Promise<core.HDWallet> {
+  async pairRawDevice(device: DeviceType<DelegateType>, tryDebugLink?: boolean): Promise<KeepKeyHDWallet> {
     await this.initialize([device], tryDebugLink, true);
-    return core.mustBeDefined(this.keyring.get((await this.inspectDevice(device)).serialNumber));
+    return core.mustBeDefined(this.keyring.get((await this.inspectDevice(device)).serialNumber) as KeepKeyHDWallet);
   }
 }

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -611,7 +611,7 @@ export class KeepKeyHDWalletInfo
   }
 }
 
-export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWallet, core.DebugLinkWallet {
+export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWallet {
   readonly _supportsETHInfo = true;
   readonly _supportsBTCInfo = true;
   readonly _supportsCosmosInfo = true;

--- a/packages/hdwallet-ledger-webhid/src/adapter.ts
+++ b/packages/hdwallet-ledger-webhid/src/adapter.ts
@@ -31,7 +31,7 @@ export class WebHIDLedgerAdapter {
     try {
       await this.initialize(e.device);
       this.keyring.emit(["Ledger", e.device.productName ?? "", core.Events.CONNECT], MOCK_SERIAL_NUMBER);
-    } catch (error) {
+    } catch (error: any) {
       this.keyring.emit(
         ["Ledger", e.device.productName ?? "", core.Events.FAILURE],
         [MOCK_SERIAL_NUMBER, { message: { code: error.type, ...error } }]
@@ -60,8 +60,8 @@ export class WebHIDLedgerAdapter {
     }, APP_NAVIGATION_DELAY);
   }
 
-  public get(): core.HDWallet {
-    return core.mustBeDefined(this.keyring.get(MOCK_SERIAL_NUMBER));
+  public get(): ledger.LedgerHDWallet {
+    return core.mustBeDefined(this.keyring.get<ledger.LedgerHDWallet>(MOCK_SERIAL_NUMBER));
   }
 
   // without unique device identifiers, we should only ever have one HID ledger device on the keyring at a time
@@ -81,13 +81,13 @@ export class WebHIDLedgerAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<ledger.LedgerHDWallet> {
     const ledgerTransport = await getTransport();
 
     const device = ledgerTransport.device;
 
     await this.initialize(device);
 
-    return core.mustBeDefined(this.keyring.get(MOCK_SERIAL_NUMBER));
+    return core.mustBeDefined(this.keyring.get<ledger.LedgerHDWallet>(MOCK_SERIAL_NUMBER));
   }
 }

--- a/packages/hdwallet-ledger-webusb/src/adapter.ts
+++ b/packages/hdwallet-ledger-webusb/src/adapter.ts
@@ -31,7 +31,7 @@ export class WebUSBLedgerAdapter {
     try {
       await this.initialize(e.device);
       this.keyring.emit([e.device.manufacturerName ?? "", e.device.productName ?? "", core.Events.CONNECT], e.device.serialNumber);
-    } catch (error) {
+    } catch (error: any) {
       this.keyring.emit(
         [e.device.manufacturerName ?? "", e.device.productName ?? "", core.Events.FAILURE],
         [e.device.serialNumber, { message: { code: error.type, ...error } }]
@@ -60,8 +60,8 @@ export class WebUSBLedgerAdapter {
     }, APP_NAVIGATION_DELAY);
   }
 
-  public get(device: USBDevice): core.HDWallet {
-    return core.mustBeDefined(this.keyring.get(device.serialNumber));
+  public get(device: USBDevice): ledger.LedgerHDWallet {
+    return core.mustBeDefined(this.keyring.get<ledger.LedgerHDWallet>(device.serialNumber));
   }
 
   // without unique device identifiers, we should only ever have one ledger device on the keyring at a time
@@ -81,13 +81,13 @@ export class WebUSBLedgerAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<ledger.LedgerHDWallet> {
     const ledgerTransport = await getTransport();
 
     const device = ledgerTransport.device;
 
     await this.initialize(device);
 
-    return core.mustBeDefined(this.keyring.get(device.serialNumber));
+    return core.mustBeDefined(this.keyring.get<ledger.LedgerHDWallet>(device.serialNumber));
   }
 }

--- a/packages/hdwallet-metamask/src/adapter.ts
+++ b/packages/hdwallet-metamask/src/adapter.ts
@@ -21,7 +21,7 @@ export class MetaMaskAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<MetaMaskHDWallet> {
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     if (!provider) {
       const onboarding = new MetaMaskOnboarding();

--- a/packages/hdwallet-native/src/adapter.ts
+++ b/packages/hdwallet-native/src/adapter.ts
@@ -28,7 +28,7 @@ export class NativeAdapter {
     return 0;
   }
 
-  async pairDevice(deviceId: string): Promise<core.HDWallet | null> {
+  async pairDevice(deviceId: string): Promise<native.NativeHDWallet | null> {
     let wallet: core.HDWallet | null = this.keyring.get(deviceId);
     if (!wallet && deviceId) {
       // If a wallet with that ID hasn't been added to the keychain, then create it

--- a/packages/hdwallet-native/src/bitcoin.test.ts
+++ b/packages/hdwallet-native/src/bitcoin.test.ts
@@ -149,7 +149,6 @@ describe("NativeBTCWalletInfo", () => {
     expect(await info.btcSupportsScriptType("bitcoin", "p2sh" as any)).toBe(true);
     expect(await info.btcSupportsScriptType("bitcoin", "p2wpkh" as any)).toBe(true);
     expect(await info.btcSupportsScriptType("bitcoin", "p2sh-p2wpkh" as any)).toBe(true);
-    expect(await info.btcSupportsScriptType("bitcoin", "bech32" as any)).toBe(true);
     expect(await info.btcSupportsScriptType("bitcoin", "cashaddr" as any)).toBe(false);
     expect(await info.btcSupportsScriptType("bitcoincash", "cashaddr" as any)).toBe(false);
     expect(await info.btcSupportsScriptType("bitcoin", "foobar" as any)).toBe(false);

--- a/packages/hdwallet-native/src/bitcoin.ts
+++ b/packages/hdwallet-native/src/bitcoin.ts
@@ -9,7 +9,7 @@ import * as util from "./util";
 
 const supportedCoins = ["bitcoin", "dash", "digibyte", "dogecoin", "litecoin", "bitcoincash", "testnet"];
 
-const segwit = ["p2wpkh", "p2sh-p2wpkh", "bech32"];
+const segwit = ["p2wpkh", "p2sh-p2wpkh"];
 
 export type BTCScriptType = core.BTCInputScriptType | core.BTCOutputScriptType;
 
@@ -52,7 +52,6 @@ export function MixinNativeBTCWalletInfo<TBase extends core.Constructor<core.HDW
         case core.BTCInputScriptType.SpendMultisig:
         case core.BTCInputScriptType.SpendAddress:
         case core.BTCInputScriptType.SpendWitness:
-        case core.BTCInputScriptType.Bech32:
         case core.BTCInputScriptType.SpendP2SHWitness:
           return true;
         default:
@@ -158,11 +157,6 @@ export function MixinNativeBTCWallet<TBase extends core.Constructor<NativeHDWall
             redeem: bitcoin.payments.p2wpkh({ pubkey, network }),
             network,
           });
-        case "bech32":
-          return bitcoin.payments.p2wsh({
-            redeem: bitcoin.payments.p2wsh({ pubkey, network }),
-            network,
-          });
         default:
           throw new Error(`no implementation for script type: ${scriptType}`);
       }
@@ -241,7 +235,6 @@ export function MixinNativeBTCWallet<TBase extends core.Constructor<NativeHDWall
         switch (scriptType) {
           case "p2sh-p2wpkh":
           case "p2sh":
-          case "bech32":
             scriptData.redeemScript = payment.redeem?.output;
             break;
         }

--- a/packages/hdwallet-portis/src/adapter.ts
+++ b/packages/hdwallet-portis/src/adapter.ts
@@ -28,7 +28,7 @@ export class PortisAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<PortisHDWallet> {
     try {
       const wallet = await this.pairPortisDevice();
       this.portis.onActiveWalletChanged(async (wallAddr: string) => {
@@ -58,7 +58,7 @@ export class PortisAdapter {
     }
   }
 
-  private async pairPortisDevice(): Promise<core.HDWallet> {
+  private async pairPortisDevice(): Promise<PortisHDWallet> {
     const Portis = (await import("@portis/web3")).default;
     this.portis = new Portis(this.portisAppId, "mainnet");
     const wallet = new PortisHDWallet(this.portis);

--- a/packages/hdwallet-trezor-connect/src/adapter.ts
+++ b/packages/hdwallet-trezor-connect/src/adapter.ts
@@ -165,7 +165,7 @@ export class TrezorAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<trezor.TrezorHDWallet> {
     const init = await _initialization;
     if (!init) throw new Error("Could not pair Trezor: TrezorConnect not initialized");
 

--- a/packages/hdwallet-xdefi/src/adapter.ts
+++ b/packages/hdwallet-xdefi/src/adapter.ts
@@ -19,7 +19,7 @@ export class XDeFiAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<XDeFiHDWallet> {
     const provider: any = (globalThis as any).xfi?.ethereum;
     if (!provider) {
       throw new Error("XDeFi provider not found");


### PR DESCRIPTION
Requires #418.

- removes `Bech32` script type, which did the same thing as `SpendWitness`
- removes the `DebugLinkWallet` abstraction; #418 passes the precise type of wallet through so there's no need to introspect it to find out if it's got support