### PR TITLE
research: refactor adapter/wallet `initialize()`

### DIFF
--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -320,7 +320,7 @@ export interface HDWallet extends HDWalletInfo {
   /**
    * Initialize a device session.
    */
-  initialize(): Promise<any>;
+  initialize(): Promise<boolean>;
 
   /**
    * Send a ping to the device.

--- a/packages/hdwallet-keepkey/src/adapter.ts
+++ b/packages/hdwallet-keepkey/src/adapter.ts
@@ -92,7 +92,7 @@ export class Adapter<DelegateType extends AdapterDelegate<any>> {
     await this.keyring.emit([productName, serialNumber, core.Events.DISCONNECT], serialNumber);
   }
 
-  async initialize(
+  private async initialize(
     device: DeviceType<DelegateType>,
     tryDebugLink?: boolean,
     autoConnect?: boolean

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -999,7 +999,7 @@ export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHW
   }
 
   // Initialize assigns a hid connection to this KeepKey and send initialize message to device
-  public async initialize(): Promise<Messages.Features.AsObject> {
+  public async initialize(): Promise<boolean> {
     const initialize = new Messages.Initialize();
     const event = await this.transport.call(Messages.MessageType.MESSAGETYPE_INITIALIZE, initialize);
     if (!event.message) throw event;
@@ -1024,7 +1024,7 @@ export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHW
     // this._supportsThorchain = Semver.get(fwVersion, "v7.0.0");
 
     this.cacheFeatures(out);
-    return out;
+    return await this.isInitialized();
   }
 
   // GetFeatures returns the features and other device information such as the version, label, and supported coins

--- a/packages/hdwallet-ledger/src/ledger.ts
+++ b/packages/hdwallet-ledger/src/ledger.ts
@@ -301,8 +301,8 @@ export class LedgerHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
     this.info = new LedgerHDWalletInfo();
   }
 
-  public async initialize(): Promise<any> {
-    return;
+  public async initialize(): Promise<boolean> {
+    return await this.isInitialized();
   }
 
   public async isInitialized(): Promise<boolean> {

--- a/packages/hdwallet-metamask/src/adapter.ts
+++ b/packages/hdwallet-metamask/src/adapter.ts
@@ -17,10 +17,6 @@ export class MetaMaskAdapter {
     return new MetaMaskAdapter(keyring);
   }
 
-  public async initialize(): Promise<number> {
-    return Object.keys(this.keyring.wallets).length;
-  }
-
   public async pairDevice(): Promise<core.HDWallet> {
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     if (!provider) {

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -77,14 +77,14 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
     return Promise.resolve("MetaMask");
   }
 
-  public async initialize(): Promise<any> {
+  public async initialize(): Promise<boolean> {
     try {
       this.provider = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
+      return true;
     } catch (e) {
       console.error(e);
+      return false;
     }
-
-    return Promise.resolve();
   }
 
   public hasOnDevicePinEntry(): boolean {

--- a/packages/hdwallet-native/src/adapter.test.ts
+++ b/packages/hdwallet-native/src/adapter.test.ts
@@ -7,7 +7,6 @@ describe("NativeAdapter", () => {
   it("creates a unique wallet per deviceId", async () => {
     const keyring = new core.Keyring();
     const adapter = NativeAdapter.useKeyring(keyring);
-    expect(await adapter.initialize()).toBe(0);
     const wallet = await adapter.pairDevice("foobar");
     expect(wallet).toBeInstanceOf(NativeHDWallet);
     expect(await adapter.pairDevice("foobar")).toBe(wallet);

--- a/packages/hdwallet-native/src/adapter.ts
+++ b/packages/hdwallet-native/src/adapter.ts
@@ -24,10 +24,6 @@ export class NativeAdapter {
     return new NativeAdapter(keyring);
   }
 
-  async initialize(): Promise<number> {
-    return 0;
-  }
-
   async pairDevice(deviceId: string): Promise<core.HDWallet | null> {
     let wallet: core.HDWallet | null = this.keyring.get(deviceId);
     if (!wallet && deviceId) {

--- a/packages/hdwallet-native/src/native.test.ts
+++ b/packages/hdwallet-native/src/native.test.ts
@@ -238,7 +238,7 @@ describe("NativeHDWallet", () => {
     });
     wallet.events.addListener(native.NativeEvents.READY, readyMock);
     wallet.events.addListener(native.NativeEvents.MNEMONIC_REQUIRED, mnemonicRequiredMock);
-    expect(await wallet.initialize()).toBe(null);
+    expect(await wallet.initialize()).toBe(false);
     expect(mnemonicRequiredMock).toHaveBeenCalled();
     expect(readyMock).not.toHaveBeenCalled();
   });
@@ -267,7 +267,7 @@ describe("NativeHDWallet", () => {
     expect(await wallet.initialize()).toBe(true);
     await wallet.wipe();
     expect(mock).not.toHaveBeenCalled();
-    expect(await wallet.initialize()).toBe(null);
+    expect(await wallet.initialize()).toBe(false);
     expect(mock).toHaveBeenCalled();
   });
 

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -286,7 +286,7 @@ export class NativeHDWallet
 
   async clearSession(): Promise<void> {}
 
-  async initialize(): Promise<boolean | null> {
+  async initialize(): Promise<boolean> {
     return this.needsMnemonic(!!this.#masterKey, async () => {
       const masterKey = await this.#masterKey!;
       try {
@@ -309,9 +309,8 @@ export class NativeHDWallet
         this.#initialized = false;
         await this.wipe();
       }
-
-      return this.#initialized;
-    });
+      return await this.isInitialized();
+    }) ?? false;
   }
 
   async ping(msg: core.Ping): Promise<core.Pong> {

--- a/packages/hdwallet-portis/src/adapter.ts
+++ b/packages/hdwallet-portis/src/adapter.ts
@@ -24,13 +24,9 @@ export class PortisAdapter {
     return new PortisAdapter(keyring, args);
   }
 
-  public async initialize(): Promise<number> {
-    return Object.keys(this.keyring.wallets).length;
-  }
-
-  public async pairDevice(): Promise<core.HDWallet> {
+  public async pairDevice(): Promise<PortisHDWallet> {
     try {
-      const wallet = await this.pairPortisDevice();
+      const wallet = await this.initialize();
       this.portis.onActiveWalletChanged(async (wallAddr: string) => {
         // check if currentDeviceId has changed
         const walletAddress = "portis:" + wallAddr;
@@ -40,7 +36,7 @@ export class PortisAdapter {
             this.keyring.emit(["Portis", currentDeviceId, core.Events.DISCONNECT], currentDeviceId);
             this.keyring.remove(currentDeviceId);
           }
-          this.pairPortisDevice();
+          await this.initialize();
         }
       });
       this.portis.onLogout(() => {
@@ -58,7 +54,7 @@ export class PortisAdapter {
     }
   }
 
-  private async pairPortisDevice(): Promise<core.HDWallet> {
+  private async initialize(): Promise<PortisHDWallet> {
     const Portis = (await import("@portis/web3")).default;
     this.portis = new Portis(this.portisAppId, "mainnet");
     const wallet = new PortisHDWallet(this.portis);

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -70,10 +70,10 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
     return "Portis";
   }
 
-  public initialize(): Promise<any> {
+  public async initialize(): Promise<boolean> {
     // no means to reset the state of the Portis widget
     // while it's in the middle of execution
-    return Promise.resolve();
+    return await this.isInitialized();
   }
 
   public hasOnDevicePinEntry(): boolean {

--- a/packages/hdwallet-trezor/src/trezor.ts
+++ b/packages/hdwallet-trezor/src/trezor.ts
@@ -275,8 +275,8 @@ export class TrezorHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
     this.info = new TrezorHDWalletInfo();
   }
 
-  public async initialize(): Promise<any> {
-    return;
+  public async initialize(): Promise<boolean> {
+    return this.isInitialized();
   }
 
   public async isInitialized(): Promise<boolean> {

--- a/packages/hdwallet-xdefi/src/adapter.test.ts
+++ b/packages/hdwallet-xdefi/src/adapter.test.ts
@@ -7,7 +7,6 @@ describe("XDeFiAdapter", () => {
   it("throws error if provider is not preset", async () => {
     const keyring = new core.Keyring();
     const adapter = XDeFiAdapter.useKeyring(keyring);
-    expect(await adapter.initialize()).toBe(0);
     try {
       await adapter.pairDevice();
     } catch (e) {
@@ -21,7 +20,6 @@ describe("XDeFiAdapter", () => {
     const keyring = new core.Keyring();
     const adapter = XDeFiAdapter.useKeyring(keyring);
     const add = jest.spyOn(adapter.keyring, "add");
-    expect(await adapter.initialize()).toBe(0);
     const wallet = await adapter.pairDevice();
     expect(wallet).toBeInstanceOf(XDeFiHDWallet);
     expect(add).toBeCalled();

--- a/packages/hdwallet-xdefi/src/adapter.ts
+++ b/packages/hdwallet-xdefi/src/adapter.ts
@@ -15,10 +15,6 @@ export class XDeFiAdapter {
     return new XDeFiAdapter(keyring);
   }
 
-  public async initialize(): Promise<number> {
-    return Object.keys(this.keyring.wallets).length;
-  }
-
   public async pairDevice(): Promise<core.HDWallet> {
     const provider: any = (globalThis as any).xfi?.ethereum;
     if (!provider) {

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -49,10 +49,11 @@ export class XDeFiHDWallet implements core.HDWallet, core.ETHWallet {
   }
 
   public initialize(): never;
-  public initialize(provider: unknown): Promise<any>;
-  public async initialize(provider?: unknown): Promise<any> {
-    if (!provider) throw new Error("provider is required");
+  public initialize(provider: unknown): Promise<boolean>;
+  public async initialize(provider?: unknown): Promise<boolean> {
+    if (!provider) return false;
     this.provider = provider;
+    return true;
   }
 
   public hasOnDevicePinEntry(): boolean {


### PR DESCRIPTION
- Makes `initialize()` on adapters private and removes unnecessary dummy implementations
- Makes `initialize()` on wallets always return a `boolean`
- On adapters with do have `initialize()`, it consistently turns a single device into a wallet. `pairDevice()` now picks the default device and delegates to wallet creation to `initialize()`.