### PR TITLE
refactor: remove `isWalletType` introspection functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ You can import the generated bundle to use each of the component libraries:
 
 ```javascript
 import { HDWallet } from "@shapeshiftoss/hdwallet-core";
-import { isKeepKey, KeepKeyHDWallet } from "@shapeshiftoss/hdwallet-keepkey";
-import { isLedger, LedgerHDWallet } from "@shapeshiftoss/hdwallet-ledger";
-import { isTrezor, TrezorHDWallet } from "@shapeshiftoss/hdwallet-trezor";
+import { KeepKeyHDWallet } from "@shapeshiftoss/hdwallet-keepkey";
+import { LedgerHDWallet } from "@shapeshiftoss/hdwallet-ledger";
+import { TrezorHDWallet } from "@shapeshiftoss/hdwallet-trezor";
 
 import { WebUSBKeepKeyAdapter } from "@shapeshiftoss/hdwallet-keepkey-webusb";
 import { WebUSBLedgerAdapter } from "@shapeshiftoss/hdwallet-ledger-webusb";

--- a/examples/sandbox/index.ts
+++ b/examples/sandbox/index.ts
@@ -257,7 +257,7 @@ async function deviceConnected(deviceId) {
     if (wallet) {
       if (wallet.transport) {
         await wallet.transport.connect();
-        if (keepkey.isKeepKey(wallet)) {
+        if (wallet instanceof keepkey.KeepKeyHDWallet) {
           console.log("try connect debuglink");
           await wallet.transport.tryConnectDebugLink();
         }
@@ -451,7 +451,7 @@ $getXpubs.on("click", async (e) => {
       addressNList: hardenedPath,
       curve: "secp256k1",
       showDisplay: true, // Not supported by TrezorConnect or Ledger, but KeepKey should do it
-      coin: portis.isPortis(wallet) ? "Bitcoin" : "Ethereum",
+      coin: wallet instanceof portis.PortisHDWallet ? "Bitcoin" : "Ethereum",
     },
   ]);
 

--- a/integration/src/bitcoin/bitcoin.ts
+++ b/integration/src/bitcoin/bitcoin.ts
@@ -60,7 +60,7 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
     test(
       "btcSupportsCoin()",
       async () => {
-        if (!wallet || portis.isPortis(wallet)) return;
+        if (!wallet || wallet instanceof portis.PortisHDWallet) return;
         expect(wallet.btcSupportsCoin("Bitcoin")).toBeTruthy();
         expect(await info.btcSupportsCoin("Bitcoin")).toBeTruthy();
         expect(wallet.btcSupportsCoin("Testnet")).toBeTruthy();
@@ -70,7 +70,7 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
     );
 
     test("getPublicKeys", async () => {
-      if (!wallet || ledger.isLedger(wallet) || trezor.isTrezor(wallet) || portis.isPortis(wallet)) return;
+      if (!wallet || wallet instanceof ledger.LedgerHDWallet || wallet instanceof trezor.TrezorHDWallet || wallet instanceof portis.PortisHDWallet) return;
 
       /* FIXME: Expected failure (trezor does not use scriptType in deriving public keys
           and ledger's dependency bitcoinjs-lib/src/crypto.js throws a mysterious TypeError
@@ -148,7 +148,7 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
     test(
       "btcGetAddress()",
       async () => {
-        if (!wallet || portis.isPortis(wallet)) return;
+        if (!wallet || wallet instanceof portis.PortisHDWallet) return;
         await each(
           [
             [
@@ -214,8 +214,8 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
     test(
       "btcSignTx() - p2pkh",
       async () => {
-        if (!wallet || portis.isPortis(wallet)) return;
-        if (ledger.isLedger(wallet)) return; // FIXME: Expected failure
+        if (!wallet || wallet instanceof portis.PortisHDWallet) return;
+        if (wallet instanceof ledger.LedgerHDWallet) return; // FIXME: Expected failure
         const tx: core.BitcoinTx = {
           version: 1,
           locktime: 0,
@@ -289,9 +289,9 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
     test(
       "btcSignTx() - thorchain swap",
       async () => {
-        if (!wallet || portis.isPortis(wallet)) return;
-        if (ledger.isLedger(wallet)) return; // FIXME: Expected failure
-        if (trezor.isTrezor(wallet)) return; //TODO: Add trezor support for op return data passed at top level
+        if (!wallet || wallet instanceof portis.PortisHDWallet) return;
+        if (wallet instanceof ledger.LedgerHDWallet) return; // FIXME: Expected failure
+        if (wallet instanceof trezor.TrezorHDWallet) return; // FIXME: Expected failure
         const tx: core.BitcoinTx = {
           version: 1,
           locktime: 0,
@@ -375,11 +375,7 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
       "btcSignMessage()",
       async () => {
         if (!wallet) return;
-
-        // not implemented for native
-        if (native.isNative(wallet)) {
-          return;
-        }
+        if (wallet instanceof native.NativeHDWallet) return; // TODO: not implemented for native
 
         let res = wallet.btcSignMessage({
           addressNList: core.bip32ToAddressNList("m/44'/0'/0'/0/0"),
@@ -389,7 +385,7 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
         });
 
         // not implemented on portis
-        if (portis.isPortis(wallet)) {
+        if (wallet instanceof portis.PortisHDWallet) {
           await expect(res).rejects.toThrowError("not supported");
           return;
         }
@@ -407,11 +403,7 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
       "btcVerifyMessage() - good",
       async () => {
         if (!wallet) return;
-
-        // not implemented for native
-        if (native.isNative(wallet)) {
-          return;
-        }
+        if (wallet instanceof native.NativeHDWallet) return; // TODO: not implemented for native
 
         let res = await wallet.btcVerifyMessage({
           address: "1FH6ehAd5ZFXCM1cLGzHxK1s4dGdq1JusM",
@@ -430,11 +422,7 @@ export function bitcoinTests(get: () => { wallet: core.HDWallet; info: core.HDWa
       "btcVerifyMessage() - bad",
       async () => {
         if (!wallet) return;
-
-        // not implemented for native
-        if (native.isNative(wallet)) {
-          return;
-        }
+        if (wallet instanceof native.NativeHDWallet) return; // TODO: not implemented for native
 
         let res = await wallet.btcVerifyMessage({
           address: "1FH6ehAd5ZFXCM1cLGzHxK1s4dGdq1JusM",

--- a/integration/src/bitcoin/testnet.ts
+++ b/integration/src/bitcoin/testnet.ts
@@ -31,8 +31,8 @@ export function testnetTests(get: () => { wallet: core.HDWallet; info: core.HDWa
     test(
       "btcSignTx() - p2sh-p2wpkh",
       async () => {
-        if (!wallet || portis.isPortis(wallet)) return;
-        if (ledger.isLedger(wallet)) return; // FIXME: Expected failure
+        if (!wallet || wallet instanceof portis.PortisHDWallet) return;
+        if (wallet instanceof ledger.LedgerHDWallet) return; // FIXME: Expected failure
         if (!wallet.btcSupportsCoin("Testnet")) return;
         const inputs: core.BTCSignTxInputUnguarded[] = [
           {
@@ -75,8 +75,8 @@ export function testnetTests(get: () => { wallet: core.HDWallet; info: core.HDWa
     );
 
     test("btcSignTx() - p2wpkh", async () => {
-      if (!wallet || portis.isPortis(wallet)) return;
-      if (ledger.isLedger(wallet)) return; // FIXME: Expected failure
+      if (!wallet || wallet instanceof portis.PortisHDWallet) return;
+      if (wallet instanceof ledger.LedgerHDWallet) return; // FIXME: Expected failure
       if (!wallet.btcSupportsCoin("Testnet")) return;
       const tx: core.BitcoinTx = {
         version: core.untouchable("tx.version not provided by test"),

--- a/integration/src/ethereum/ethereum.ts
+++ b/integration/src/ethereum/ethereum.ts
@@ -281,9 +281,9 @@ export function ethereumTests(get: () => { wallet: core.HDWallet; info: core.HDW
       "ethSignTx() - long contract data",
       async () => {
         if (!wallet) return;
-        if (ledger.isLedger(wallet)) return; // FIXME: just test kk for now
-        if (trezor.isTrezor(wallet)) return; // FIXME: just test kk for now
-        if (portis.isPortis(wallet)) return; // FIXME: just test kk for now
+        if (wallet instanceof ledger.LedgerHDWallet) return; // FIXME: just test kk for now
+        if (wallet instanceof trezor.TrezorHDWallet) return; // FIXME: just test kk for now
+        if (wallet instanceof portis.PortisHDWallet) return; // FIXME: just test kk for now
 
         const txToSign = {
           addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
@@ -371,7 +371,7 @@ export function ethereumTests(get: () => { wallet: core.HDWallet; info: core.HDW
       "ethSignMessage()",
       async () => {
         if (!wallet) return;
-        if (ledger.isLedger(wallet)) return; // FIXME: Expected failure
+        if (wallet instanceof ledger.LedgerHDWallet) return; // FIXME: Expected failure
         let res = await wallet.ethSignMessage({
           addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
           message: "Hello World",

--- a/integration/src/integration.ts
+++ b/integration/src/integration.ts
@@ -1,11 +1,4 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
-import * as keepkey from "@shapeshiftoss/hdwallet-keepkey";
-import * as ledger from "@shapeshiftoss/hdwallet-ledger";
-import * as metamask from "@shapeshiftoss/hdwallet-metamask";
-import * as native from "@shapeshiftoss/hdwallet-native";
-import * as portis from "@shapeshiftoss/hdwallet-portis";
-import * as trezor from "@shapeshiftoss/hdwallet-trezor";
-import * as xdefi from "@shapeshiftoss/hdwallet-xdefi";
 
 import { btcTests } from "./bitcoin";
 import { ethTests } from "./ethereum";
@@ -48,18 +41,6 @@ export function integration(suite: WalletSuite): void {
     describe("Type Guards", () => {
       beforeAll(async () => {
         wallet = await suite.createWallet();
-      });
-
-      it("has only one vendor", () => {
-        expect(
-          (keepkey.isKeepKey(wallet) ? 1 : 0) +
-            (trezor.isTrezor(wallet) ? 1 : 0) +
-            (ledger.isLedger(wallet) ? 1 : 0) +
-            (portis.isPortis(wallet) ? 1 : 0) +
-            (native.isNative(wallet) ? 1 : 0) +
-            (metamask.isMetaMask(wallet) ? 1 : 0) +
-            (xdefi.isXDeFi(wallet) ? 1 : 0)
-        ).toEqual(1);
       });
     });
 

--- a/integration/src/wallets/keepkey.ts
+++ b/integration/src/wallets/keepkey.ts
@@ -80,7 +80,7 @@ export function selfTest(get: () => core.HDWallet): void {
 
   beforeAll(async () => {
     let w = get();
-    if (keepkey.isKeepKey(w) && core.supportsBTC(w) && core.supportsETH(w)) wallet = w;
+    if (w instanceof keepkey.KeepKeyHDWallet && core.supportsBTC(w) && core.supportsETH(w)) wallet = w;
     else fail("Wallet is not a KeepKey");
 
     await wallet.wipe();

--- a/integration/src/wallets/ledger.ts
+++ b/integration/src/wallets/ledger.ts
@@ -225,7 +225,7 @@ export function selfTest(get: () => core.HDWallet): void {
 
   beforeAll(async () => {
     let w = get();
-    if (ledger.isLedger(w) && core.supportsBTC(w) && core.supportsETH(w)) wallet = w;
+    if (w instanceof ledger.LedgerHDWallet && core.supportsBTC(w) && core.supportsETH(w)) wallet = w;
     else fail("Wallet is not a Ledger");
   });
 

--- a/integration/src/wallets/metamask.ts
+++ b/integration/src/wallets/metamask.ts
@@ -21,7 +21,7 @@ export function selfTest(get: () => core.HDWallet): void {
   beforeAll(async () => {
     let w = get() as metamask.MetaMaskHDWallet;
 
-    if (metamask.isMetaMask(w) && !core.supportsBTC(w) && core.supportsETH(w)) {
+    if (w instanceof metamask.MetaMaskHDWallet && !core.supportsBTC(w) && core.supportsETH(w)) {
       wallet = w;
     } else {
       fail("Wallet is not a MetaMask");

--- a/integration/src/wallets/native.ts
+++ b/integration/src/wallets/native.ts
@@ -177,9 +177,9 @@ export function selfTest(get: () => core.HDWallet): void {
   let wallet: native.NativeHDWallet;
 
   beforeAll(async () => {
-    let w = get() as native.NativeHDWallet;
+    let w = get();
 
-    if (native.isNative(w) && core.supportsBTC(w) && core.supportsETH(w)) {
+    if (w instanceof native.NativeHDWallet && core.supportsBTC(w) && core.supportsETH(w)) {
       wallet = w;
     } else {
       fail("Wallet is not native");

--- a/integration/src/wallets/portis.ts
+++ b/integration/src/wallets/portis.ts
@@ -65,7 +65,7 @@ export function selfTest(get: () => core.HDWallet): void {
 
   beforeAll(() => {
     let w = get();
-    if (portis.isPortis(w) && core.supportsETH(w)) wallet = w;
+    if (w instanceof portis.PortisHDWallet && core.supportsETH(w)) wallet = w;
     else fail("Wallet is not Portis");
   });
 

--- a/integration/src/wallets/trezor.ts
+++ b/integration/src/wallets/trezor.ts
@@ -367,7 +367,7 @@ export function selfTest(get: () => core.HDWallet): void {
 
   beforeAll(async () => {
     let w = get();
-    if (trezor.isTrezor(w) && core.supportsBTC(w) && core.supportsETH(w)) wallet = w;
+    if (w instanceof trezor.TrezorHDWallet && core.supportsBTC(w) && core.supportsETH(w)) wallet = w;
     else fail("Wallet is not a Trezor");
   });
 

--- a/integration/src/wallets/xdefi.ts
+++ b/integration/src/wallets/xdefi.ts
@@ -21,7 +21,7 @@ export function selfTest(get: () => core.HDWallet): void {
 
   beforeAll(() => {
     let w = get();
-    if (xdefi.isXDeFi(w) && core.supportsETH(w)) wallet = w;
+    if (w instanceof xdefi.XDeFiHDWallet && core.supportsETH(w)) wallet = w;
     else fail("Wallet is not XDeFi");
   });
 

--- a/packages/hdwallet-keepkey/src/keepkey.ts
+++ b/packages/hdwallet-keepkey/src/keepkey.ts
@@ -15,10 +15,6 @@ import { Transport } from "./transport";
 import { messageTypeRegistry } from "./typeRegistry";
 import { protoFieldToSetMethod, translateInputScriptType } from "./utils";
 
-export function isKeepKey(wallet: core.HDWallet): wallet is KeepKeyHDWallet {
-  return _.isObject(wallet) && (wallet as any)._isKeepKey;
-}
-
 function describeETHPath(path: core.BIP32Path): core.PathDescription {
   let pathStr = core.addressNListToBIP32(path);
   let unknown: core.PathDescription = {
@@ -618,24 +614,15 @@ export class KeepKeyHDWallet implements core.HDWallet, core.BTCWallet, core.ETHW
   readonly _supportsRippleInfo = true;
   readonly _supportsBinanceInfo = true;
   readonly _supportsEosInfo = true;
-  readonly _supportsFioInfo = false;
   readonly _supportsDebugLink: boolean;
-  readonly _isKeepKey = true;
   readonly _supportsETH = true;
   readonly _supportsBTC = true;
   _supportsCosmos = true;
   _supportsRipple = true;
   _supportsBinance = true;
   _supportsEos = true;
-  readonly _supportsFio = false;
   readonly _supportsThorchainInfo = true;
   readonly _supportsThorchain = true;
-  readonly _supportsSecretInfo = false;
-  readonly _supportsSecret = false;
-  readonly _supportsKava = false;
-  readonly _supportsKavaInfo = false;
-  readonly _supportsTerra = false;
-  readonly _supportsTerraInfo = false;
 
   transport: Transport;
   features?: Messages.Features.AsObject;

--- a/packages/hdwallet-ledger/src/ledger.ts
+++ b/packages/hdwallet-ledger/src/ledger.ts
@@ -6,10 +6,6 @@ import * as eth from "./ethereum";
 import { LedgerTransport } from "./transport";
 import { coinToLedgerAppName, handleError } from "./utils";
 
-export function isLedger(wallet: core.HDWallet): wallet is LedgerHDWallet {
-  return _.isObject(wallet) && (wallet as any)._isLedger;
-}
-
 function describeETHPath(path: core.BIP32Path): core.PathDescription {
   let pathStr = core.addressNListToBIP32(path);
   let unknown: core.PathDescription = {
@@ -290,8 +286,6 @@ export class LedgerHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
   readonly _supportsBTCInfo = true;
   readonly _supportsBTC = true;
   readonly _supportsETH = true;
-
-  _isLedger: boolean = true;
 
   transport: LedgerTransport;
   info: LedgerHDWalletInfo & core.HDWalletInfo;

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -13,10 +13,6 @@ class MetaMaskTransport extends core.Transport {
   }
 }
 
-export function isMetaMask(wallet: core.HDWallet): wallet is MetaMaskHDWallet {
-  return _.isObject(wallet) && (wallet as any)._isMetaMask;
-}
-
 type HasNonTrivialConstructor<T> = T extends { new (): any } ? never : T;
 
 export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
@@ -32,7 +28,6 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
   readonly _supportsBinance = false;
   readonly _supportsDebugLink = false;
   readonly _isPortis = false;
-  readonly _isMetaMask = true;
   readonly _supportsRippleInfo = false;
   readonly _supportsRipple = false;
   readonly _supportsEosInfo = false;

--- a/packages/hdwallet-native/src/adapter.ts
+++ b/packages/hdwallet-native/src/adapter.ts
@@ -33,12 +33,12 @@ export class NativeAdapter {
     if (!wallet && deviceId) {
       // If a wallet with that ID hasn't been added to the keychain, then create it
       wallet = await native.create({ deviceId });
-      if (!native.isNative(wallet)) throw new Error("expected native wallet");
+      if (!(wallet instanceof native.NativeHDWallet)) throw new Error("expected native wallet");
       this.keyring.add(wallet, deviceId);
       this.keyring.decorateEvents(deviceId, wallet.events);
     }
 
-    if (wallet && native.isNative(wallet)) {
+    if (wallet && wallet instanceof native.NativeHDWallet) {
       const id = await wallet.getDeviceID();
       this.keyring.emit([wallet.getVendor(), id, core.Events.CONNECT], id);
 

--- a/packages/hdwallet-native/src/native.test.ts
+++ b/packages/hdwallet-native/src/native.test.ts
@@ -271,11 +271,6 @@ describe("NativeHDWallet", () => {
     expect(mock).toHaveBeenCalled();
   });
 
-  it("should work with isNative", () => {
-    const wallet = native.create({ deviceId: "native" });
-    expect(native.isNative(wallet)).toBe(true);
-  });
-
   it("should respond to .ping()", async () => {
     const wallet = native.create({ deviceId: "native" });
     expect(await wallet.ping({ msg: "pong" })).toEqual({ msg: "pong" });

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -213,7 +213,6 @@ export class NativeHDWallet
   readonly _supportsSecret = true;
   readonly _supportsTerra = true;
   readonly _supportsKava = true;
-  readonly _isNative = true;
 
   #deviceId: string;
   #initialized: boolean = false;
@@ -390,10 +389,6 @@ export class NativeHDWallet
   async disconnect(): Promise<void> {
     await this.wipe();
   }
-}
-
-export function isNative(wallet: core.HDWallet): wallet is NativeHDWallet {
-  return _.isObject(wallet) && (wallet as any)._isNative;
 }
 
 export function info() {

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -17,10 +17,6 @@ class PortisTransport extends core.Transport {
   }
 }
 
-export function isPortis(wallet: core.HDWallet): wallet is PortisHDWallet {
-  return _.isObject(wallet) && (wallet as any)._isPortis;
-}
-
 type HasNonTrivialConstructor<T> = T extends { new (): any } ? never : T;
 export type Portis = InstanceType<HasNonTrivialConstructor<typeof Portis>>;
 
@@ -29,7 +25,6 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
   readonly _supportsETHInfo = true;
   readonly _supportsBTCInfo = true;
   readonly _supportsBTC = true;
-  readonly _isPortis = true;
 
   transport: core.Transport = new PortisTransport(new core.Keyring());
 

--- a/packages/hdwallet-trezor/src/trezor.ts
+++ b/packages/hdwallet-trezor/src/trezor.ts
@@ -6,10 +6,6 @@ import * as Btc from "./bitcoin";
 import * as Eth from "./ethereum";
 import { TrezorTransport } from "./transport";
 
-export function isTrezor(wallet: core.HDWallet): wallet is TrezorHDWallet {
-  return _.isObject(wallet) && (wallet as any)._isTrezor;
-}
-
 function describeETHPath(path: core.BIP32Path): core.PathDescription {
   let pathStr = core.addressNListToBIP32(path);
   let unknown: core.PathDescription = {
@@ -264,7 +260,6 @@ export class TrezorHDWallet implements core.HDWallet, core.BTCWallet, core.ETHWa
   readonly _supportsETH = true;
   readonly _supportsKavaInfo = true;
   readonly _supportsTerraInfo = true;
-  readonly _isTrezor = true;
 
   transport: TrezorTransport;
   featuresCache: any;

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -10,14 +10,9 @@ class XDeFiTransport extends core.Transport {
   public async call(...args: any[]): Promise<any> {}
 }
 
-export function isXDeFi(wallet: core.HDWallet): wallet is XDeFiHDWallet {
-  return _.isObject(wallet) && (wallet as any)._isXDeFi;
-}
-
 export class XDeFiHDWallet implements core.HDWallet, core.ETHWallet {
   readonly _supportsETH = true;
   readonly _supportsETHInfo = true;
-  readonly _isXDeFi = true;
 
   transport: core.Transport = new XDeFiTransport(new core.Keyring());
   info: XDeFiHDWalletInfo & core.HDWalletInfo;


### PR DESCRIPTION
`instanceof` makes implementing new wallet types easier (and everything less messy)