### PR TITLE
add optional auth header to bridge

### DIFF
--- a/packages/hdwallet-keepkey-tcp/src/transport.ts
+++ b/packages/hdwallet-keepkey-tcp/src/transport.ts
@@ -12,7 +12,7 @@ export class TransportDelegate implements keepkey.TransportDelegate {
     this.config = {
       ...config,
       headers: {
-        'Authorization': config.apiKey,
+        'Authorization': config.headers.serviceKey,
         "content-type": "application/json",
         "Access-Control-Allow-Origin": config.baseURL,
       },

--- a/packages/hdwallet-keepkey-tcp/src/transport.ts
+++ b/packages/hdwallet-keepkey-tcp/src/transport.ts
@@ -12,7 +12,7 @@ export class TransportDelegate implements keepkey.TransportDelegate {
     this.config = {
       ...config,
       headers: {
-        'Authorization': config.headers.serviceKey,
+        'Authorization': config.headers.serviceKey || '',
         "content-type": "application/json",
         "Access-Control-Allow-Origin": config.baseURL,
       },

--- a/packages/hdwallet-keepkey-tcp/src/transport.ts
+++ b/packages/hdwallet-keepkey-tcp/src/transport.ts
@@ -12,6 +12,7 @@ export class TransportDelegate implements keepkey.TransportDelegate {
     this.config = {
       ...config,
       headers: {
+        'Authorization': config.apiKey,
         "content-type": "application/json",
         "Access-Control-Allow-Origin": config.baseURL,
       },

--- a/packages/hdwallet-keepkey-tcp/src/transport.ts
+++ b/packages/hdwallet-keepkey-tcp/src/transport.ts
@@ -12,7 +12,7 @@ export class TransportDelegate implements keepkey.TransportDelegate {
     this.config = {
       ...config,
       headers: {
-        'Authorization': config.headers.serviceKey || '',
+        'Authorization': config?.headers?.serviceKey || '',
         "content-type": "application/json",
         "Access-Control-Allow-Origin": config.baseURL,
       },


### PR DESCRIPTION
This adds an optional auth header to the tcp bridge. allows bridge applications to verify what applications are communicating with the device. 
