### PR TITLE
kk-nodewebusb: remove strict product id check

### DIFF
--- a/packages/hdwallet-keepkey-nodewebusb/src/transport.ts
+++ b/packages/hdwallet-keepkey-nodewebusb/src/transport.ts
@@ -11,7 +11,6 @@ export class TransportDelegate implements keepkey.TransportDelegate {
 
   constructor(usbDevice: Device) {
     if (usbDevice.vendorId !== VENDOR_ID) throw new core.WebUSBCouldNotPair("KeepKey", "bad vendor id");
-    if (usbDevice.productId !== WEBUSB_PRODUCT_ID) throw new core.FirmwareUpdateRequired("KeepKey", "6.1.0");
     this.usbDevice = usbDevice;
   }
 


### PR DESCRIPTION
Turns out that `hdwallet-keepkey-nodewebusb` is perfectly capable of superceding `hdwallet-keepkey-nodehid` entirely; the WebUSB *API* can be used to communicate with any device, even HID devices, as long as the "browser" lets you. Removing this check will enable HID device references manually passed in via `adapter.pairRawDevice()` to work, hopefully paving the way for the removal of `hdwallet-keepkey-nodehid` from the keepkey updater (and, in the future, hopefully from hdwallet entirely).