### PR TITLE
feat: add ethAddChain method

### DIFF
--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -106,6 +106,20 @@ export interface ETHVerifyMessage {
   signature: string;
 }
 
+// https://docs.metamask.io/guide/rpc-api.html#wallet-addethereumchain
+export interface AddEthereumChainParameter {
+  chainId: string; // A 0x-prefixed hexadecimal string
+  chainName: string;
+  nativeCurrency: {
+    name: string;
+    symbol: string; // 2-6 characters long
+    decimals: 18;
+  };
+  rpcUrls: string[];
+  blockExplorerUrls?: string[];
+  iconUrls?: string[]; // Currently ignored.
+}
+
 export interface ETHWalletInfo extends HDWalletInfo {
   readonly _supportsETHInfo: boolean;
 
@@ -125,6 +139,12 @@ export interface ETHWalletInfo extends HDWalletInfo {
    * https://eips.ethereum.org/EIPS/eip-3326
    */
   ethSwitchChain?(chain_id: number): Promise<void>;
+
+  /**
+   * Add an Ethereum chain to user's wallet
+   * https://eips.ethereum.org/EIPS/eip-3085
+   * */
+  ethAddChain?(params: AddEthereumChainParameter): Promise<void>;
 
   /**
    * Does the device support internal transfers without the user needing to

--- a/packages/hdwallet-metamask/package.json
+++ b/packages/hdwallet-metamask/package.json
@@ -17,7 +17,7 @@
     "@metamask/detect-provider": "^1.2.0",
     "@metamask/onboarding": "^1.0.1",
     "@shapeshiftoss/hdwallet-core": "1.24.0",
-    "lodash": "^4.17.21"
+    "eth-rpc-errors": "^4.0.3"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.168",

--- a/packages/hdwallet-metamask/src/metamask.ts
+++ b/packages/hdwallet-metamask/src/metamask.ts
@@ -1,8 +1,23 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
+import { AddEthereumChainParameter } from "@shapeshiftoss/hdwallet-core";
+import { serializeError } from "eth-rpc-errors";
 import * as ethers from "ethers";
 import _ from "lodash";
 
 import * as eth from "./ethereum";
+
+// https://docs.avax.network/dapps/smart-contracts/add-avalanche-to-metamask-programmatically
+const AVALANCHE_MAINNET_ADD_CHAIN_PARAMS: AddEthereumChainParameter = {
+  chainId: "0xA86A",
+  chainName: "Avalanche Mainnet C-Chain",
+  nativeCurrency: {
+    name: "Avalanche",
+    symbol: "AVAX",
+    decimals: 18,
+  },
+  rpcUrls: ["https://api.avax.network/ext/bc/C/rpc"],
+  blockExplorerUrls: ["https://snowtrace.io/"],
+};
 
 export function isMetaMask(wallet: core.HDWallet): wallet is MetaMaskHDWallet {
   return _.isObject(wallet) && (wallet as any)._isMetaMask;
@@ -261,18 +276,30 @@ export class MetaMaskHDWallet implements core.HDWallet, core.ETHWallet {
     }
   }
 
+  public async ethAddChain(params: AddEthereumChainParameter): Promise<void> {
+    // at this point, we know that we're in the context of a valid MetaMask provider
+    await this.provider.request({ method: "wallet_addEthereumChain", params: [params] });
+  }
+
   public async ethSwitchChain(chainId: number): Promise<void> {
     const hexChainId = ethers.utils.hexValue(chainId);
     try {
       // at this point, we know that we're in the context of a valid MetaMask provider
       await this.provider.request({ method: "wallet_switchEthereumChain", params: [{ chainId: hexChainId }] });
     } catch (e: any) {
-      const error: core.SerializedEthereumRpcError = e;
-      console.error(error);
-      if (error.code === 4902) {
-        // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to MetaMask.
+      const error = serializeError(e);
+      if (error.code === -32603) {
+        // We only support Avalanche C-Chain currently. It is supported natively in XDEFI, and unsupported in Tally, both with no capabilities to add a new chain
+        // TODO(gomes): Find a better home for these. When that's done, we'll want to call ethSwitchChain with (params: AddEthereumChainParameter) instead
+        await this.ethAddChain(AVALANCHE_MAINNET_ADD_CHAIN_PARAMS);
+        return;
       }
+
+      throw (error.data as any).originalError as {
+        code: number;
+        message: string;
+        stack: string;
+      };
     }
   }
 

--- a/packages/hdwallet-tallyho/src/tallyho.ts
+++ b/packages/hdwallet-tallyho/src/tallyho.ts
@@ -242,10 +242,11 @@ export class TallyHoHDWallet implements core.HDWallet, core.ETHWallet {
     } catch (e: any) {
       const error: core.SerializedEthereumRpcError = e;
       console.error(error);
-      if (error.code === 4902) {
-        // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to Tally.
+      if (error.code === -32603) {
+        // TODO: TallyHo currently supports a finite number of chains natively (Mainnet + Polygon/Arbitrum/Optimism under feature flag), with no capabilities to add new chains
       }
+
+      throw new Error(e);
     }
   }
 

--- a/packages/hdwallet-xdefi/src/xdefi.ts
+++ b/packages/hdwallet-xdefi/src/xdefi.ts
@@ -240,10 +240,11 @@ export class XDEFIHDWallet implements core.HDWallet, core.ETHWallet {
     } catch (e: any) {
       const error: core.SerializedEthereumRpcError = e;
       console.error(error);
-      if (error.code === 4902) {
-        // TODO: EVM Chains Milestone
-        // We will need to pass chainName and rpcUrls, which we don't have yet, to add a chain to XDEFI.
+      if (error.code === -32603) {
+        // TODO: XDEFI currently supports a finite number of chains natively, with no capabilities to add new chains
       }
+
+      throw new Error(e);
     }
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8369,7 +8369,7 @@ eth-rpc-errors@^3.0.0:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-eth-rpc-errors@^4.0.2:
+eth-rpc-errors@^4.0.2, eth-rpc-errors@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz#6ddb6190a4bf360afda82790bb7d9d5e724f423a"
   integrity sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==


### PR DESCRIPTION
This adds an `ethAddChain` that allows adding a new Ethereum chain, and consumes it in MetaMask's `eth_switchChain` in case the chain we're switching to isn't currently added.

Note that this is only consumed in MetaMask: while switching chains is a valid operation in XDEFI and Tally, adding a network in unsupported in Both (although Tally explicitly has it as an unsupported method for now, hinting at future support https://github.com/tallycash/extension/blob/a7a7c1148025e27f522db201e49a0cb711fef9cd/background/services/internal-ethereum-provider/index.ts#L277)

<img width="472" alt="image" src="https://user-images.githubusercontent.com/17035424/176548257-53ce4ebf-a042-4233-ba15-afbc478c67a9.png">