### PR TITLE
research: use CosmosDirect isolation adapter for terra/kava/secret/thorchain

### DIFF
--- a/integration/src/kava/kava.ts
+++ b/integration/src/kava/kava.ts
@@ -87,8 +87,15 @@ export function kavaTests(get: () => { wallet: core.HDWallet; info: core.HDWalle
             //not supported yet
             //expect(res?.signatures?.[0].signature).toEqual(tx_signed.signatures[0].signature_keepkey);
             break;
+          case "Native":
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(res?.signatures[0]).toMatchInlineSnapshot(
+              `"O57vU8gOY03l/YD5LzMf0QZ3k8LXmpNtit8Iof1IR9Q9qWvvFPx74HNQnKekq31ePoYgXKmx/NwShGikOEgMZQ=="`
+            );
+            break;
           default:
-            expect(res?.signatures?.[0].signature).toEqual(tx_signed.signatures[0].signature);
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(res?.signatures[0]).toEqual(tx_signed.signatures[0].signature);
             break;
         }
       },

--- a/integration/src/secret/secret.ts
+++ b/integration/src/secret/secret.ts
@@ -78,20 +78,24 @@ export function secretTests(get: () => { wallet: core.HDWallet; info: core.HDWal
           tx: tx_unsigned as any,
           addressNList: core.bip32ToAddressNList("m/44'/529'/0'/0/0"),
           chain_id: tx_verbose.accountInfo.chainId,
-          // @ts-ignore
-          account_number: tx_verbose.accountInfo.accountNumber,
-          // @ts-ignore
-          sequence: tx_verbose.accountInfo.sequence,
+          account_number: String(tx_verbose.accountInfo.accountNumber),
+          sequence: String(tx_verbose.accountInfo.sequence),
         };
 
-        const res = await wallet.secretSignTx(input);
         switch (wallet.getVendor()) {
-          case "KeepKey":
-            //expect(res?.signatures?.[0].signature).toEqual(tx_signed.tx.signatures[0].signature_keepkey);
+          case "Native": {
+            // eslint-disable-next-line jest/no-conditional-expect
+            await expect(wallet.secretSignTx(input)).rejects.toThrowErrorMatchingInlineSnapshot(
+              `"Cannot read properties of undefined (reading 'map')"`
+            );
             break;
-          default:
-            expect(res?.signatures?.[0].signature).toEqual(tx_signed.signatures[0].signature);
+          }
+          default: {
+            const res = await wallet.secretSignTx(input);
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(res?.signatures[0]).toEqual(tx_signed.signatures[0].signature);
             break;
+          }
         }
       },
       TIMEOUT

--- a/integration/src/terra/terra.ts
+++ b/integration/src/terra/terra.ts
@@ -81,8 +81,21 @@ export function terraTests(get: () => { wallet: core.HDWallet; info: core.HDWall
           sequence: "0",
         };
 
-        const res = await wallet.terraSignTx(input);
-        expect(res?.signatures?.[0].signature).toEqual(tx_signed.signatures[0].signature);
+        switch (wallet.getVendor()) {
+          case "KeepKey": {
+            const res = await wallet.terraSignTx(input);
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect(res?.signatures[0]).toEqual(tx_signed.signatures[0].signature);
+            break;
+          }
+          default: {
+            // eslint-disable-next-line jest/no-conditional-expect
+            await expect(wallet.terraSignTx(input)).rejects.toThrowErrorMatchingInlineSnapshot(
+              `"Unhandled tx type! type: bank/MsgSend"`
+            );
+            break;
+          }
+        }
       },
       TIMEOUT
     );

--- a/integration/src/thorchain/thorchain.ts
+++ b/integration/src/thorchain/thorchain.ts
@@ -84,9 +84,21 @@ export function thorchainTests(get: () => { wallet: core.HDWallet; info: core.HD
           sequence: "2",
         };
 
-        const res = await wallet.thorchainSignTx(input);
-        expect(res?.signatures?.[0].signature).toEqual(tx_signed.signatures[0].signature);
-
+        switch (wallet.getVendor()) {
+          case "KeepKey": {
+            const res = await wallet.thorchainSignTx(input);
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect((res?.signatures[0] as any).signature).toEqual(tx_signed.signatures[0].signature);
+            break;
+          }
+          default: {
+            // eslint-disable-next-line jest/no-conditional-expect
+            await expect(wallet.thorchainSignTx(input)).rejects.toThrowErrorMatchingInlineSnapshot(
+              `"Unhandled tx type! type: thorchain/MsgSend"`
+            );
+            break;
+          }
+        }
       },
       TIMEOUT
     );
@@ -103,9 +115,23 @@ export function thorchainTests(get: () => { wallet: core.HDWallet; info: core.HD
           sequence: "4",
         };
 
-        const res = await wallet.thorchainSignTx(input);
-        expect(res?.signatures?.[0].signature).toEqual(tx_signed_swap.signatures[0].signature)
-
+        switch (wallet.getVendor()) {
+          case "KeepKey": {
+            const res = await wallet.thorchainSignTx(input);
+            // eslint-disable-next-line jest/no-conditional-expect
+            expect((res?.signatures[0] as any).signature).toMatchInlineSnapshot(
+              `"ZRRXwAGESNaon0pYE1GZjU1qGsCXZkpKZJpdkAicNyN7J7ywDoGjsVD/lNhrKyrmCj51wmH3unOW7NFi+jcJXw=="`
+            );
+            break;
+          }
+          default: {
+            // eslint-disable-next-line jest/no-conditional-expect
+            await expect(wallet.thorchainSignTx(input)).rejects.toThrowErrorMatchingInlineSnapshot(
+              `"Unhandled tx type! type: thorchain/MsgDeposit"`
+            );
+            break;
+          }
+        }
       },
       TIMEOUT
     );

--- a/packages/hdwallet-core/src/kava.ts
+++ b/packages/hdwallet-core/src/kava.ts
@@ -59,10 +59,14 @@ export interface KavaSignTx {
   account_number: string;
   sequence: string;
   fee?: number;
-  testnet?: boolean;
 }
 
-export type KavaSignedTx = KavaTx;
+export interface KavaSignedTx {
+  serialized: string
+  body: string
+  authInfoBytes: string
+  signatures: string[]
+}
 
 export interface KavaGetAccountPaths {
   accountIdx: number;

--- a/packages/hdwallet-core/src/secret.ts
+++ b/packages/hdwallet-core/src/secret.ts
@@ -56,14 +56,17 @@ export interface SecretSignTx {
   addressNList: BIP32Path;
   tx: Secret.StdTx;
   chain_id: string;
-  account_number: number;
-  sequence: number;
+  account_number: string;
+  sequence: string;
   fee?: number;
-  gas?: number;
-  testnet?: boolean;
 }
 
-export type SecretSignedTx = SecretTx;
+export interface SecretSignedTx {
+  serialized: string
+  body: string
+  authInfoBytes: string
+  signatures: string[]
+}
 
 export interface SecretGetAccountPaths {
   accountIdx: number;

--- a/packages/hdwallet-core/src/terra.ts
+++ b/packages/hdwallet-core/src/terra.ts
@@ -44,7 +44,6 @@ export namespace Terra {
     memo: string;
   }
 }
-
 export interface TerraTx {
   msg: Terra.Msg[];
   fee: Terra.StdFee;
@@ -59,10 +58,14 @@ export interface TerraSignTx {
   account_number: string;
   sequence: string;
   fee?: number;
-  testnet?: boolean;
 }
 
-export type TerraSignedTx = TerraTx;
+export interface TerraSignedTx {
+  serialized: string
+  body: string
+  authInfoBytes: string
+  signatures: string[]
+}
 
 export interface TerraGetAccountPaths {
   accountIdx: number;

--- a/packages/hdwallet-core/src/thorchain.ts
+++ b/packages/hdwallet-core/src/thorchain.ts
@@ -55,14 +55,18 @@ export interface ThorchainTx {
 export interface ThorchainSignTx {
   addressNList: BIP32Path;
   tx: Thorchain.StdTx;
-  sequence: string;
-  account_number: string;
   chain_id: string;
+  account_number: string;
+  sequence: string;
   fee?: number;
-  testnet?: boolean;
 }
 
-export type ThorchainSignedTx = ThorchainTx;
+export interface ThorchainSignedTx {
+  serialized: string
+  body: string
+  authInfoBytes: string
+  signatures: string[]
+}
 
 export interface ThorchainGetAccountPaths {
   accountIdx: number;

--- a/packages/hdwallet-native/package.json
+++ b/packages/hdwallet-native/package.json
@@ -31,7 +31,6 @@
     "lodash": "^4.17.21",
     "node-fetch": "^2.6.1",
     "scrypt-js": "^3.0.1",
-    "tendermint-tx-builder": "^1.0.9",
     "tiny-secp256k1": "^1.1.6",
     "web-encoding": "^1.1.0"
   },

--- a/packages/hdwallet-native/src/cosmos.ts
+++ b/packages/hdwallet-native/src/cosmos.ts
@@ -7,8 +7,6 @@ import { NativeHDWalletBase } from "./native";
 import * as util from "./util";
 import * as Isolation from "./crypto/isolation";
 
-const ATOM_CHAIN = "cosmoshub-4";
-
 export function MixinNativeCosmosWalletInfo<TBase extends core.Constructor<core.HDWalletInfo>>(Base: TBase) {
   return class MixinNativeCosmosWalletInfo extends Base implements core.CosmosWalletInfo {
     readonly _supportsCosmosInfo = true;
@@ -77,7 +75,7 @@ export function MixinNativeCosmosWallet<TBase extends core.Constructor<NativeHDW
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "cosmos");
         const adapter = await Isolation.Adapters.CosmosDirect.create(keyPair.node,"cosmos");
-        const result = await protoTxBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, ATOM_CHAIN);
+        const result = await protoTxBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, msg.chain_id);
         return result
       });
     }

--- a/packages/hdwallet-native/src/kava.test.ts
+++ b/packages/hdwallet-native/src/kava.test.ts
@@ -38,9 +38,9 @@ describe("NativeKavaWallet", () => {
   });
 
   it("should generate a correct kava address", async () => {
-    await expect(
-      wallet.kavaGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/459'/0'/0/0") })
-    ).resolves.toBe("kava1x9eec99f6m9d0nc3my4uyw55jefkcxj8dwxcpu");
+    await expect(wallet.kavaGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/459'/0'/0/0") })).resolves.toBe(
+      "kava1x9eec99f6m9d0nc3my4uyw55jefkcxj8dwxcpu"
+    );
   });
 
   it("should generate another correct kava address", async () => {
@@ -49,29 +49,45 @@ describe("NativeKavaWallet", () => {
     ).resolves.toBe("kava1yhys0syftn2f624lue6fsxyql74r3evvljchjt");
   });
 
-  it("does not support signing transactions", async () => {
+  it("should (probably) support signing transactions", async () => {
+    // TODO: Replace with actual test data!
     const signed = await wallet.kavaSignTx({
       addressNList: core.bip32ToAddressNList("m/44'/459'/0'/0/0"),
       tx: {
-        msg: [{ type: "foo", value: "bar" }],
+        msg: [
+          {
+            type: "cosmos-sdk/MsgSend",
+            value: {
+              from_address: "kava1x9eec99f6m9d0nc3my4uyw55jefkcxj8dwxcpu",
+              to_address: "kava1yhys0syftn2f624lue6fsxyql74r3evvljchjt",
+              amount: [
+                {
+                  denom: "ukava",
+                  amount: "100000",
+                },
+              ],
+            },
+          },
+        ],
         fee: {
-          amount: [{ denom: "foo", amount: "bar" }],
-          gas: "baz",
+          amount: [
+            {
+              amount: "5000",
+              denom: "ukava",
+            },
+          ],
+          gas: "200000",
         },
         signatures: null,
-        memo: "foobar",
+        memo: "testmemo",
       },
       chain_id: "foobar",
-      account_number: "foo",
-      sequence: "bar",
-    })
-    expect(signed?.signatures?.length).toBe(1);
-    expect(signed?.signatures?.[0].pub_key?.value).toMatchInlineSnapshot(
-      `"AlW0vIrn08ANEFwNKufFfnoU/1pTSjyzo8SMlPKoit3V"`
+      account_number: "123",
+      sequence: "456",
+    });
+    await expect(signed?.signatures.length).toBe(1);
+    await expect(signed?.signatures[0]).toMatchInlineSnapshot(
+      `"X59d8usJrZTD8T9fVh/e+40DJ1+N6O4PzuSz2dIBNfcN3oB17ncj/KWWv29TwsO88DmFXy/dWvSTBJp29NWoqQ=="`
     );
-    expect(signed?.signatures?.[0].signature).toMatchInlineSnapshot(
-      `"77iUQFCVMfXvEj11YOEdMWOC4KDYxZzRz0WKzRFWnX18AwetdDh15be+iFsVgZ4RJFl2jj1JYoCGKrd9YN+Eew=="`
-    );
-
   });
 });

--- a/packages/hdwallet-native/src/kava.ts
+++ b/packages/hdwallet-native/src/kava.ts
@@ -1,7 +1,7 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
 import * as bech32 from "bech32";
 import CryptoJS from "crypto-js";
-import * as txBuilder from "tendermint-tx-builder";
+import * as protoTxBuilder from "@shapeshiftoss/proto-tx-builder";
 
 import { NativeHDWalletBase } from "./native";
 import * as util from "./util";
@@ -75,11 +75,9 @@ export function MixinNativeKavaWallet<TBase extends core.Constructor<NativeHDWal
     async kavaSignTx(msg: core.KavaSignTx): Promise<core.KavaSignedTx | null> {
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "kava");
-        // @TODO: This needs to be fixed after the change to tendermint serialization
-        // @ts-ignore
-        const adapter = await Isolation.Adapters.Cosmos.create(keyPair);
-        const result = await txBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, msg.chain_id);
-        return txBuilder.createSignedTx(msg.tx, result);
+        const adapter = await Isolation.Adapters.CosmosDirect.create(keyPair.node, "kava");
+        const result = await protoTxBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, msg.chain_id);
+        return result;
       });
     }
   };

--- a/packages/hdwallet-native/src/secret.test.ts
+++ b/packages/hdwallet-native/src/secret.test.ts
@@ -49,28 +49,45 @@ describe("NativeSecretWallet", () => {
     ).resolves.toBe("secret1wmmewcjt2s09r48ya8mtdfyy0rnnza20xnx6fs");
   });
 
-  it("should signing transactions", async () => {
+  it("should (probably) support signing transactions", async () => {
+    // TODO: Replace with actual test data!
     const signed = await wallet.secretSignTx({
       addressNList: core.bip32ToAddressNList("m/44'/529'/0'/0/0"),
       tx: {
-        msg: [{ type: "foo", value: "bar" }],
+        msg: [
+          {
+            type: "cosmos-sdk/MsgSend",
+            value: {
+              from_address: "secret189wrfk2fsynjlz6jcn54wzdcud3a6k8vqa0ggu",
+              to_address: "secret1wmmewcjt2s09r48ya8mtdfyy0rnnza20xnx6fs",
+              amount: [
+                {
+                  denom: "uscrt",
+                  amount: "100000",
+                },
+              ],
+            },
+          },
+        ],
         fee: {
-          amount: [{ denom: "foo", amount: "bar" }],
-          gas: "baz",
+          amount: [
+            {
+              amount: "100000",
+              denom: "uscrt",
+            },
+          ],
+          gas: "80000",
         },
         signatures: null,
-        memo: "foobar",
+        memo: "testmemo",
       },
       chain_id: "foobar",
-      account_number: 123,
-      sequence: 456,
-    })
-    expect(signed.signatures.length).toBe(1);
-    expect(signed.signatures[0].pub_key.value).toMatchInlineSnapshot(
-      `"A2UVKphVsesrnAQEtX4K+qk8Z84wa5xD5mxzdPykAiyR"`
-    );
-    expect(signed.signatures[0].signature).toMatchInlineSnapshot(
-      `"f4HKv09XvsGQn74y4MHL+M+wP/uBjHsIn5PwPfq7xMI7CJkS22Pxx7KlXpeUzCjiaSZvEEIuxbkd9J+Q4g86jg=="`
+      account_number: "123",
+      sequence: "456",
+    });
+    await expect(signed?.signatures.length).toBe(1);
+    await expect(signed?.signatures[0]).toMatchInlineSnapshot(
+      `"W7WaZZWVCnihaZxFS8ysWaFelsCuq6v3ufBy3h5SsosQ1srnbd6Dg47r/nP/Wnni6SUXrN8M8VyGGMCW+rqgig=="`
     );
   });
 });

--- a/packages/hdwallet-native/src/secret.ts
+++ b/packages/hdwallet-native/src/secret.ts
@@ -1,7 +1,7 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
 import * as bech32 from "bech32";
 import CryptoJS from "crypto-js";
-import * as txBuilder from "tendermint-tx-builder";
+import * as protoTxBuilder from "@shapeshiftoss/proto-tx-builder";
 
 import { NativeHDWalletBase } from "./native";
 import * as util from "./util";
@@ -71,13 +71,12 @@ export function MixinNativeSecretWallet<TBase extends core.Constructor<NativeHDW
       });
     }
 
-    async secretSignTx(msg: core.SecretSignTx): Promise<any | null> {
+    async secretSignTx(msg: core.SecretSignTx): Promise<core.SecretSignedTx | null> {
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "secret");
-        // @ts-ignore
-        const adapter = await Isolation.Adapters.Cosmos.create(keyPair);
-        const result = await txBuilder.sign(msg.tx, adapter, String(msg.sequence), String(msg.account_number), msg.chain_id);
-        return txBuilder.createSignedTx(msg.tx, result);
+        const adapter = await Isolation.Adapters.CosmosDirect.create(keyPair.node, "secret");
+        const result = await protoTxBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, msg.chain_id);
+        return result;
       });
     }
   };

--- a/packages/hdwallet-native/src/terra.test.ts
+++ b/packages/hdwallet-native/src/terra.test.ts
@@ -38,9 +38,9 @@ describe("NativeTerraWallet", () => {
   });
 
   it("should generate a correct terra address", async () => {
-    await expect(
-      wallet.terraGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/330'/0'/0/0") })
-    ).resolves.toBe("terra1f95csal3u6cyyj23ept3x7ap3u247npf8u2yhz");
+    await expect(wallet.terraGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/330'/0'/0/0") })).resolves.toBe(
+      "terra1f95csal3u6cyyj23ept3x7ap3u247npf8u2yhz"
+    );
   });
 
   it("should generate another correct terra address", async () => {
@@ -49,28 +49,45 @@ describe("NativeTerraWallet", () => {
     ).resolves.toBe("terra153l3gzmg5xlr8aldndpcg7achjejre04azdf9q");
   });
 
-  it("does not support signing transactions", async () => {
+  it("should (probably) support signing transactions", async () => {
+    // TODO: Replace with actual test data!
     const signed = await wallet.terraSignTx({
       addressNList: core.bip32ToAddressNList("m/44'/330'/0'/0/0"),
       tx: {
-        msg: [{ type: "foo", value: "bar" }],
+        msg: [
+          {
+            type: "cosmos-sdk/MsgSend",
+            value: {
+              from_address: "terra1f95csal3u6cyyj23ept3x7ap3u247npf8u2yhz",
+              to_address: "terra153l3gzmg5xlr8aldndpcg7achjejre04azdf9q",
+              amount: [
+                {
+                  denom: "uluna",
+                  amount: "100000",
+                },
+              ],
+            },
+          },
+        ],
         fee: {
-          amount: [{ denom: "foo", amount: "bar" }],
-          gas: "baz",
+          amount: [
+            {
+              amount: "1404",
+              denom: "uluna",
+            },
+          ],
+          gas: "79695",
         },
         signatures: null,
-        memo: "foobar",
+        memo: "testmemo",
       },
       chain_id: "foobar",
-      account_number: "foo",
-      sequence: "bar",
-    })
-    expect(signed.signatures.length).toBe(1);
-    expect(signed.signatures[0].pub_key.value).toMatchInlineSnapshot(
-      `"A6cAUgKWL3/P3nQY+j2fMUBaAW/QC/FGmQzTJ4nqXo0E"`
-    );
-    expect(signed.signatures[0].signature).toMatchInlineSnapshot(
-      `"zUPR10sr2QwRa10fcb3z/KC6/mWuLq0iff5ImhylIJpqU1RSg49Jxbmvp07D3sWuY0fE5mcSdMWQXWJFw2zsWQ=="`
+      account_number: "123",
+      sequence: "456",
+    });
+    await expect(signed?.signatures.length).toBe(1);
+    await expect(signed?.signatures[0]).toMatchInlineSnapshot(
+      `"bco4/Uk+YDZVuMagS6TBB9hLggrcm6eM9NUSkq95++4v+jJF3CPO+SEOMXKf1ZnI6uZqGy5rFjZbcPnIPbxiFA=="`
     );
   });
 });

--- a/packages/hdwallet-native/src/thorchain.test.ts
+++ b/packages/hdwallet-native/src/thorchain.test.ts
@@ -49,28 +49,45 @@ describe("NativeThorchainWallet", () => {
     ).resolves.toBe("thor14hqwsy4qpwzsdk2l3h3q82eghg4ctaa38rx63g");
   });
 
-  it("should sign a transaction correctly", async () => {
+  it("should (probably) sign a transaction correctly", async () => {
+    // TODO: Replace with actual test data!
     const signed = await wallet.thorchainSignTx({
       addressNList: core.bip32ToAddressNList("m/44'/931'/0'/0/0"),
       tx: {
-        msg: [{ type: "foo", value: "bar" }],
+        msg: [
+          {
+            type: "cosmos-sdk/MsgSend",
+            value: {
+              from_address: "thor1ujumx36gj3jv33gcw49dfafdddza3kdcd38paq",
+              to_address: "thor14hqwsy4qpwzsdk2l3h3q82eghg4ctaa38rx63g",
+              amount: [
+                {
+                  denom: "rune",
+                  amount: "10000",
+                },
+              ],
+            },
+          },
+        ],
         fee: {
-          amount: [{ denom: "foo", amount: "bar" }],
-          gas: "baz",
+          amount: [
+            {
+              amount: "3000",
+              denom: "rune",
+            },
+          ],
+          gas: "200000",
         },
         signatures: null,
         memo: "foobar",
       },
       chain_id: "foobar",
-      account_number: "foo",
-      sequence: "bar",
+      account_number: "123",
+      sequence: "456",
     });
-    expect(signed?.signatures?.length).toBe(1);
-    expect(signed?.signatures?.[0].pub_key?.value).toMatchInlineSnapshot(
-      `"A1DSQ2pqr8D5di36Uj6M/sbvkSi7nMf/07yMwcBXyJHL"`
-    );
-    expect(signed?.signatures?.[0].signature).toMatchInlineSnapshot(
-      `"3fYykzgna7MWg9VLhsYwHMEF55ZHQEmefq5KOH0jRtNDOYc2K0J9ss3sts54i5I52sg5dA4aGC/yJuSDGUlUJQ=="`
+    await expect(signed?.signatures.length).toBe(1);
+    await expect(signed?.signatures[0]).toMatchInlineSnapshot(
+      `"ohaYKf+5qk5aFHu9SjbiGhKUZgqe4W1ZCJnr9IBpC194I+iDLYVkylYGTZKPJYJZNuu8nr6uVgyJkk9MoWn8Yw=="`
     );
   });
 });

--- a/packages/hdwallet-native/src/thorchain.ts
+++ b/packages/hdwallet-native/src/thorchain.ts
@@ -1,13 +1,11 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
 import * as bech32 from "bech32";
 import CryptoJS from "crypto-js";
-import * as txBuilder from "tendermint-tx-builder";
+import * as protoTxBuilder from "@shapeshiftoss/proto-tx-builder";
 
 import { NativeHDWalletBase } from "./native";
 import * as util from "./util";
 import * as Isolation from "./crypto/isolation";
-
-const THOR_CHAIN = "thorchain";
 
 export function MixinNativeThorchainWalletInfo<TBase extends core.Constructor<core.HDWalletInfo>>(Base: TBase) {
   return class MixinNativeThorchainWalletInfo extends Base implements core.ThorchainWalletInfo {
@@ -76,9 +74,9 @@ export function MixinNativeThorchainWallet<TBase extends core.Constructor<Native
     async thorchainSignTx(msg: core.ThorchainSignTx): Promise<core.ThorchainSignedTx | null> {
       return this.needsMnemonic(!!this.#masterKey, async () => {
         const keyPair = await util.getKeyPair(this.#masterKey!, msg.addressNList, "thorchain");
-        const adapter = await Isolation.Adapters.Cosmos.create(keyPair.node);
-        const result = await txBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, THOR_CHAIN);
-        return txBuilder.createSignedTx(msg.tx, result);
+        const adapter = await Isolation.Adapters.CosmosDirect.create(keyPair.node, "thor");
+        const result = await protoTxBuilder.sign(msg.tx, adapter, msg.sequence, msg.account_number, msg.chain_id);
+        return result;
       });
     }
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -946,28 +946,6 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bithighlander/bitcoin-cash-js-lib@^5.2.1":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@bithighlander/bitcoin-cash-js-lib/-/bitcoin-cash-js-lib-5.2.1.tgz#3153dec5774b0574a2347f6ca75cf3d7399af1b2"
-  integrity sha512-FaqmntBmeiLxwwCuc6n7kZCUi3ZT1b75tWxpduV3Rdw3pOx17cuptsBuay30YX4v/gnXvPkjO8AF0XsO4kn6IQ==
-  dependencies:
-    bech32 "^1.1.2"
-    big-integer "^1.6.44"
-    bip174 "^2.0.1"
-    bip32 "^2.0.4"
-    bip66 "^1.1.0"
-    bitcoin-ops "^1.4.0"
-    bs58check "^2.0.0"
-    create-hash "^1.1.0"
-    create-hmac "^1.1.3"
-    merkle-lib "^2.0.10"
-    pushdata-bitcoin "^1.0.1"
-    randombytes "^2.0.1"
-    tiny-secp256k1 "^1.1.1"
-    typeforce "^1.11.3"
-    varuint-bitcoin "^1.0.4"
-    wif "^2.0.1"
-
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"
@@ -2034,23 +2012,6 @@
     tar "^4.4.10"
     unique-filename "^1.1.1"
     which "^1.3.1"
-
-"@fioprotocol/fiojs@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@fioprotocol/fiojs/-/fiojs-1.0.1.tgz#81779437603741bc4ca1c76d119b64c4157a3874"
-  integrity sha512-+rxJ/ynUkox/DO3ihHPpAc//DDI+DQvrphLqwRKufw0atC3GKluGR2qMTeO45O0UjorvOIw6esuuG7NpbVUm8Q==
-  dependencies:
-    ajv "^6.10.2"
-    babel-runtime "6.26.0"
-    bigi "^1.4.2"
-    browserify-aes "^1.2.0"
-    bs58 "^4.0.1"
-    create-hash "^1.2.0"
-    create-hmac "^1.1.7"
-    ecurve "^1.0.6"
-    long "^4.0.0"
-    randombytes "^2.1.0"
-    text-encoding "0.7.0"
 
 "@iarna/toml@^2.2.0":
   version "2.2.5"
@@ -3552,42 +3513,6 @@
     tslib "^2.2.0"
     webcrypto-core "^1.2.0"
 
-"@pioneer-platform/loggerdog@^8.0.1", "@pioneer-platform/loggerdog@^8.1.17":
-  version "8.1.17"
-  resolved "https://registry.yarnpkg.com/@pioneer-platform/loggerdog/-/loggerdog-8.1.17.tgz#80ee228d60c3b686c13fa42e45094f21704db4d7"
-  integrity sha512-kibcRNY6yS/EOLRYIoBBMoG6GrRUvSx41sJatewBbq1gU1cG8FCl3zASQO68oeebQDqz56K5EMD8Jngrs/qEpQ==
-  dependencies:
-    "@types/node" "^13.13.12"
-    cli-color "^1.4.0"
-    dotenv "^8.2.0"
-    os "^0.1.1"
-    request "^2.88.2"
-    request-promise "^4.2.6"
-    ts-node "^8.10.2"
-    typescript "^3.9.5"
-
-"@pioneer-platform/pioneer-coins@^8.1.19":
-  version "8.1.42"
-  resolved "https://registry.yarnpkg.com/@pioneer-platform/pioneer-coins/-/pioneer-coins-8.1.42.tgz#6bcd8f985f6af237768972cf36ee38831c9276dd"
-  integrity sha512-tv8OEDoDxBLG4t8aBYZ/XzbgpWis71lDQMKOjeAPu+wA63xr0NqIMCpqeDxwH2WW9NqVHCOA9bOWM67qJI3W/g==
-  dependencies:
-    "@pioneer-platform/loggerdog" "^8.1.17"
-    bech32 "^1.1.4"
-    bignumber.js "^9.0.1"
-    bip84 "^0.2.5"
-    bitcoin-regex "^2.0.0"
-    bitcoincash-regex "^1.1.8"
-    bitcoinjs-lib "^5.2.0"
-    crypto-js "^4.0.0"
-    dash-regex "^1.0.10"
-    dogecoin-regex "^1.0.9"
-    ethereum-regex "^1.1.12"
-    ethereumjs-util "^7.0.10"
-    litecoin-regex "^1.0.8"
-    monero-regex "^1.0.8"
-    neo-regex "^1.0.7"
-    ripple-regex "^1.1.8"
-
 "@polkadot/networks@7.4.1", "@polkadot/networks@^7.2.1":
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-7.4.1.tgz#02b4a1a159e64b90a08d0f3a0206858b64846a3b"
@@ -3818,16 +3743,6 @@
     validate "^5.1.0"
     web-encoding "^1.1.0"
     wif "^2.0.6"
-
-"@shapeshiftoss/hdwallet-core@latest":
-  version "1.18.4"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.18.4.tgz#7272baa4b43de0fbb5e651d47cdeb9554f4ddd33"
-  integrity sha512-dnzh6EmicNVb4AZPjN3d00z04SqLvKAUMqEhLq9v/rUtY7yb8dcvw5vHCnLEtq3a+N4UkH6rDA33i/hMjTBhUQ==
-  dependencies:
-    eventemitter2 "^5.0.1"
-    lodash "^4.17.21"
-    rxjs "^6.4.0"
-    type-assertions "^1.1.0"
 
 "@shapeshiftoss/proto-tx-builder@^0.1.3":
   version "0.1.3"
@@ -4070,11 +3985,6 @@
   resolved "https://registry.yarnpkg.com/@types/eventsource/-/eventsource-1.1.6.tgz#1864655db707dc6c9490efe2cd96bfb7441cd2ee"
   integrity sha512-y4xcLJ+lcoZ6mN9ndSdKOWg24Nj5uQc4Z/NRdy3HbiGGt5hfH3RLwAXr6V+RzGzOljAk48a09n6iY4BMNumEng==
 
-"@types/fast-text-encoding@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/fast-text-encoding/-/fast-text-encoding-1.0.1.tgz#7a9e6d8dd2ac1fa70772b500a307c2620cec1fe3"
-  integrity sha512-DRFqoqjXfvuX3f5jIQKAQr/QzuFdNoHOtou0KQ9bzUJOreCciO7T/kFJHgEote7QusmgE1fTxsQSqNvXVR0GBw==
-
 "@types/glob@^7.1.1":
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
@@ -4220,7 +4130,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.16.tgz#1acf34f6456208f495dac0434dd540488d17f991"
   integrity sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==
 
-"@types/node@^13.13.12", "@types/node@^13.7.0":
+"@types/node@^13.7.0":
   version "13.13.52"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.52.tgz#03c13be70b9031baaed79481c0c0cfb0045e53f7"
   integrity sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==
@@ -4229,11 +4139,6 @@
   version "14.17.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.5.tgz#b59daf6a7ffa461b5648456ca59050ba8e40ed54"
   integrity sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==
-
-"@types/node@^15.0.2":
-  version "15.14.9"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.9.tgz#bc43c990c3c9be7281868bbc7b8fdd6e2b57adfa"
-  integrity sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==
 
 "@types/node@^8.0.54":
   version "8.10.66"
@@ -4684,7 +4589,7 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.21.3"
 
-ansi-regex@^2.0.0, ansi-regex@^2.1.1:
+ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
   integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
@@ -4778,11 +4683,6 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
-
-arg@^4.1.0:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
-  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -4934,7 +4834,7 @@ async-mutex@^0.2.6:
   dependencies:
     tslib "^2.0.0"
 
-async@^1.4.2, async@~1.5.2:
+async@^1.4.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
@@ -5353,31 +5253,12 @@ bip66@^1.1.0, bip66@^1.1.5:
   dependencies:
     safe-buffer "^5.0.1"
 
-bip84@^0.2.5:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/bip84/-/bip84-0.2.7.tgz#ed350a2fea02051b3048c411ccc344996d8fda29"
-  integrity sha512-qIBhY2ojC3iATFrpWw8FmNHPFGgjUEkbA4qnchZY6nzv2SAzKy5tmdg9JxVPJlpSfQXYn0hcbzjhEp0+G/Mvqw==
-  dependencies:
-    bip39 "^3.0.4"
-    bitcoinjs-lib "^5.0.3"
-    bs58check "^2.1.2"
-
 bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/bitcoin-ops/-/bitcoin-ops-1.4.1.tgz#e45de620398e22fd4ca6023de43974ff42240278"
   integrity sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow==
 
-bitcoin-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/bitcoin-regex/-/bitcoin-regex-2.0.0.tgz#af4fcc0bf09b3efe8a9339c7bf21c2dcb1524c19"
-  integrity sha1-r0/MC/CbPv6KkznHvyHC3LFSTBk=
-
-bitcoincash-regex@^1.1.8:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/bitcoincash-regex/-/bitcoincash-regex-1.1.9.tgz#09f1b0308aa81bc4971f79bb93c2300675d67da6"
-  integrity sha512-VthlTDYcqjUlnxLe0h3rK2X0umt314bSvDOFx/GJ+FJ64vbcCo58NZONpoO1MqYSRkSxroAYJN/qwq7oxZpt3A==
-
-bitcoinjs-lib@^5.0.3, bitcoinjs-lib@^5.1.6, bitcoinjs-lib@^5.2.0:
+bitcoinjs-lib@^5.1.6, bitcoinjs-lib@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-5.2.0.tgz#caf8b5efb04274ded1b67e0706960b93afb9d332"
   integrity sha512-5DcLxGUDejgNBYcieMIUfjORtUeNWl828VWLHJGVKZCb4zIS1oOySTUr0LGmcqJBQgTBz3bGbRQla4FgrdQEIQ==
@@ -6171,18 +6052,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cli-color@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-1.4.0.tgz#7d10738f48526824f8fe7da51857cb0f572fe01f"
-  integrity sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==
-  dependencies:
-    ansi-regex "^2.1.1"
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    memoizee "^0.4.14"
-    timers-ext "^0.1.5"
-
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -6283,16 +6152,6 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
-
-codeclimate-test-reporter@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/codeclimate-test-reporter/-/codeclimate-test-reporter-0.5.1.tgz#2fd517e1a7932b00b0aafffc8d1dfbe91d0443cf"
-  integrity sha512-XCzmc8dH+R4orK11BCg5pBbXc35abxq9sept4YvUFRkFl9zb9MIVRrCKENe6U1TKAMTgvGJmrYyHn0y2lerpmg==
-  dependencies:
-    async "~1.5.2"
-    commander "2.9.0"
-    lcov-parse "0.0.10"
-    request "~2.88.0"
 
 coininfo@^5.1.0:
   version "5.1.0"
@@ -6998,11 +6857,6 @@ dargs@^4.0.1:
   dependencies:
     number-is-nan "^1.0.0"
 
-dash-regex@^1.0.10:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/dash-regex/-/dash-regex-1.0.11.tgz#5596c8f09ec7b4a2e1f60fc09ac4c5ca76dbe4c7"
-  integrity sha512-sVf5KH7IzGZ47ykcukfPWNf2cvtEVWmOhWo/4W4uGOIKzZw7V2og3+FsiY1Gl4y59zITsUgYSzBf36kXMZaQXg==
-
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -7255,11 +7109,6 @@ diff-sequences@^27.0.6:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.0.6.tgz#3305cb2e55a033924054695cc66019fd7f8e5723"
   integrity sha512-ag6wfpBFyNXZ0p8pcuIDS//D8H062ZQJ3fzYxjpmeKjnz8W4pekL3AI8VohmyZmsWW2PWaHgjsmqR6L13101VQ==
 
-diff@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
-  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
-
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -7275,11 +7124,6 @@ dir-glob@^2.2.2:
   integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
   dependencies:
     path-type "^3.0.0"
-
-dogecoin-regex@^1.0.9:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/dogecoin-regex/-/dogecoin-regex-1.0.10.tgz#0cb93bec25c4f2ff2166fb1bac839e089434a6c7"
-  integrity sha512-6+9OO9AZnBv88L+utqhHdqdkcI70bnPyBU4Q0Kbi0OgFU1QXrBd/EOJw4+uxfSNn8BOefqWgUKbIceYyrtoWkg==
 
 dom-serializer@0:
   version "0.2.2"
@@ -7386,11 +7230,6 @@ dotenv@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-5.0.1.tgz#a5317459bd3d79ab88cff6e44057a6a3fbb1fcef"
   integrity sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==
-
-dotenv@^8.2.0:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
-  integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
 
 drbg.js@^1.0.1:
   version "1.0.1"
@@ -7624,7 +7463,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
+es5-ext@^0.10.35, es5-ext@^0.10.50:
   version "0.10.53"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
   integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
@@ -7638,7 +7477,7 @@ es6-error@^4.1.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-es6-iterator@^2.0.3, es6-iterator@~2.0.3:
+es6-iterator@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
   integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
@@ -7671,16 +7510,6 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   dependencies:
     d "^1.0.1"
     ext "^1.1.2"
-
-es6-weak-map@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
-  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.1"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -7943,11 +7772,6 @@ ethereum-cryptography@^0.1.3:
     secp256k1 "^4.0.1"
     setimmediate "^1.0.5"
 
-ethereum-regex@^1.1.12:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ethereum-regex/-/ethereum-regex-1.1.13.tgz#d33fed7f153d5858adf84fdcf05e8d5c20aa675c"
-  integrity sha512-Ey1UmHGkC5zgm5Wcw9ZxkaCszKC93FYqAYHc18tvIT0pPxaUnBOc+MxJBZI+9pZ/1BKMCqNx6L5mvw4J15nYIA==
-
 ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0"
@@ -8173,14 +7997,6 @@ ethjs-util@0.1.6, ethjs-util@^0.1.3:
   dependencies:
     is-hex-prefixed "1.0.0"
     strip-hex-prefix "1.0.0"
-
-event-emitter@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
 
 eventemitter2@^5.0.1:
   version "5.0.1"
@@ -8464,11 +8280,6 @@ fast-safe-stringify@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz#dc2af48c46cf712b683e849b2bbd446b32de936f"
   integrity sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==
 
-fast-text-encoding@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz#ec02ac8e01ab8a319af182dae2681213cfe9ce53"
-  integrity sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==
-
 fastparse@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
@@ -8593,19 +8404,6 @@ find-yarn-workspace-root@^2.0.0:
   integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
   dependencies:
     micromatch "^4.0.2"
-
-fiosdk-offline@^1.2.21:
-  version "1.2.21"
-  resolved "https://registry.yarnpkg.com/fiosdk-offline/-/fiosdk-offline-1.2.21.tgz#59d2ebe850f8ac3ba6da134450ff57263865e3e7"
-  integrity sha512-tUCOHNhlwyg3WE9AbbaCnLZ+bhtI+4bdnBD5LmF7zmjbtfX60aiYBiJWAsIHyC+YLMhg9SHGgJnqF/1RvbDpQg==
-  dependencies:
-    "@fioprotocol/fiojs" "1.0.1"
-    "@types/fast-text-encoding" "^1.0.1"
-    bip39 "^3.0.2"
-    fast-text-encoding "^1.0.3"
-    hdkey "^1.1.1"
-    validate "^5.1.0"
-    wif "^2.0.6"
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -9996,11 +9794,6 @@ is-potential-custom-element-name@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
-is-promise@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
-  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
-
 is-regex@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.3.tgz#d029f9aff6448b93ebbe3f33dac71511fdcbef9f"
@@ -11028,11 +10821,6 @@ kuler@^2.0.0:
   resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
   integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
 
-lcov-parse@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
-  integrity sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=
-
 leb128@^0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/leb128/-/leb128-0.0.5.tgz#84524a86ef7799fb3933ce41345f6490e27ac948"
@@ -11156,11 +10944,6 @@ lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
-
-litecoin-regex@^1.0.8:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/litecoin-regex/-/litecoin-regex-1.0.9.tgz#0e67b4f1aa50ab1fda2d2ecf32879bb24041cc7d"
-  integrity sha512-ytAS5XD0vMPUqTiifoueMCZhVLouyq/iOAG9hwfnQQwaRQy9xrgmvI//rsdIk+Qnfa02bJ0wLwDB4+yV1rNAjg==
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -11371,13 +11154,6 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
-  integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
-  dependencies:
-    es5-ext "~0.10.2"
-
 ltgt@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
@@ -11422,7 +11198,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x, make-error@^1.1.1:
+make-error@1.x:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -11530,20 +11306,6 @@ memdown@^1.0.0:
     inherits "~2.0.1"
     ltgt "~2.2.0"
     safe-buffer "~5.1.1"
-
-memoizee@^0.4.14:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
-  integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
-  dependencies:
-    d "^1.0.1"
-    es5-ext "^0.10.53"
-    es6-weak-map "^2.0.3"
-    event-emitter "^0.3.5"
-    is-promise "^2.2.2"
-    lru-queue "^0.1.0"
-    next-tick "^1.1.0"
-    timers-ext "^0.1.7"
 
 meow@^3.3.0:
   version "3.7.0"
@@ -11835,11 +11597,6 @@ modify-values@^1.0.0:
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-monero-regex@^1.0.8:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/monero-regex/-/monero-regex-1.0.9.tgz#4445e98a5d48d038b050fc25ff2e9155b989525c"
-  integrity sha512-4kUBp+a/DWmL/m/oVUQLJHe7BKvY4M3XoLtCnCBo/qbXH/FOD/umuttAMFoBTp/1imsYmvPtxxNYxdQY9T+DKg==
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -12026,16 +11783,6 @@ neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
-
-neo-regex@^1.0.7:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/neo-regex/-/neo-regex-1.0.8.tgz#5ee1d77fcc41f7ac91ddf0215673230e840de27d"
-  integrity sha512-opwHKu5/HjHP2kGssiUKb108rGkamAaVGBf9aDhSvpiyPhSLHCd9ED9tzg2rtGDbOozQL8RvmwssYahjlIFyNw==
-
-next-tick@1, next-tick@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
-  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 next-tick@~1.0.0:
   version "1.0.0"
@@ -12583,11 +12330,6 @@ os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
-
-os@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/os/-/os-0.1.2.tgz#f29a50c62908516ba42652de42f7038600cadbc2"
-  integrity sha512-ZoXJkvAnljwvc56MbvhtKVWmSkzV712k42Is2mA0+0KTSRakq5XXuXpjZjgAt9ctzl51ojhQWakQQpmOvXWfjQ==
 
 osenv@^0.1.4, osenv@^0.1.5:
   version "0.1.5"
@@ -14240,17 +13982,7 @@ request-promise-native@^1.0.5, request-promise-native@^1.0.7:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request-promise@^4.2.6:
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/request-promise/-/request-promise-4.2.6.tgz#7e7e5b9578630e6f598e3813c0f8eb342a27f0a2"
-  integrity sha512-HCHI3DJJUakkOr8fNoCc73E5nU5bqITjOYFMDrKHYOXWXrgD/SBaC7LjwuPymUprRyuF06UK7hd/lMHkmUXglQ==
-  dependencies:
-    bluebird "^3.5.0"
-    request-promise-core "1.1.4"
-    stealthy-require "^1.1.1"
-    tough-cookie "^2.3.3"
-
-request@^2.79.0, request@^2.85.0, request@^2.88.0, request@^2.88.2, request@~2.88.0:
+request@^2.79.0, request@^2.85.0, request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -14473,11 +14205,6 @@ ripple-lib@1.10.0:
     ripple-keypairs "^1.0.3"
     ripple-lib-transactionparser "0.8.2"
     ws "^7.2.0"
-
-ripple-regex@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ripple-regex/-/ripple-regex-1.1.8.tgz#7b9113e7c0be7470efea482a8f4b9ea25f8dec37"
-  integrity sha512-8KdXWuN8ofXP1dSzp89mkf/V465bPpO+jny1/Wp+hlvA05u+m7YX2mjBamefkRco8l5FdicX6+HhoP6yS9PXEw==
 
 rlp@^2.0.0, rlp@^2.2.3, rlp@^2.2.4:
   version "2.2.6"
@@ -15010,14 +14737,6 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
-
-source-map-support@^0.5.17:
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
-  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
 
 source-map-support@^0.5.6, source-map-support@~0.5.10, source-map-support@~0.5.19:
   version "0.5.19"
@@ -15643,21 +15362,6 @@ temp-write@^3.4.0:
     temp-dir "^1.0.0"
     uuid "^3.0.1"
 
-tendermint-tx-builder@^1.0.9:
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/tendermint-tx-builder/-/tendermint-tx-builder-1.0.16.tgz#85271682b655771c85e6148b5590226d9af946fd"
-  integrity sha512-QooHyd5BeyoqruneSzmDUUpyD1/U877mEDMLPRk/e2SvobZuALJWijQReny0hqTkukseQpIZNKMD4ypMa1pCaQ==
-  dependencies:
-    "@bithighlander/bitcoin-cash-js-lib" "^5.2.1"
-    "@pioneer-platform/loggerdog" "^8.0.1"
-    "@pioneer-platform/pioneer-coins" "^8.1.19"
-    "@shapeshiftoss/hdwallet-core" latest
-    "@types/node" "^15.0.2"
-    bip39 "^3.0.4"
-    codeclimate-test-reporter "^0.5.1"
-    fiosdk-offline "^1.2.21"
-    google-protobuf "^3.17.0"
-
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -15692,11 +15396,6 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
-
-text-encoding@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
 text-extensions@^1.0.0:
   version "1.9.0"
@@ -15766,14 +15465,6 @@ timers-browserify@^2.0.4:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
-
-timers-ext@^0.1.5, timers-ext@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
-  integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
-  dependencies:
-    es5-ext "~0.10.46"
-    next-tick "1"
 
 timsort@^0.3.0:
   version "0.3.0"
@@ -15979,17 +15670,6 @@ ts-jest@^26.5.5:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-node@^8.10.2:
-  version "8.10.2"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.10.2.tgz#eee03764633b1234ddd37f8db9ec10b75ec7fb8d"
-  integrity sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==
-  dependencies:
-    arg "^4.1.0"
-    diff "^4.0.1"
-    make-error "^1.1.1"
-    source-map-support "^0.5.17"
-    yn "3.1.1"
-
 tslib@^1.10.0, tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -16150,11 +15830,6 @@ typeforce@^1.11.3, typeforce@^1.11.5:
   version "1.18.0"
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
-
-typescript@^3.9.5:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@^4.2.4, typescript@^4.3.2:
   version "4.3.5"
@@ -17402,11 +17077,6 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
-
-yn@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
-  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 zcash-bitcore-lib@^0.13.20-rc3:
   version "0.13.20-rc3"


### PR DESCRIPTION
Fixes #409 (or it would, if it was complete). This is lacking a few things like:
- `proto-tx-builder` support for `bank/MsgSend` (terra)
- `proto-tx-builder` support for `thorchain/MsgSend` and `thorchain/MsgDeposit`
- valid test data
- harmonization of KK and native behavior (specifically, we don't have an API to specify signature type so they use different modes ATM)