### PR TITLE
fix: lowercase checksummed address in ethGetAddress()

### DIFF
--- a/packages/hdwallet-keepkey/src/ethereum.ts
+++ b/packages/hdwallet-keepkey/src/ethereum.ts
@@ -193,7 +193,7 @@ export async function ethGetAddress(transport: Transport, msg: core.ETHGetAddres
   else if (ethAddress.hasAddress()) address = "0x" + core.toHexString(ethAddress.getAddress_asU8());
   else throw new Error("Unable to obtain ETH address from device.");
 
-  return address;
+  return address.toLowerCase();
 }
 
 export async function ethSignMessage(transport: Transport, msg: core.ETHSignMessage): Promise<core.ETHSignedMessage> {

--- a/packages/hdwallet-native/src/ethereum.test.ts
+++ b/packages/hdwallet-native/src/ethereum.test.ts
@@ -48,7 +48,7 @@ describe("NativeETHWallet", () => {
 
   it("should generate a correct ethereum address", async () => {
     expect(await wallet.ethGetAddress({ addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0") })).toBe(
-      "0x73d0385F4d8E00C5e6504C6030F47BF6212736A8"
+      "0x73d0385f4d8e00c5e6504c6030f47bf6212736a8"
     );
   });
 

--- a/packages/hdwallet-native/src/ethereum.ts
+++ b/packages/hdwallet-native/src/ethereum.ts
@@ -66,7 +66,12 @@ export function MixinNativeETHWallet<TBase extends core.Constructor<NativeHDWall
       if (!_.isEqual(msg.addressNList, core.bip32ToAddressNList("m/44'/60'/0'/0/0"))) {
         throw new Error("path not supported");
       }
-      return this.needsMnemonic(!!this.#ethSigner, () => this.#ethSigner!.getAddress());
+      return this.needsMnemonic(!!this.#ethSigner, async () => {
+        const address = await this.#ethSigner!.getAddress()
+        if (!address) return address
+
+        return address.toLowerCase()
+      });
     }
 
     async ethSignTx(msg: core.ETHSignTx): Promise<core.ETHSignedTx | null> {

--- a/packages/hdwallet-portis/src/portis.ts
+++ b/packages/hdwallet-portis/src/portis.ts
@@ -292,7 +292,11 @@ export class PortisHDWallet implements core.HDWallet, core.ETHWallet, core.BTCWa
   public async _ethGetAddress(): Promise<string> {
     if (this.ethAddress) return this.ethAddress;
 
-    const out: string = (await (await this.web3).eth.getAccounts())[0];
+    // https://web3js.readthedocs.io/en/v1.2.11/web3-eth.html#note-on-checksum-addresses
+    // web3.eth.getAccounts() returns us checksum addresses, with mixed upper/lowercase
+    // We need to lowercase the addresses for consistency with other wallets
+    const outCheksum: string = (await (await this.web3).eth.getAccounts())[0];
+    const out = outCheksum ? outCheksum.toLowerCase() : ''
     this.ethAddress = out;
     return out;
   }


### PR DESCRIPTION
## Description

This fixes addresses being returned as checksum addresses by Portis, KeepKey, and Native wallets.

This is a discrepancy from Metamask hdwallet, which methods return the lowercase version of an address, and as a result:

- There is a visual discrepancy across the app in how addresses are displayed, depending on the used wallet and where in the app you are
- When getting the CAIP19 for an address, we get the CAIP19 for the cheksummed version, which is the correct behavior since the `asset_id`/`asset_type` parts are case-sensitive ([docs](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-19.md#syntax)). 
Because of this, we are getting different CAIP19s across web which results in a bug when trying to compare account specifiers with the current account ID:

https://github.com/shapeshift/web/blob/ad806dee305535434440679906f1d74f130a8fa4/src/pages/Accounts/AccountToken/AccountToken.tsx#L28

### Risk

I fixed this at the root level rather than throwing `.toLowerCase()` everywhere.

There is a risk that lowercase addresses are not supported everywhere, but since e.g the Metamask hdwallet uses these (by making an ethereum JsonRPC [`eth_account`](https://eth.wiki/json-rpc/API#eth_accounts) call which returns the lowercased version, that is supported in unchained) this shouldn't be an issue.

@mrnerdhair WDYT, do we want to keep the chesksum addresses in hdwallet since it's a lower-level package, or is it fine to lowercase them? If we want to keep them as is, we will:

1. Need to find a way to implement the same behavior in metamask hdwallet for consistency, since the JsonRPC endpoint gives us the lowercase version
2. Need to move the lowercasing logic to chain-adapters, or one level more, in web.

### Testing

No testing steps here until the dependency is bumped in `chain-adapters` and the `chain-adapters` dependency is bumped in `web`. 