### PR TITLE
chore: add effort and sponsor to bounty template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bounty.yml
+++ b/.github/ISSUE_TEMPLATE/bounty.yml
@@ -39,6 +39,18 @@ body:
           required: true
         - label: As the sponsor of this bounty I will review the changes in a preview environment (ops/product) or review the PR (engineering)
           required: true
+  - type: input
+    id: estimate
+    attributes:
+      label: Estimated effort
+      description: "Estimated effort to complete the bounty, in hours or days"
+      placeholder: "Half a day"
+  - type: input
+    id: stakeholder
+    attributes:
+      label: Sponsor / Stakeholder
+      description: "To whom can the bounty hunter go to for questions and support?"
+      placeholder: "github_handle or discord_handle"
   - type: textarea
     id: need-by-date
     attributes:


### PR DESCRIPTION
Bring the `hdwallet` bounty template in line with `web` by adding effort and sponsor inputs.

<img width="385" alt="Screen Shot 2022-03-26 at 7 06 55 pm" src="https://user-images.githubusercontent.com/97164662/160230703-73639ab5-1ddb-40e7-8a7b-9cc67f627fd7.png">

