### PR TITLE
feat: add ethSwitchChain method

### DIFF
--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -108,6 +108,12 @@ export interface ETHWalletInfo extends HDWalletInfo {
   ethSupportsNetwork(chain_id: number): Promise<boolean>;
 
   /**
+   * Switch the wallet's active Ethereum chain
+   * https://eips.ethereum.org/EIPS/eip-3326
+   */
+  ethSwitchChain(chain_id: number): Promise<void>;
+
+  /**
    * Does the device support internal transfers without the user needing to
    * confirm the destination address?
    */

--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -111,7 +111,7 @@ export interface ETHWalletInfo extends HDWalletInfo {
    * Switch the wallet's active Ethereum chain
    * https://eips.ethereum.org/EIPS/eip-3326
    */
-  ethSwitchChain(chain_id: number): Promise<void>;
+  ethSwitchChain?(chain_id: number): Promise<void>;
 
   /**
    * Does the device support internal transfers without the user needing to

--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -1,6 +1,13 @@
 import { addressNListToBIP32, slip44ByCoin } from "./utils";
 import { BIP32Path, ExchangeType, HDWallet, HDWalletInfo, PathDescription } from "./wallet";
 
+// https://github.com/MetaMask/eth-rpc-errors/blob/f917c2cfee9e6117a88be4178f2a877aff3acabe/src/classes.ts#L3-L7
+export interface SerializedEthereumRpcError {
+  code: number;
+  message: string;
+  stack?: string;
+}
+
 export enum ETHTransactionType {
   ETH_TX_TYPE_LEGACY = 0,
   ETH_TX_TYPE_EIP_2930 = 1,

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -5,12 +5,6 @@ import _ from "lodash";
 
 import * as eth from "./ethereum";
 
-// https://github.com/MetaMask/eth-rpc-errors/blob/f917c2cfee9e6117a88be4178f2a877aff3acabe/src/classes.ts#L3-L7
-interface SerializedEthereumRpcError {
-  code: number;
-  message: string;
-  stack?: string;
-}
 export function isMetaMask(wallet: core.HDWallet): wallet is MetaMaskHDWallet {
   return _.isObject(wallet) && (wallet as any)._isMetaMask;
 }
@@ -82,12 +76,12 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
 
   public async ethSwitchChain(chainId = 1): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
-    // at this point, we know that we're in the context of a valid MetaMask provider
     try {
+      // at this point, we know that we're in the context of a valid MetaMask provider
       const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
-      const error: SerializedEthereumRpcError = e;
+      const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.
@@ -274,12 +268,12 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
 
   public async ethSwitchChain(chainId = 1): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
-    // at this point, we know that we're in the context of a valid MetaMask provider
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     try {
+      // at this point, we know that we're in the context of a valid MetaMask provider
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
-      const error: SerializedEthereumRpcError = e;
+      const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -70,7 +70,7 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
     return undefined;
   }
 
-  public async ethSupportsNetwork(chainId = 1): Promise<boolean> {
+  public async ethSupportsNetwork(chainId: number): Promise<boolean> {
     return chainId === 1;
   }
 
@@ -251,7 +251,7 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
     return chainId === 1;
   }
 
-  public async ethSwitchChain(chainId = 1): Promise<void> {
+  public async ethSwitchChain(chainId: number): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     try {

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -1,4 +1,3 @@
-import detectEthereumProvider from "@metamask/detect-provider";
 import * as core from "@shapeshiftoss/hdwallet-core";
 import * as ethers from "ethers";
 import _ from "lodash";
@@ -253,10 +252,9 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
 
   public async ethSwitchChain(chainId: number): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
-    const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     try {
       // at this point, we know that we're in the context of a valid MetaMask provider
-      await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
+      await this.provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
       const error: core.SerializedEthereumRpcError = e;
       console.error(error);

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -74,21 +74,6 @@ export class MetaMaskHDWalletInfo implements core.HDWalletInfo, core.ETHWalletIn
     return chainId === 1;
   }
 
-  public async ethSwitchChain(chainId = 1): Promise<void> {
-    const hexChainId = ethers.utils.hexValue(chainId);
-    try {
-      // at this point, we know that we're in the context of a valid MetaMask provider
-      const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
-      await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
-    } catch (e: any) {
-      const error: core.SerializedEthereumRpcError = e;
-      if (error.code === 4902) {
-        // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.
-      }
-    }
-  }
-
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return false;
   }
@@ -274,6 +259,7 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
       const error: core.SerializedEthereumRpcError = e;
+      console.error(error);
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.

--- a/packages/hdwallet-tallyho/src/adapter.ts
+++ b/packages/hdwallet-tallyho/src/adapter.ts
@@ -3,11 +3,11 @@ import TallyHoOnboarding from "tallyho-onboarding";
 
 import { TallyHoHDWallet } from "./tallyho";
 
-export interface TallyHoEthereumProvider {
+interface TallyHoEthereumProvider {
   isTally?: boolean;
 }
 
-export interface Window {
+interface Window {
   ethereum?: TallyHoEthereumProvider;
 }
 

--- a/packages/hdwallet-tallyho/src/adapter.ts
+++ b/packages/hdwallet-tallyho/src/adapter.ts
@@ -3,11 +3,11 @@ import TallyHoOnboarding from "tallyho-onboarding";
 
 import { TallyHoHDWallet } from "./tallyho";
 
-interface TallyHoEthereumProvider {
+export interface TallyHoEthereumProvider {
   isTally?: boolean;
 }
 
-interface Window {
+export interface Window {
   ethereum?: TallyHoEthereumProvider;
 }
 

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -224,6 +224,11 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
     return false;
   }
 
+  /*
+   * Tally works the same way as metamask.
+   * This code is copied from the @metamask/detect-provider package
+   * @see https://www.npmjs.com/package/@metamask/detect-provider
+   */
   private async detectTallyProvider(): Promise<TallyHoEthereumProvider | null> {
     let handled = false;
 

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -5,13 +5,6 @@ import _ from "lodash";
 import { TallyHoEthereumProvider, Window } from "./adapter";
 import * as eth from "./ethereum";
 
-// https://github.com/MetaMask/eth-rpc-errors/blob/f917c2cfee9e6117a88be4178f2a877aff3acabe/src/classes.ts#L3-L7
-interface SerializedEthereumRpcError {
-  code: number;
-  message: string;
-  stack?: string;
-}
-
 export function isTallyHo(wallet: core.HDWallet): wallet is TallyHoHDWallet {
   return _.isObject(wallet) && (wallet as any)._isTallyHo;
 }
@@ -119,7 +112,7 @@ export class TallyHoHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInf
       const provider: any = await this.detectTallyProvider();
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
-      const error: SerializedEthereumRpcError = e;
+      const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.
@@ -327,12 +320,12 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
   }
   public async ethSwitchChain(chainId = 1): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
-    // at this point, we know that we're in the context of a valid MetaMask provider
     try {
+      // at this point, we know that we're in the context of a valid MetaMask provider
       const provider: any = await this.detectTallyProvider();
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
-      const error: SerializedEthereumRpcError = e;
+      const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -115,7 +115,7 @@ export class TallyHoHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInf
       const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.
+        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to Tally.
       }
     }
   }
@@ -328,7 +328,7 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
       const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.
+        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to Tally.
       }
     }
   }

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -262,6 +262,7 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
       }
     });
   }
+
   public async ethSwitchChain(chainId = 1): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
     try {

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -263,7 +263,7 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
     });
   }
 
-  public async ethSwitchChain(chainId = 1): Promise<void> {
+  public async ethSwitchChain(chainId: number): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
     try {
       // at this point, we know that we're in the context of a valid MetaMask provider

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -64,62 +64,6 @@ export class TallyHoHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInf
     return chainId === 1;
   }
 
-  private async detectTallyProvider(): Promise<TallyHoEthereumProvider | null> {
-    let handled = false;
-
-    return new Promise((resolve) => {
-      if ((window as Window).ethereum) {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        handleEthereum();
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        window.addEventListener("ethereum#initialized", handleEthereum, { once: true });
-
-        setTimeout(() => {
-          // eslint-disable-next-line @typescript-eslint/no-use-before-define
-          handleEthereum();
-        }, 3000);
-      }
-
-      function handleEthereum() {
-        if (handled) {
-          return;
-        }
-        handled = true;
-
-        window.removeEventListener("ethereum#initialized", handleEthereum);
-
-        const { ethereum } = window as Window;
-
-        if (ethereum && ethereum.isTally) {
-          resolve(ethereum as unknown as TallyHoEthereumProvider);
-        } else {
-          const message = ethereum ? "Non-TallyHo window.ethereum detected." : "Unable to detect window.ethereum.";
-
-          console.error("hdwallet-tallyho: ", message);
-          resolve(null);
-        }
-      }
-    });
-  }
-
-  public async ethSwitchChain(chainId = 1): Promise<void> {
-    // NOTE: TallyHo currently supports mainnet only and doesn't allow for chain
-    // However, multi-chain/custom RPC support is in the roadmap, see https://tally-ho.upvoty.com/
-    const hexChainId = ethers.utils.hexValue(chainId);
-    try {
-      // at this point, we know that we're in the context of a valid MetaMask provider
-      const provider: any = await this.detectTallyProvider();
-      await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
-    } catch (e: any) {
-      const error: core.SerializedEthereumRpcError = e;
-      if (error.code === 4902) {
-        // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to Tally.
-      }
-    }
-  }
-
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return false;
   }
@@ -326,6 +270,7 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
       const error: core.SerializedEthereumRpcError = e;
+      console.error(error);
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to Tally.

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -75,7 +75,7 @@ export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
       const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.
+        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to XDEFI.
       }
     }
   }
@@ -247,7 +247,7 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
       const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.
+        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to XDEFI.
       }
     }
   }

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -9,13 +9,6 @@ export function isXDEFI(wallet: core.HDWallet): wallet is XDEFIHDWallet {
   return isObject(wallet) && (wallet as any)._isXDEFI;
 }
 
-// https://github.com/MetaMask/eth-rpc-errors/blob/f917c2cfee9e6117a88be4178f2a877aff3acabe/src/classes.ts#L3-L7
-interface SerializedEthereumRpcError {
-  code: number;
-  message: string;
-  stack?: string;
-}
-
 export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo {
   readonly _supportsETHInfo = true;
   readonly _supportsBTCInfo = false;
@@ -74,12 +67,12 @@ export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
 
   public async ethSwitchChain(chainId = 1): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
-    // at this point, we know that we're in the context of a valid MetaMask provider
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     try {
+      // at this point, we know that we're in the context of a valid MetaMask provider
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
-      const error: SerializedEthereumRpcError = e;
+      const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.
@@ -246,12 +239,12 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
 
   public async ethSwitchChain(chainId = 1): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
-    // at this point, we know that we're in the context of a valid MetaMask provider
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     try {
+      // at this point, we know that we're in the context of a valid MetaMask provider
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
-      const error: SerializedEthereumRpcError = e;
+      const error: core.SerializedEthereumRpcError = e;
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -1,4 +1,3 @@
-import detectEthereumProvider from "@metamask/detect-provider";
 import * as core from "@shapeshiftoss/hdwallet-core";
 import * as ethers from "ethers";
 import isObject from "lodash/isObject";
@@ -224,10 +223,9 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
 
   public async ethSwitchChain(chainId: number): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
-    const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     try {
-      // at this point, we know that we're in the context of a valid MetaMask provider
-      await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
+      // at this point, we know that we're in the context of a valid XDEFI provider
+      await this.provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
       const error: core.SerializedEthereumRpcError = e;
       console.error(error);

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -65,22 +65,6 @@ export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
     return chainId === 1;
   }
 
-  public async ethSwitchChain(chainId = 1): Promise<void> {
-    const hexChainId = ethers.utils.hexValue(chainId);
-    const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
-    try {
-      // at this point, we know that we're in the context of a valid MetaMask provider
-      await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
-    } catch (e: any) {
-      const error: core.SerializedEthereumRpcError = e;
-      console.error(error);
-      if (error.code === 4902) {
-        // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to XDEFI.
-      }
-    }
-  }
-
   public async ethSupportsSecureTransfer(): Promise<boolean> {
     return false;
   }

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -222,7 +222,7 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
     return chainId === 1;
   }
 
-  public async ethSwitchChain(chainId = 1): Promise<void> {
+  public async ethSwitchChain(chainId: number): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });
     try {

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -73,6 +73,7 @@ export class XDEFIHDWalletInfo implements core.HDWalletInfo, core.ETHWalletInfo 
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
       const error: core.SerializedEthereumRpcError = e;
+      console.error(error);
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to XDEFI.
@@ -245,6 +246,7 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
       await provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
       const error: core.SerializedEthereumRpcError = e;
+      console.error(error);
       if (error.code === 4902) {
         // TODO: EVM Chains Milestone
         // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to XDEFI.

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -245,7 +245,6 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
   }
 
   public async ethSwitchChain(chainId = 1): Promise<void> {
-    console.log("ethSwitchChain...");
     const hexChainId = ethers.utils.hexValue(chainId);
     // at this point, we know that we're in the context of a valid MetaMask provider
     const provider: any = await detectEthereumProvider({ mustBeMetaMask: true, silent: false, timeout: 3000 });


### PR DESCRIPTION
### Description

This adds a `ethSwitchChain` method to allow switching the currently active wallet chain, using the `wallet_switchEthereumChain` JSON RPC method.

### Issue

Tackles https://github.com/shapeshift/web/issues/1843

### Screenshots

#### MetaMask

<img width="362" alt="image" src="https://user-images.githubusercontent.com/17035424/173197949-56f09329-f5f5-40f5-8c6e-f0acd2f0380a.png">

### XDEFI

XDEFI doesn't need user confirmation to switch chains. This prepares `hdwallet-xdefi` for chain switch, but shouldn't be consumed in web since this isn't in the milestone 0.

### TallyHo

~~TallyHo doesn't support multi-chain currently but it is in the roadmap, see the high-level roadmap https://tally-ho.upvoty.com/.~~ 
This prepares `hdwallet-tallyho` for chain switch, but shouldn't be consumed in web currently since calling it will be a no-op and it's not in the milestone 0.
Update: Tally does support multi-chain, but not Avalanche currently, and not in the current stable release. There are [flags](https://github.com/tallycash/extension/blob/cdbeb8b5840caa6fb7f7438d8dc38f681b0dfebf/background/features.ts#L10) to enable Polygon/Arbitrum/Optimism.
Building from source and enabling the right flags gives us this network switcher, so it looks like we might be able to support multiple EVM chains with Tally in the future
<img width="397" alt="image" src="https://user-images.githubusercontent.com/17035424/174149366-d261f588-ea6b-4e2e-8b51-39f23a16ab04.png">