### PR TITLE
chore(hdwallet-metamask): remove unused HasNonTrivialConstructor type

### DIFF
--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -17,8 +17,6 @@ export function isMetaMask(wallet: core.HDWallet): wallet is MetaMaskHDWallet {
   return _.isObject(wallet) && (wallet as any)._isMetaMask;
 }
 
-type HasNonTrivialConstructor<T> = T extends { new (): any } ? never : T;
-
 export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
   readonly _supportsETH = true;
   readonly _supportsETHInfo = true;


### PR DESCRIPTION
Spotted in https://github.com/shapeshift/hdwallet/pull/506#discussion_r844993457