### PR TITLE
feat: add ethGetChainId method

### DIFF
--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -111,7 +111,7 @@ export interface ETHWalletInfo extends HDWalletInfo {
    * Get the current chainId from ethereum's JSON RPC
    * https://eips.ethereum.org/EIPS/eip-695
    */
-  ethGetChainId?(): Promise<number>;
+  ethGetChainId?(): Promise<number | null>;
 
   /**
    * Does the device support internal transfers without the user needing to

--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -108,6 +108,12 @@ export interface ETHWalletInfo extends HDWalletInfo {
   ethSupportsNetwork(chain_id: number): Promise<boolean>;
 
   /**
+   * Get the current chainId from ethereum's JSON RPC
+   * https://eips.ethereum.org/EIPS/eip-695
+   */
+  ethGetChainId?(): Promise<number | void>;
+
+  /**
    * Does the device support internal transfers without the user needing to
    * confirm the destination address?
    */

--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -111,7 +111,7 @@ export interface ETHWalletInfo extends HDWalletInfo {
    * Get the current chainId from ethereum's JSON RPC
    * https://eips.ethereum.org/EIPS/eip-695
    */
-  ethGetChainId?(): Promise<number | void>;
+  ethGetChainId?(): Promise<number>;
 
   /**
    * Does the device support internal transfers without the user needing to

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -250,12 +250,16 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
     return chainId === 1;
   }
 
-  public async ethGetChainId(): Promise<number> {
-    // at this point, we know that we're in the context of a valid MetaMask provider
-    const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
-    // chainId as hex string
-    const chainId: string = await provider.request({ method: "eth_chainId" });
-    return parseInt(chainId, 16);
+  public async ethGetChainId(): Promise<number | null> {
+    try {
+      const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
+      // chainId as hex string
+      const chainId: string = await provider.request({ method: "eth_chainId" });
+      return parseInt(chainId, 16);
+    } catch (e) {
+      console.error(e);
+      return null;
+    }
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -1,3 +1,4 @@
+import detectEthereumProvider from "@metamask/detect-provider";
 import * as core from "@shapeshiftoss/hdwallet-core";
 import _ from "lodash";
 
@@ -70,6 +71,16 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
 
   public async ethSupportsNetwork(chainId = 1): Promise<boolean> {
     return chainId === 1;
+  }
+
+  public async ethGetChainId(): Promise<number> {
+    const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
+    if (!provider) {
+      throw new Error("Cannot get chainId");
+    }
+    // chainId as hex string
+    const chainId: string = provider.request({ method: "eth_chainId" });
+    return parseInt(chainId, 16);
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
@@ -247,6 +258,16 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
 
   public async ethSupportsNetwork(chainId = 1): Promise<boolean> {
     return chainId === 1;
+  }
+
+  public async ethGetChainId(): Promise<number> {
+    const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
+    if (!provider) {
+      throw new Error("Cannot get chainId");
+    }
+    // chainId as hex string
+    const chainId: string = provider.request({ method: "eth_chainId" });
+    return parseInt(chainId, 16);
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -74,10 +74,8 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
   }
 
   public async ethGetChainId(): Promise<number> {
+    // at this point, we know that we're in the context of a valid MetaMask provider
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
-    if (!provider) {
-      throw new Error("Cannot get chainId");
-    }
     // chainId as hex string
     const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);
@@ -261,10 +259,8 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
   }
 
   public async ethGetChainId(): Promise<number> {
+    // at this point, we know that we're in the context of a valid MetaMask provider
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
-    if (!provider) {
-      throw new Error("Cannot get chainId");
-    }
     // chainId as hex string
     const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -1,4 +1,3 @@
-import detectEthereumProvider from "@metamask/detect-provider";
 import * as core from "@shapeshiftoss/hdwallet-core";
 import _ from "lodash";
 
@@ -252,9 +251,8 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
 
   public async ethGetChainId(): Promise<number | null> {
     try {
-      const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
       // chainId as hex string
-      const chainId: string = await provider.request({ method: "eth_chainId" });
+      const chainId: string = await this.provider.request({ method: "eth_chainId" });
       return parseInt(chainId, 16);
     } catch (e) {
       console.error(e);

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -73,14 +73,6 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
     return chainId === 1;
   }
 
-  public async ethGetChainId(): Promise<number> {
-    // at this point, we know that we're in the context of a valid MetaMask provider
-    const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
-    // chainId as hex string
-    const chainId: string = await provider.request({ method: "eth_chainId" });
-    return parseInt(chainId, 16);
-  }
-
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return false;
   }

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -79,7 +79,7 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
       throw new Error("Cannot get chainId");
     }
     // chainId as hex string
-    const chainId: string = provider.request({ method: "eth_chainId" });
+    const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);
   }
 
@@ -266,7 +266,7 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
       throw new Error("Cannot get chainId");
     }
     // chainId as hex string
-    const chainId: string = provider.request({ method: "eth_chainId" });
+    const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);
   }
 

--- a/packages/hdwallet-tallyho/src/adapter.ts
+++ b/packages/hdwallet-tallyho/src/adapter.ts
@@ -3,11 +3,11 @@ import TallyHoOnboarding from "tallyho-onboarding";
 
 import { TallyHoHDWallet } from "./tallyho";
 
-export interface TallyHoEthereumProvider {
+interface TallyHoEthereumProvider {
   isTally?: boolean;
 }
 
-export interface Window {
+interface Window {
   ethereum?: TallyHoEthereumProvider;
 }
 

--- a/packages/hdwallet-tallyho/src/adapter.ts
+++ b/packages/hdwallet-tallyho/src/adapter.ts
@@ -3,11 +3,11 @@ import TallyHoOnboarding from "tallyho-onboarding";
 
 import { TallyHoHDWallet } from "./tallyho";
 
-interface TallyHoEthereumProvider {
+export interface TallyHoEthereumProvider {
   isTally?: boolean;
 }
 
-interface Window {
+export interface Window {
   ethereum?: TallyHoEthereumProvider;
 }
 

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -102,12 +102,10 @@ export class TallyHoHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInf
     });
   }
 
-  public async ethGetChainId(): Promise<number | void> {
+  public async ethGetChainId(): Promise<number> {
+    // at this point, we know that we're in the context of a valid TallyHo provider
     const provider: any = await this.detectTallyProvider();
     // chainId as hex string
-    if (!provider) {
-      throw new Error("Cannot get chainId");
-    }
     const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);
   }
@@ -303,12 +301,10 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
     });
   }
 
-  public async ethGetChainId(): Promise<number | void> {
+  public async ethGetChainId(): Promise<number> {
+    // at this point, we know that we're in the context of a valid TallyHo provider
     const provider: any = await this.detectTallyProvider();
     // chainId as hex string
-    if (!provider) {
-      throw new Error("Cannot get chainId");
-    }
     const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);
   }

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -215,6 +215,11 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
     return chainId === 1;
   }
 
+  /*
+   * Tally works the same way as metamask.
+   * This code is copied from the @metamask/detect-provider package
+   * @see https://www.npmjs.com/package/@metamask/detect-provider
+   */
   private async detectTallyProvider(): Promise<TallyHoEthereumProvider | null> {
     let handled = false;
 

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -63,45 +63,6 @@ export class TallyHoHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInf
     return chainId === 1;
   }
 
-  private async detectTallyProvider(): Promise<TallyHoEthereumProvider | null> {
-    let handled = false;
-
-    return new Promise((resolve) => {
-      if ((window as Window).ethereum) {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        handleEthereum();
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        window.addEventListener("ethereum#initialized", handleEthereum, { once: true });
-
-        setTimeout(() => {
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          handleEthereum();
-        }, 3000);
-      }
-
-      function handleEthereum() {
-        if (handled) {
-          return;
-        }
-        handled = true;
-
-        window.removeEventListener("ethereum#initialized", handleEthereum);
-
-        const { ethereum } = window as Window;
-
-        if (ethereum && ethereum.isTally) {
-          resolve(ethereum as unknown as TallyHoEthereumProvider);
-        } else {
-          const message = ethereum ? "Non-TallyHo window.ethereum detected." : "Unable to detect window.ethereum.";
-
-          console.error("hdwallet-tallyho: ", message);
-          resolve(null);
-        }
-      }
-    });
-  }
-
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return false;
   }

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -108,7 +108,7 @@ export class TallyHoHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInf
     if (!provider) {
       throw new Error("Cannot get chainId");
     }
-    const chainId: string = provider.request({ method: "eth_chainId" });
+    const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);
   }
 
@@ -309,7 +309,7 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
     if (!provider) {
       throw new Error("Cannot get chainId");
     }
-    const chainId: string = provider.request({ method: "eth_chainId" });
+    const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);
   }
 

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -1,7 +1,6 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
 import _ from "lodash";
 
-import { TallyHoEthereumProvider, Window } from "./adapter";
 import * as eth from "./ethereum";
 
 export function isTallyHo(wallet: core.HDWallet): wallet is TallyHoHDWallet {
@@ -215,55 +214,10 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
     return chainId === 1;
   }
 
-  /*
-   * Tally works the same way as metamask.
-   * This code is copied from the @metamask/detect-provider package
-   * @see https://www.npmjs.com/package/@metamask/detect-provider
-   */
-  private async detectTallyProvider(): Promise<TallyHoEthereumProvider | null> {
-    let handled = false;
-
-    return new Promise((resolve) => {
-      if ((window as Window).ethereum) {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        handleEthereum();
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        window.addEventListener("ethereum#initialized", handleEthereum, { once: true });
-
-        setTimeout(() => {
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          handleEthereum();
-        }, 3000);
-      }
-
-      function handleEthereum() {
-        if (handled) {
-          return;
-        }
-        handled = true;
-
-        window.removeEventListener("ethereum#initialized", handleEthereum);
-
-        const { ethereum } = window as Window;
-
-        if (ethereum && ethereum.isTally) {
-          resolve(ethereum as unknown as TallyHoEthereumProvider);
-        } else {
-          const message = ethereum ? "Non-TallyHo window.ethereum detected." : "Unable to detect window.ethereum.";
-
-          console.error("hdwallet-tallyho: ", message);
-          resolve(null);
-        }
-      }
-    });
-  }
-
   public async ethGetChainId(): Promise<number | null> {
     try {
-      const provider: any = await this.detectTallyProvider();
       // chainId as hex string
-      const chainId: string = await provider.request({ method: "eth_chainId" });
+      const chainId: string = await this.provider.request({ method: "eth_chainId" });
       return parseInt(chainId, 16);
     } catch (e) {
       console.error(e);

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -254,12 +254,16 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
     });
   }
 
-  public async ethGetChainId(): Promise<number> {
-    // at this point, we know that we're in the context of a valid TallyHo provider
-    const provider: any = await this.detectTallyProvider();
-    // chainId as hex string
-    const chainId: string = await provider.request({ method: "eth_chainId" });
-    return parseInt(chainId, 16);
+  public async ethGetChainId(): Promise<number | null> {
+    try {
+      const provider: any = await this.detectTallyProvider();
+      // chainId as hex string
+      const chainId: string = await provider.request({ method: "eth_chainId" });
+      return parseInt(chainId, 16);
+    } catch (e) {
+      console.error(e);
+      return null;
+    }
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -102,14 +102,6 @@ export class TallyHoHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInf
     });
   }
 
-  public async ethGetChainId(): Promise<number> {
-    // at this point, we know that we're in the context of a valid TallyHo provider
-    const provider: any = await this.detectTallyProvider();
-    // chainId as hex string
-    const chainId: string = await provider.request({ method: "eth_chainId" });
-    return parseInt(chainId, 16);
-  }
-
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return false;
   }

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -1,4 +1,3 @@
-import detectEthereumProvider from "@metamask/detect-provider";
 import * as core from "@shapeshiftoss/hdwallet-core";
 import isObject from "lodash/isObject";
 
@@ -223,9 +222,8 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
 
   public async ethGetChainId(): Promise<number | null> {
     try {
-      const provider: any = await detectEthereumProvider({ mustBeMetaMask: false, silent: false, timeout: 3000 });
       // chainId as hex string
-      const chainId: string = await provider.request({ method: "eth_chainId" });
+      const chainId: string = await this.provider.request({ method: "eth_chainId" });
       return parseInt(chainId, 16);
     } catch (e) {
       console.error(e);

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -70,7 +70,7 @@ export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
       throw new Error("Cannot get chainId");
     }
     // chainId as hex string
-    const chainId: string = provider.request({ method: "eth_chainId" });
+    const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);
   }
 
@@ -237,7 +237,7 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
       throw new Error("Cannot get chainId");
     }
     // chainId as hex string
-    const chainId: string = provider.request({ method: "eth_chainId" });
+    const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);
   }
 

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -64,7 +64,7 @@ export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
     return chainId === 1;
   }
 
-  public async ethGetChainId(): Promise<number | void> {
+  public async ethGetChainId(): Promise<number> {
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: false, silent: false, timeout: 3000 });
     if (!provider) {
       throw new Error("Cannot get chainId");
@@ -232,10 +232,8 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
   }
 
   public async ethGetChainId(): Promise<number> {
+    // at this point, we know that we're in the context of a valid XDEFI provider
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: false, silent: false, timeout: 3000 });
-    if (!provider) {
-      throw new Error("Cannot get chainId");
-    }
     // chainId as hex string
     const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -66,9 +66,6 @@ export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
 
   public async ethGetChainId(): Promise<number> {
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: false, silent: false, timeout: 3000 });
-    if (!provider) {
-      throw new Error("Cannot get chainId");
-    }
     // chainId as hex string
     const chainId: string = await provider.request({ method: "eth_chainId" });
     return parseInt(chainId, 16);

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -1,3 +1,4 @@
+import detectEthereumProvider from "@metamask/detect-provider";
 import * as core from "@shapeshiftoss/hdwallet-core";
 import isObject from "lodash/isObject";
 
@@ -61,6 +62,16 @@ export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
 
   public async ethSupportsNetwork(chainId = 1): Promise<boolean> {
     return chainId === 1;
+  }
+
+  public async ethGetChainId(): Promise<number | void> {
+    const provider: any = await detectEthereumProvider({ mustBeMetaMask: false, silent: false, timeout: 3000 });
+    if (!provider) {
+      throw new Error("Cannot get chainId");
+    }
+    // chainId as hex string
+    const chainId: string = provider.request({ method: "eth_chainId" });
+    return parseInt(chainId, 16);
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {
@@ -218,6 +229,16 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
 
   public async ethSupportsNetwork(chainId = 1): Promise<boolean> {
     return chainId === 1;
+  }
+
+  public async ethGetChainId(): Promise<number> {
+    const provider: any = await detectEthereumProvider({ mustBeMetaMask: false, silent: false, timeout: 3000 });
+    if (!provider) {
+      throw new Error("Cannot get chainId");
+    }
+    // chainId as hex string
+    const chainId: string = provider.request({ method: "eth_chainId" });
+    return parseInt(chainId, 16);
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -64,13 +64,6 @@ export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
     return chainId === 1;
   }
 
-  public async ethGetChainId(): Promise<number> {
-    const provider: any = await detectEthereumProvider({ mustBeMetaMask: false, silent: false, timeout: 3000 });
-    // chainId as hex string
-    const chainId: string = await provider.request({ method: "eth_chainId" });
-    return parseInt(chainId, 16);
-  }
-
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return false;
   }

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -221,12 +221,16 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
     return chainId === 1;
   }
 
-  public async ethGetChainId(): Promise<number> {
-    // at this point, we know that we're in the context of a valid XDEFI provider
-    const provider: any = await detectEthereumProvider({ mustBeMetaMask: false, silent: false, timeout: 3000 });
-    // chainId as hex string
-    const chainId: string = await provider.request({ method: "eth_chainId" });
-    return parseInt(chainId, 16);
+  public async ethGetChainId(): Promise<number | null> {
+    try {
+      const provider: any = await detectEthereumProvider({ mustBeMetaMask: false, silent: false, timeout: 3000 });
+      // chainId as hex string
+      const chainId: string = await provider.request({ method: "eth_chainId" });
+      return parseInt(chainId, 16);
+    } catch (e) {
+      console.error(e);
+      return null;
+    }
   }
 
   public async ethSupportsSecureTransfer(): Promise<boolean> {


### PR DESCRIPTION
### Description
This adds an `ethGetChainId` method to `hdwallet-metamask`, `hdwallet-xdefi` and `hdwallet-tallyho` to be able to detect the current `chainId`.

Note: We currently are able to call `provider.chainId` and get the right chainId. It is working for MetaMask, XDEFI and Tally currently, however, this is both a deprecated as well as a non-standard property and we shouldn't be relying on it for all wallets that support ethereum JSONRPC calls: https://docs.metamask.io/guide/ethereum-provider.html#legacy-api

### Issue

Partially tackles https://github.com/shapeshift/web/issues/1843

### Screenshots

#### MetaMask:
 
Ethereum Mainnet: 

<img width="124" alt="image" src="https://user-images.githubusercontent.com/17035424/173092597-5f6ba5b3-a39f-48d3-97ce-aeab93c840d7.png">

Polygon Mainnet:

<img width="148" alt="image" src="https://user-images.githubusercontent.com/17035424/173092796-eddd3d33-5438-48e8-9710-97c08cdb5bc7.png">

Gnosis Chain:

<img width="147" alt="image" src="https://user-images.githubusercontent.com/17035424/173092883-12fdf6b8-2d46-4d58-bce7-6f70fb57ebf0.png">

### Tally 

Ethereum Mainnet:

<img width="133" alt="image" src="https://user-images.githubusercontent.com/17035424/173111568-dbfbf720-251f-491c-a372-81a0365bbddb.png">

Note: Tally currently only supports mainnet, but from what I can see on their codebase, other EVM networks supports is already partially implemented so it makes sense to add this for Tally as well. 

### XDEFI

Ethereum Mainnet:

<img width="130" alt="image" src="https://user-images.githubusercontent.com/17035424/173146480-19222f10-bb92-448e-ac12-ff7bf168ed3c.png">

Polygon Mainnet:

<img width="144" alt="image" src="https://user-images.githubusercontent.com/17035424/173146440-1d56f526-1617-48ef-9122-b55c9345a8a0.png">