### PR TITLE
fix: strict gas price specification in ETHSignTx

### DIFF
--- a/integration/src/ethereum/ethereum.ts
+++ b/integration/src/ethereum/ethereum.ts
@@ -199,38 +199,6 @@ export function ethereumTests(get: () => { wallet: core.HDWallet; info: core.HDW
     );
 
     test(
-      "ethSignTx() - ETH EIP-1559 (optional)",
-      async () => {
-        if (!wallet) return;
-
-        if (!(await wallet.ethSupportsEIP1559())) {
-          return;
-        }
-
-        const res = await wallet.ethSignTx({
-          addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
-          nonce: "0x01",
-          gasPrice: "0x1dcd65000",
-          gasLimit: "0x5622",
-          maxFeePerGas: "",
-          maxPriorityFeePerGas: "",
-          value: "0x2c68af0bb14000",
-          to: "0x12eC06288EDD7Ae2CC41A843fE089237fC7354F0",
-          chainId: 1,
-          data: "",
-        });
-        expect(res).toEqual({
-          r: "0x63db3dd3bf3e1fe7dde1969c0fc8850e34116d0b501c0483a0e08c0f77b8ce0a",
-          s: "0x28297d012cccf389f6332415e96ee3fc0bbf8474d05f646e029cd281a031464b",
-          v: 38,
-          serialized:
-            "0xf86b018501dcd650008256229412ec06288edd7ae2cc41a843fe089237fc7354f0872c68af0bb140008026a063db3dd3bf3e1fe7dde1969c0fc8850e34116d0b501c0483a0e08c0f77b8ce0aa028297d012cccf389f6332415e96ee3fc0bbf8474d05f646e029cd281a031464b",
-        });
-      },
-      TIMEOUT
-    );
-
-    test(
       "ethSignTx() - ERC20",
       async () => {
         if (!wallet) return;

--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -31,19 +31,13 @@ export interface ETHGetAddress {
   showDisplay?: boolean;
 }
 
-export interface ETHSignTx {
+export type ETHSignTx = {
   /** bip32 path to sign the transaction from */
   addressNList: BIP32Path;
   /** big-endian hex, prefixed with '0x' */
   nonce: string;
   /** big-endian hex, prefixed with '0x' */
-  gasPrice?: string;
-  /** big-endian hex, prefixed with '0x' */
   gasLimit: string;
-  /** EIP-1559 - The maximum total fee per gas the sender is willing to pay. <=256 bit unsigned big endian (in wei) */
-  maxFeePerGas?: string;
-  /** EIP-1559 - Maximum fee per gas the sender is willing to pay to miners. <=256 bit unsigned big endian (in wei) */
-  maxPriorityFeePerGas?: string;
   /** address, with '0x' prefix */
   to: string;
   /** bip32 path for destination (device must `ethSupportsSecureTransfer()`) */
@@ -58,7 +52,21 @@ export interface ETHSignTx {
    * Device must `ethSupportsNativeShapeShift()`
    */
   exchangeType?: ExchangeType;
-}
+} & (
+  | {
+      /** big-endian hex, prefixed with '0x' */
+      gasPrice: string;
+      maxFeePerGas?: never;
+      maxPriorityFeePerGas?: never;
+    }
+  | {
+      gasPrice?: never;
+      /** EIP-1559 - The maximum total fee per gas the sender is willing to pay. <=256 bit unsigned big endian (in wei) */
+      maxFeePerGas?: string;
+      /** EIP-1559 - Maximum fee per gas the sender is willing to pay to miners. <=256 bit unsigned big endian (in wei) */
+      maxPriorityFeePerGas?: string;
+    }
+);
 
 export interface ETHTxHash {
   hash: string;

--- a/packages/hdwallet-xdefi/src/ethereum.test.ts
+++ b/packages/hdwallet-xdefi/src/ethereum.test.ts
@@ -98,9 +98,9 @@ describe("XDeFi - Ethereum Adapter", () => {
       {
         addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
         nonce: "0xDEADBEEF",
-        gasPrice: "0xDEADBEEF",
         gasLimit: "0xDEADBEEF",
         maxFeePerGas: "0xDEADBEEF",
+        maxPriorityFeePerGas: "0xDEADBEEF",
         to: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
         value: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
         data: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF",

--- a/packages/hdwallet-xdefi/src/xdefi.test.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.test.ts
@@ -164,9 +164,9 @@ describe("XDeFiHDWallet", () => {
     const hash = await wallet.ethSendTx({
       addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
       nonce: "0xDEADBEEF",
-      gasPrice: "0xDEADBEEF",
       gasLimit: "0xDEADBEEF",
       maxFeePerGas: "0xDEADBEEF",
+      maxPriorityFeePerGas: "0xDEADBEEF",
       to: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
       value: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
       data: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF",


### PR DESCRIPTION
Fixes #478. Compatble with, but not required for, https://github.com/shapeshift/lib/pull/440 and https://github.com/shapeshift/web/pull/1182.