### PR TITLE
chore: publish hdwallet-keepkey-nodehid

### DIFF
--- a/packages/hdwallet-keepkey-nodehid/package.json
+++ b/packages/hdwallet-keepkey-nodehid/package.json
@@ -2,7 +2,9 @@
   "name": "@shapeshiftoss/hdwallet-keepkey-nodehid",
   "version": "1.20.0",
   "license": "MIT",
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "main": "dist/index.js",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",

--- a/packages/hdwallet-keepkey/package.json
+++ b/packages/hdwallet-keepkey/package.json
@@ -20,6 +20,7 @@
     "@keepkey/device-protocol": "^7.8.1",
     "@shapeshiftoss/bitcoinjs-lib": "5.2.0-shapeshift.2",
     "@shapeshiftoss/hdwallet-core": "1.20.0",
+    "@shapeshiftoss/proto-tx-builder": "^0.1.3",
     "bignumber.js": "^9.0.1",
     "bnb-javascript-sdk-nobroadcast": "^2.16.14",
     "crypto-js": "^4.0.0",


### PR DESCRIPTION
We need this package to update the KK updater.