### PR TITLE
fix: hdwallet-tallyho version

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -27,7 +27,7 @@
     "lerna": "^3.22.1",
     "msw": "^0.27.1",
     "ts-jest": "^26.5.5",
-    "typescript": "^4.2.4",
+    "typescript": "^4.3.2",
     "whatwg-fetch": "^3.6.2"
   }
 }

--- a/packages/hdwallet-tallyho/package.json
+++ b/packages/hdwallet-tallyho/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/hdwallet-tallyho",
-  "version": "1.19.0",
+  "version": "1.21.2",
   "license": "MIT",
   "publishConfig": {
     "access": "public"
@@ -14,7 +14,7 @@
     "prepublishOnly": "yarn clean && yarn build"
   },
   "dependencies": {
-    "@shapeshiftoss/hdwallet-core": "1.19.0",
+    "@shapeshiftoss/hdwallet-core": "1.21.2",
     "lodash": "^4.17.21",
     "tallyho-onboarding": "^1.0.2"
   },

--- a/packages/hdwallet-tallyho/src/ethereum.test.ts
+++ b/packages/hdwallet-tallyho/src/ethereum.test.ts
@@ -92,7 +92,6 @@ describe("Tally Ho - Ethereum Adapter", () => {
       {
         addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
         nonce: "0xDEADBEEF",
-        gasPrice: "0xDEADBEEF",
         gasLimit: "0xDEADBEEF",
         maxFeePerGas: "0xDEADBEEF",
         to: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",

--- a/packages/hdwallet-tallyho/src/tallyho.test.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.test.ts
@@ -158,7 +158,6 @@ describe("TallyHoHDWallet", () => {
     const hash = await wallet.ethSendTx({
       addressNList: core.bip32ToAddressNList("m/44'/60'/0'/0/0"),
       nonce: "0xDEADBEEF",
-      gasPrice: "0xDEADBEEF",
       gasLimit: "0xDEADBEEF",
       maxFeePerGas: "0xDEADBEEF",
       to: "0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3887,16 +3887,6 @@
     web-encoding "^1.1.0"
     wif "^2.0.6"
 
-"@shapeshiftoss/hdwallet-core@1.19.0":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.19.0.tgz#7eeae9be9f90fff53887611c6ac02c334781baa3"
-  integrity sha512-Dht99dolYQLDuunKsyQXuNcZH20MrgNrIcb4qG2XLrwuwMUsUOXguQ0MBxi6fFl81hz3G8481v83gOYA5L5tGw==
-  dependencies:
-    eventemitter2 "^5.0.1"
-    lodash "^4.17.21"
-    rxjs "^6.4.0"
-    type-assertions "^1.1.0"
-
 "@shapeshiftoss/hdwallet-core@latest":
   version "1.18.4"
   resolved "https://registry.yarnpkg.com/@shapeshiftoss/hdwallet-core/-/hdwallet-core-1.18.4.tgz#7272baa4b43de0fbb5e651d47cdeb9554f4ddd33"
@@ -10686,10 +10676,10 @@ jest@^26.6.3:
     import-local "^3.0.2"
     jest-cli "^26.6.3"
 
-jose@^4.3.2:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-4.7.0.tgz#f0a88709285e1a6c1ba7df0d19e33f64aca03cad"
-  integrity sha512-DJNm2vlcVW+0Fhl5LVxdhXK5Nw5VYZvL79uiq3ZCRm6vqzTuEVT9T5lIRfzmkGbaaiV+edefGog25TWVyJ4mRQ==
+jose@^4.3.5:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.8.1.tgz#dc7c2660b115ba29b44880e588c5ac313c158247"
+  integrity sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==
 
 jquery@^3.4.1:
   version "3.6.0"
@@ -15738,7 +15728,7 @@ typescript@^3.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.3.2:
+typescript@^4.2.4, typescript@^4.3.2:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -10677,9 +10677,9 @@ jest@^26.6.3:
     jest-cli "^26.6.3"
 
 jose@^4.3.5:
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-4.8.1.tgz#dc7c2660b115ba29b44880e588c5ac313c158247"
-  integrity sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-4.3.5.tgz#890ec0b3bf26db0b36946ca54087335200deb6f7"
+  integrity sha512-mdTu3En79OYMGBNHw4828hl6ZUOb+gQtNZVRgM+eVL3Rrs4ZYUv/yHPpfDh65GN2HhKBvJsvA0/6tKEcpkyzeg==
 
 jquery@^3.4.1:
   version "3.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15728,7 +15728,7 @@ typescript@^3.9.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
-typescript@^4.2.4, typescript@^4.3.2:
+typescript@^4.3.2:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
   integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==


### PR DESCRIPTION
Update version to match the rest of hdwallet.

Update version of `hdwallet-core` that's required.