### PR TITLE
remove unused adapter.initialize() return value from the public API

### DIFF
--- a/packages/hdwallet-keepkey/src/adapter.ts
+++ b/packages/hdwallet-keepkey/src/adapter.ts
@@ -95,7 +95,7 @@ export class Adapter<DelegateType extends AdapterDelegate<any>> {
     devices?: Array<DeviceType<DelegateType>>,
     tryDebugLink?: boolean,
     autoConnect?: boolean
-  ): Promise<number> {
+  ): Promise<void> {
     devices = devices ?? (await this.getDevices());
     for (const device of devices) {
       const { serialNumber } = await this.inspectDevice(device);
@@ -112,7 +112,6 @@ export class Adapter<DelegateType extends AdapterDelegate<any>> {
       if (autoConnect) await wallet.initialize();
       this.keyring.add(wallet, serialNumber);
     }
-    return Object.keys(this.keyring.wallets).length;
   }
 
   async getDevice(serialNumber?: string): Promise<DeviceType<DelegateType>> {

--- a/packages/hdwallet-ledger-webhid/src/adapter.ts
+++ b/packages/hdwallet-ledger-webhid/src/adapter.ts
@@ -71,7 +71,7 @@ export class WebHIDLedgerAdapter {
   }
 
   // without unique device identifiers, we should only ever have one HID ledger device on the keyring at a time
-  public async initialize(device?: HIDDevice): Promise<number> {
+  public async initialize(device?: HIDDevice): Promise<void> {
     device = device ?? (await getFirstLedgerDevice()) ?? undefined;
 
     if (device) {
@@ -83,8 +83,6 @@ export class WebHIDLedgerAdapter {
 
       this.keyring.add(wallet, MOCK_SERIAL_NUMBER);
     }
-
-    return Object.keys(this.keyring.wallets).length;
   }
 
   public async pairDevice(): Promise<ledger.LedgerHDWallet> {

--- a/packages/hdwallet-ledger-webusb/src/adapter.ts
+++ b/packages/hdwallet-ledger-webusb/src/adapter.ts
@@ -71,7 +71,7 @@ export class WebUSBLedgerAdapter {
   }
 
   // without unique device identifiers, we should only ever have one ledger device on the keyring at a time
-  public async initialize(usbDevice?: USBDevice): Promise<number> {
+  public async initialize(usbDevice?: USBDevice): Promise<void> {
     const device = usbDevice ?? (await getFirstLedgerDevice());
 
     if (device) {
@@ -85,8 +85,6 @@ export class WebUSBLedgerAdapter {
 
       this.keyring.add(wallet, device.serialNumber);
     }
-
-    return Object.keys(this.keyring.wallets).length;
   }
 
   public async pairDevice(): Promise<ledger.LedgerHDWallet> {

--- a/packages/hdwallet-metamask/src/adapter.ts
+++ b/packages/hdwallet-metamask/src/adapter.ts
@@ -18,9 +18,8 @@ export class MetaMaskAdapter {
     return new MetaMaskAdapter(keyring);
   }
 
-  public async initialize(): Promise<number> {
-    return Object.keys(this.keyring.wallets).length;
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public async initialize(): Promise<void> {}
 
   public async pairDevice(): Promise<MetaMaskHDWallet> {
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });

--- a/packages/hdwallet-native/src/adapter.test.ts
+++ b/packages/hdwallet-native/src/adapter.test.ts
@@ -7,7 +7,7 @@ describe("NativeAdapter", () => {
   it("creates a unique wallet per deviceId", async () => {
     const keyring = new core.Keyring();
     const adapter = NativeAdapter.useKeyring(keyring);
-    expect(await adapter.initialize()).toBe(0);
+    await adapter.initialize();
     const wallet = await adapter.pairDevice("foobar");
     expect(wallet).toBeInstanceOf(NativeHDWallet);
     expect(await adapter.pairDevice("foobar")).toBe(wallet);

--- a/packages/hdwallet-native/src/adapter.ts
+++ b/packages/hdwallet-native/src/adapter.ts
@@ -27,9 +27,8 @@ export class NativeAdapter {
     return new NativeAdapter(keyring);
   }
 
-  async initialize(): Promise<number> {
-    return 0;
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  async initialize(): Promise<void> {}
 
   async pairDevice(deviceId: string): Promise<native.NativeHDWallet | null> {
     let wallet: core.HDWallet | null = this.keyring.get(deviceId);

--- a/packages/hdwallet-portis/src/adapter.ts
+++ b/packages/hdwallet-portis/src/adapter.ts
@@ -24,9 +24,8 @@ export class PortisAdapter {
     return new PortisAdapter(keyring, args);
   }
 
-  public async initialize(): Promise<number> {
-    return Object.keys(this.keyring.wallets).length;
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public async initialize(): Promise<void> {}
 
   public async pairDevice(): Promise<PortisHDWallet> {
     try {

--- a/packages/hdwallet-trezor-connect/src/adapter.ts
+++ b/packages/hdwallet-trezor-connect/src/adapter.ts
@@ -143,7 +143,7 @@ export class TrezorAdapter {
     this.connectCacheFeatures(event);
   }
 
-  public async initialize(devices?: TrezorDevice[]): Promise<number> {
+  public async initialize(devices?: TrezorDevice[]): Promise<void> {
     const init = await _initialization;
     if (!init) throw new Error("Could not initialize TrezorAdapter: TrezorConnect not initialized");
 
@@ -162,7 +162,6 @@ export class TrezorAdapter {
       await wallet.initialize();
       this.keyring.add(wallet, device.deviceID);
     }
-    return Object.keys(this.keyring.wallets).length;
   }
 
   public async pairDevice(): Promise<trezor.TrezorHDWallet> {

--- a/packages/hdwallet-xdefi/src/adapter.test.ts
+++ b/packages/hdwallet-xdefi/src/adapter.test.ts
@@ -7,7 +7,7 @@ describe("XDeFiAdapter", () => {
   it("throws error if provider is not preset", async () => {
     const keyring = new core.Keyring();
     const adapter = XDeFiAdapter.useKeyring(keyring);
-    expect(await adapter.initialize()).toBe(0);
+    await adapter.initialize();
     await expect(async () => await adapter.pairDevice()).rejects.toThrowError("XDeFi provider not found");
   });
   it("creates a unique wallet per deviceId", async () => {
@@ -17,7 +17,7 @@ describe("XDeFiAdapter", () => {
     const keyring = new core.Keyring();
     const adapter = XDeFiAdapter.useKeyring(keyring);
     const add = jest.spyOn(adapter.keyring, "add");
-    expect(await adapter.initialize()).toBe(0);
+    await adapter.initialize();
     const wallet = await adapter.pairDevice();
     expect(wallet).toBeInstanceOf(XDeFiHDWallet);
     expect(add).toBeCalled();

--- a/packages/hdwallet-xdefi/src/adapter.ts
+++ b/packages/hdwallet-xdefi/src/adapter.ts
@@ -16,9 +16,8 @@ export class XDeFiAdapter {
     return new XDeFiAdapter(keyring);
   }
 
-  public async initialize(): Promise<number> {
-    return Object.keys(this.keyring.wallets).length;
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public async initialize(): Promise<void> {}
 
   public async pairDevice(): Promise<XDeFiHDWallet> {
     const provider: any = (globalThis as any).xfi?.ethereum;


### PR DESCRIPTION
Neither webv2 nor axiom uses the return value from `adapter.initialize()`; removing it from the API would reduce the complexity of the boilerplate new wallet implementations (xdefi, tally, keplr, etc) have to cut-n-paste.

(This is a suggestion to change a core part of the API. It should not be merged until consensus is reached on if it's a good idea or not, so it's a draft until we have that conversation.)