### PR TITLE
fix: correct metamask experimental API accessor

### DIFF
--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -132,7 +132,7 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
   }
 
   public async isLocked(): Promise<boolean> {
-    return !this.provider.metamask.isUnlocked();
+    return !this.provider._metamask.isUnlocked();
   }
 
   public getVendor(): string {


### PR DESCRIPTION
While testing web release v1.7.0 (https://github.com/shapeshift/web/pull/1730), we've found a regression in https://github.com/shapeshift/web/pull/1667

The `wallet.isUnlocked()` promise silently failed since rejections for it are unhandled in web, but when debugging it, I found out that `provider.metamask` was undefined in this method:

https://github.com/shapeshift/hdwallet/blob/24f238d2cd9feeb64135e97ab99b91228757ca69/packages/hdwallet-metamask/src/metamask.ts#L134-L136

The reason to that is that Metamask's experimental API uses `_metamask` as an accessor, whereas we use `metamask`.
Changing this to `_metamask` fixed the regressed PR and makes the `isLocked` method great again.
