### PR TITLE
build v1-legacy branch in circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,3 +77,4 @@ workflows:
             branches:
               only:
                 - master
+                - v1-legacy


### PR DESCRIPTION
This is required to publish the new v1-legacy fork for use in beta/mobile.