### PR TITLE
remove `DebugLinkWallet`

### DIFF
--- a/integration/src/wallets/keepkey.ts
+++ b/integration/src/wallets/keepkey.ts
@@ -63,9 +63,7 @@ export async function createWallet(): Promise<core.HDWallet> {
   if (!wallet) throw new Error("No suitable test KeepKey found");
 
   wallet.transport?.on(core.Events.BUTTON_REQUEST, async () => {
-    if (autoButton && core.supportsDebugLink(wallet)) {
-      await wallet.pressYes();
-    }
+    if (autoButton) await wallet.pressYes();
   });
 
   wallet.transport?.onAny((event: string | string[], ...values: any[]) => {

--- a/packages/hdwallet-core/src/debuglink.ts
+++ b/packages/hdwallet-core/src/debuglink.ts
@@ -1,9 +1,0 @@
-import { HDWallet } from "./wallet";
-
-export interface DebugLinkWallet extends HDWallet {
-  readonly _supportsDebugLink: boolean;
-
-  pressYes(): Promise<void>;
-  pressNo(): Promise<void>;
-  press(isYes: boolean): Promise<void>;
-}

--- a/packages/hdwallet-core/src/index.ts
+++ b/packages/hdwallet-core/src/index.ts
@@ -2,7 +2,6 @@ export * from "./binance";
 export * from "./bitcoin";
 export * from "./cosmos";
 export * from "./osmosis";
-export * from "./debuglink";
 export * from "./eos";
 export * from "./ethereum";
 export * from "./event";

--- a/packages/hdwallet-core/src/wallet.test.ts
+++ b/packages/hdwallet-core/src/wallet.test.ts
@@ -1,7 +1,7 @@
-import { infoBTC, infoETH, supportsBTC, supportsETH, supportsDebugLink, HDWallet } from "./wallet";
+import { infoBTC, infoETH, supportsBTC, supportsETH, HDWallet } from "./wallet";
 
 describe("wallet : guards", () => {
-  it.each([infoBTC, infoETH, supportsBTC, supportsETH, supportsDebugLink])(
+  it.each([infoBTC, infoETH, supportsBTC, supportsETH])(
     "should return falsy for `null`",
     (method) => {
       expect(method(undefined as any)).toBeFalsy();
@@ -14,6 +14,4 @@ describe("wallet : guards", () => {
   it("infoETH should be truthy", () => expect(infoETH({ _supportsETHInfo: true } as unknown as HDWallet)).toBeTruthy());
   it("supportsBTC should be truthy", () => expect(supportsBTC({ _supportsBTC: true } as unknown as HDWallet)).toBeTruthy());
   it("supportsETH should be truthy", () => expect(supportsETH({ _supportsETH: true } as unknown as HDWallet)).toBeTruthy());
-  it("supportsDebugLink should be truthy", () =>
-    expect(supportsDebugLink({ _supportsDebugLink: true } as unknown as HDWallet)).toBeTruthy());
 });

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -4,7 +4,6 @@ import { BinanceWallet, BinanceWalletInfo } from "./binance";
 import { BTCInputScriptType, BTCWallet, BTCWalletInfo } from "./bitcoin";
 import { CosmosWallet, CosmosWalletInfo } from "./cosmos";
 import { OsmosisWallet, OsmosisWalletInfo } from "./osmosis";
-import { DebugLinkWallet } from "./debuglink";
 import { EosWallet, EosWalletInfo } from "./eos";
 import { ETHWallet, ETHWalletInfo } from "./ethereum";
 import { FioWallet, FioWalletInfo } from "./fio";
@@ -211,10 +210,6 @@ export function supportsBinance(wallet: HDWallet): wallet is BinanceWallet {
 
 export function infoBinance(info: HDWalletInfo): info is BinanceWalletInfo {
   return _.isObject(info) && (info as any)._supportsBinanceInfo;
-}
-
-export function supportsDebugLink(wallet: HDWallet): wallet is DebugLinkWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsDebugLink;
 }
 
 export interface HDWalletInfo {

--- a/packages/hdwallet-keepkey/src/adapter.ts
+++ b/packages/hdwallet-keepkey/src/adapter.ts
@@ -142,7 +142,7 @@ export class Adapter<DelegateType extends AdapterDelegate<any>> {
     return await this.delegate.getTransportDelegate(device);
   }
 
-  async pairDevice(serialNumber?: string, tryDebugLink?: boolean): Promise<core.HDWallet> {
+  async pairDevice(serialNumber?: string, tryDebugLink?: boolean): Promise<KeepKeyHDWallet> {
     const device = await this.getDevice(serialNumber);
     if (!device)
       throw new Error(
@@ -153,8 +153,8 @@ export class Adapter<DelegateType extends AdapterDelegate<any>> {
     return this.pairRawDevice(device, tryDebugLink);
   }
 
-  async pairRawDevice(device: DeviceType<DelegateType>, tryDebugLink?: boolean): Promise<core.HDWallet> {
+  async pairRawDevice(device: DeviceType<DelegateType>, tryDebugLink?: boolean): Promise<KeepKeyHDWallet> {
     await this.initialize([device], tryDebugLink, true);
-    return core.mustBeDefined(this.keyring.get((await this.inspectDevice(device)).serialNumber));
+    return core.mustBeDefined(this.keyring.get((await this.inspectDevice(device)).serialNumber) as KeepKeyHDWallet);
   }
 }

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -611,7 +611,7 @@ export class KeepKeyHDWalletInfo
   }
 }
 
-export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWallet, core.DebugLinkWallet {
+export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWallet {
   readonly _supportsETHInfo = true;
   readonly _supportsBTCInfo = true;
   readonly _supportsCosmosInfo = true;

--- a/packages/hdwallet-ledger-webhid/src/adapter.ts
+++ b/packages/hdwallet-ledger-webhid/src/adapter.ts
@@ -31,7 +31,7 @@ export class WebHIDLedgerAdapter {
     try {
       await this.initialize(e.device);
       this.keyring.emit(["Ledger", e.device.productName ?? "", core.Events.CONNECT], MOCK_SERIAL_NUMBER);
-    } catch (error) {
+    } catch (error: any) {
       this.keyring.emit(
         ["Ledger", e.device.productName ?? "", core.Events.FAILURE],
         [MOCK_SERIAL_NUMBER, { message: { code: error.type, ...error } }]
@@ -60,8 +60,8 @@ export class WebHIDLedgerAdapter {
     }, APP_NAVIGATION_DELAY);
   }
 
-  public get(): core.HDWallet {
-    return core.mustBeDefined(this.keyring.get(MOCK_SERIAL_NUMBER));
+  public get(): ledger.LedgerHDWallet {
+    return core.mustBeDefined(this.keyring.get<ledger.LedgerHDWallet>(MOCK_SERIAL_NUMBER));
   }
 
   // without unique device identifiers, we should only ever have one HID ledger device on the keyring at a time
@@ -81,13 +81,13 @@ export class WebHIDLedgerAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<ledger.LedgerHDWallet> {
     const ledgerTransport = await getTransport();
 
     const device = ledgerTransport.device;
 
     await this.initialize(device);
 
-    return core.mustBeDefined(this.keyring.get(MOCK_SERIAL_NUMBER));
+    return core.mustBeDefined(this.keyring.get<ledger.LedgerHDWallet>(MOCK_SERIAL_NUMBER));
   }
 }

--- a/packages/hdwallet-ledger-webusb/src/adapter.ts
+++ b/packages/hdwallet-ledger-webusb/src/adapter.ts
@@ -31,7 +31,7 @@ export class WebUSBLedgerAdapter {
     try {
       await this.initialize(e.device);
       this.keyring.emit([e.device.manufacturerName ?? "", e.device.productName ?? "", core.Events.CONNECT], e.device.serialNumber);
-    } catch (error) {
+    } catch (error: any) {
       this.keyring.emit(
         [e.device.manufacturerName ?? "", e.device.productName ?? "", core.Events.FAILURE],
         [e.device.serialNumber, { message: { code: error.type, ...error } }]
@@ -60,8 +60,8 @@ export class WebUSBLedgerAdapter {
     }, APP_NAVIGATION_DELAY);
   }
 
-  public get(device: USBDevice): core.HDWallet {
-    return core.mustBeDefined(this.keyring.get(device.serialNumber));
+  public get(device: USBDevice): ledger.LedgerHDWallet {
+    return core.mustBeDefined(this.keyring.get<ledger.LedgerHDWallet>(device.serialNumber));
   }
 
   // without unique device identifiers, we should only ever have one ledger device on the keyring at a time
@@ -81,13 +81,13 @@ export class WebUSBLedgerAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<ledger.LedgerHDWallet> {
     const ledgerTransport = await getTransport();
 
     const device = ledgerTransport.device;
 
     await this.initialize(device);
 
-    return core.mustBeDefined(this.keyring.get(device.serialNumber));
+    return core.mustBeDefined(this.keyring.get<ledger.LedgerHDWallet>(device.serialNumber));
   }
 }

--- a/packages/hdwallet-metamask/src/adapter.ts
+++ b/packages/hdwallet-metamask/src/adapter.ts
@@ -21,7 +21,7 @@ export class MetaMaskAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<MetaMaskHDWallet> {
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     if (!provider) {
       const onboarding = new MetaMaskOnboarding();

--- a/packages/hdwallet-native/src/adapter.ts
+++ b/packages/hdwallet-native/src/adapter.ts
@@ -28,7 +28,7 @@ export class NativeAdapter {
     return 0;
   }
 
-  async pairDevice(deviceId: string): Promise<core.HDWallet | null> {
+  async pairDevice(deviceId: string): Promise<native.NativeHDWallet | null> {
     let wallet: core.HDWallet | null = this.keyring.get(deviceId);
     if (!wallet && deviceId) {
       // If a wallet with that ID hasn't been added to the keychain, then create it

--- a/packages/hdwallet-portis/src/adapter.ts
+++ b/packages/hdwallet-portis/src/adapter.ts
@@ -28,7 +28,7 @@ export class PortisAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<PortisHDWallet> {
     try {
       const wallet = await this.pairPortisDevice();
       this.portis.onActiveWalletChanged(async (wallAddr: string) => {
@@ -58,7 +58,7 @@ export class PortisAdapter {
     }
   }
 
-  private async pairPortisDevice(): Promise<core.HDWallet> {
+  private async pairPortisDevice(): Promise<PortisHDWallet> {
     const Portis = (await import("@portis/web3")).default;
     this.portis = new Portis(this.portisAppId, "mainnet");
     const wallet = new PortisHDWallet(this.portis);

--- a/packages/hdwallet-trezor-connect/src/adapter.ts
+++ b/packages/hdwallet-trezor-connect/src/adapter.ts
@@ -165,7 +165,7 @@ export class TrezorAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<trezor.TrezorHDWallet> {
     const init = await _initialization;
     if (!init) throw new Error("Could not pair Trezor: TrezorConnect not initialized");
 

--- a/packages/hdwallet-xdefi/src/adapter.ts
+++ b/packages/hdwallet-xdefi/src/adapter.ts
@@ -19,7 +19,7 @@ export class XDeFiAdapter {
     return Object.keys(this.keyring.wallets).length;
   }
 
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<XDeFiHDWallet> {
     const provider: any = (globalThis as any).xfi?.ethereum;
     if (!provider) {
       throw new Error("XDeFi provider not found");


### PR DESCRIPTION
Requires #418.

Removes the `DebugLinkWallet` abstraction; #418 passes the precise type of wallet through so there's no need to introspect it to find out if it's got support anymore.