### PR TITLE
remove `BTC(Input|Output)ScriptType.Bech32`

### DIFF
--- a/integration/src/wallets/native.ts
+++ b/integration/src/wallets/native.ts
@@ -333,7 +333,7 @@ export function selfTest(get: () => core.HDWallet): void {
         coin: "Litecoin",
         isKnown: true,
         scriptType: "p2wpkh",
-        verbose: "Litecoin Account #4 (Segwit)",
+        verbose: "Litecoin Account #4 (Segwit Native)",
         wholeAccount: true,
         isPrefork: false,
       },
@@ -365,13 +365,13 @@ export function selfTest(get: () => core.HDWallet): void {
       wallet.describePath({
         path: core.bip32ToAddressNList("m/84'/0'/0'/0/0"),
         coin: "Bitcoin",
-        scriptType: core.BTCInputScriptType.Bech32,
+        scriptType: core.BTCInputScriptType.SpendWitness,
       })
     ).toEqual({
       verbose: "Bitcoin Account #0, Address #0 (Segwit Native)",
       coin: "Bitcoin",
       isKnown: true,
-      scriptType: core.BTCInputScriptType.Bech32,
+      scriptType: core.BTCInputScriptType.SpendWitness,
       accountIdx: 0,
       addressIdx: 0,
       wholeAccount: false,

--- a/packages/hdwallet-core/src/bitcoin.ts
+++ b/packages/hdwallet-core/src/bitcoin.ts
@@ -249,10 +249,8 @@ export interface BTCSignedTx {
   serializedTx: string;
 }
 
-// Bech32 info https://en.bitcoin.it/wiki/BIP_0173
 export enum BTCInputScriptType {
   CashAddr = "cashaddr", // for Bitcoin Cash
-  Bech32 = "bech32",
   SpendAddress = "p2pkh",
   SpendMultisig = "p2sh",
   External = "external",
@@ -263,7 +261,6 @@ export enum BTCInputScriptType {
 export enum BTCOutputScriptType {
   PayToAddress = "p2pkh",
   PayToMultisig = "p2sh",
-  Bech32 = "bech32",
   PayToWitness = "p2wpkh",
   PayToP2SHWitness = "p2sh-p2wpkh",
 }
@@ -396,14 +393,15 @@ export function describeUTXOPath(path: BIP32Path, coin: Coin, scriptType: BTCInp
 
   if (purpose === 49 && scriptType !== BTCInputScriptType.SpendP2SHWitness) return unknown;
 
+  if (purpose === 84 && scriptType !== BTCInputScriptType.SpendWitness) return unknown;
+
   let wholeAccount = path.length === 3;
 
   let script = (
     {
       [BTCInputScriptType.SpendAddress]: ["Legacy"],
       [BTCInputScriptType.SpendP2SHWitness]: [],
-      [BTCInputScriptType.SpendWitness]: ["Segwit"],
-      [BTCInputScriptType.Bech32]: ["Segwit Native"],
+      [BTCInputScriptType.SpendWitness]: ["Segwit Native"],
     } as Partial<Record<BTCInputScriptType, string[]>>
   )[scriptType];
 

--- a/packages/hdwallet-native/src/bitcoin.test.ts
+++ b/packages/hdwallet-native/src/bitcoin.test.ts
@@ -149,7 +149,6 @@ describe("NativeBTCWalletInfo", () => {
     expect(await info.btcSupportsScriptType("bitcoin", "p2sh" as any)).toBe(true);
     expect(await info.btcSupportsScriptType("bitcoin", "p2wpkh" as any)).toBe(true);
     expect(await info.btcSupportsScriptType("bitcoin", "p2sh-p2wpkh" as any)).toBe(true);
-    expect(await info.btcSupportsScriptType("bitcoin", "bech32" as any)).toBe(true);
     expect(await info.btcSupportsScriptType("bitcoin", "cashaddr" as any)).toBe(false);
     expect(await info.btcSupportsScriptType("bitcoincash", "cashaddr" as any)).toBe(false);
     expect(await info.btcSupportsScriptType("bitcoin", "foobar" as any)).toBe(false);

--- a/packages/hdwallet-native/src/bitcoin.ts
+++ b/packages/hdwallet-native/src/bitcoin.ts
@@ -9,7 +9,7 @@ import * as util from "./util";
 
 const supportedCoins = ["bitcoin", "dash", "digibyte", "dogecoin", "litecoin", "bitcoincash", "testnet"];
 
-const segwit = ["p2wpkh", "p2sh-p2wpkh", "bech32"];
+const segwit = ["p2wpkh", "p2sh-p2wpkh"];
 
 export type BTCScriptType = core.BTCInputScriptType | core.BTCOutputScriptType;
 
@@ -52,7 +52,6 @@ export function MixinNativeBTCWalletInfo<TBase extends core.Constructor<core.HDW
         case core.BTCInputScriptType.SpendMultisig:
         case core.BTCInputScriptType.SpendAddress:
         case core.BTCInputScriptType.SpendWitness:
-        case core.BTCInputScriptType.Bech32:
         case core.BTCInputScriptType.SpendP2SHWitness:
           return true;
         default:
@@ -158,11 +157,6 @@ export function MixinNativeBTCWallet<TBase extends core.Constructor<NativeHDWall
             redeem: bitcoin.payments.p2wpkh({ pubkey, network }),
             network,
           });
-        case "bech32":
-          return bitcoin.payments.p2wsh({
-            redeem: bitcoin.payments.p2wsh({ pubkey, network }),
-            network,
-          });
         default:
           throw new Error(`no implementation for script type: ${scriptType}`);
       }
@@ -241,7 +235,6 @@ export function MixinNativeBTCWallet<TBase extends core.Constructor<NativeHDWall
         switch (scriptType) {
           case "p2sh-p2wpkh":
           case "p2sh":
-          case "bech32":
             scriptData.redeemScript = payment.redeem?.output;
             break;
         }


### PR DESCRIPTION
Removes the `Bech32` script type, which just does exactly the same thing as `SpendWitness`.