### PR TITLE
Remove circleci deprecated message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ orbs:
     executors:
       node:
         docker:
-          - image: cimg/node:16.0
+          - image: cimg/node:16.14
       kkemu:
         docker:
-          - image: cimg/node:16.0
+          - image: cimg/node:16.14
           - image: kktech/kkemu:latest
     jobs:
       build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ orbs:
         environment:
           JEST_JUNIT_OUTPUT: "test-results/js-test-results.xml"
         steps:
-          - run: sudo apt-get install libudev-dev libusb-dev libusb-1.0
+          - run: sudo apt-get update && sudo apt-get install libudev-dev libusb-dev libusb-1.0 libtool
           - checkout
           - run:
               name: Authenticate with registry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ orbs:
     executors:
       node:
         docker:
-          - image: circleci/node:16
+          - image: cimg/node:16
       kkemu:
         docker:
-          - image: circleci/node:16
+          - image: cimg/node:16
           - image: kktech/kkemu:latest
     jobs:
       build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,10 @@ orbs:
     executors:
       node:
         docker:
-          - image: cimg/node:16
+          - image: cimg/node:16.0
       kkemu:
         docker:
-          - image: cimg/node:16
+          - image: cimg/node:16.0
           - image: kktech/kkemu:latest
     jobs:
       build:


### PR DESCRIPTION
This is the PR aiming to fix the issue #469 by removing deprecated messages from the docker images being used.