### PR TITLE
chore: remove unused `currentDeviceID` field from `MetaMaskAdapter`

### DIFF
--- a/packages/hdwallet-metamask/src/adapter.ts
+++ b/packages/hdwallet-metamask/src/adapter.ts
@@ -7,9 +7,6 @@ import { MetaMaskHDWallet } from "./metamask";
 export class MetaMaskAdapter {
   keyring: core.Keyring;
 
-  // wallet id to remove from the keyring when the active wallet changes
-  currentDeviceID?: string;
-
   private constructor(keyring: core.Keyring) {
     this.keyring = keyring;
   }
@@ -39,7 +36,6 @@ export class MetaMaskAdapter {
     await wallet.initialize();
     const deviceID = await wallet.getDeviceID();
     this.keyring.add(wallet, deviceID);
-    this.currentDeviceID = deviceID;
     this.keyring.emit(["MetaMask", deviceID, core.Events.CONNECT], deviceID);
 
     return wallet;


### PR DESCRIPTION
This field was inherited from the copy-n-paste of `PortisAdapter`. It served a purpose there -- namely, `PortisAdapter` would detect a user logging out from Portis and remove the wallet from the keyring -- but it doesn't do anything in `MetaMaskAdapter`.