### PR TITLE
refactor: replace lodash isobject function

### DIFF
--- a/packages/hdwallet-core/src/utils.test.ts
+++ b/packages/hdwallet-core/src/utils.test.ts
@@ -3,6 +3,7 @@ import {
   bip32ToAddressNList,
   fromHexString,
   isArray,
+  isObject,
   satsFromStr,
   slip44ByCoin,
   stripHexPrefix,
@@ -112,5 +113,16 @@ describe("satsFromStr", () => {
     expect(satsFromStr("21000000")).toEqual(2100000000000000);
 
     expect(satsFromStr("12345678.90123456")).toEqual(1234567890123456);
+  });
+});
+
+describe("isObject", () => {
+  it("passes basic smoke tests", () => {
+    expect(isObject(1)).toEqual(false);
+    expect(isObject("")).toEqual(false);
+    expect(isObject(["test"])).toEqual(true);
+    expect(isObject(true)).toEqual(false);
+    expect(isObject({})).toEqual(true);
+    expect(isObject({ 1: 1, 2: [], 3: { a: "a", b: "b" } })).toEqual(true);
   });
 });

--- a/packages/hdwallet-core/src/utils.ts
+++ b/packages/hdwallet-core/src/utils.ts
@@ -254,7 +254,7 @@ export function isIndexable(x: unknown): x is Record<string | number | symbol, u
   return x !== null && ["object", "function"].includes(typeof x);
 }
 
-/* Replacement for _.isObject() */
-export function isObject(x: any) {
-  return typeof x === "object" && x !== null;
+/* Replacement for lodash.isObject() */
+export function isObject(x: unknown) {
+  return x !== null && ["object", "function"].includes(typeof x);
 }

--- a/packages/hdwallet-core/src/utils.ts
+++ b/packages/hdwallet-core/src/utils.ts
@@ -253,3 +253,8 @@ export function compatibleBufferConcat(list: Uint8Array[]): Buffer {
 export function isIndexable(x: unknown): x is Record<string | number | symbol, unknown> {
   return x !== null && ["object", "function"].includes(typeof x);
 }
+
+/* Replacement for _.isObject() */
+export function isObject(x: any) {
+  return typeof x === "object" && x !== null;
+}

--- a/packages/hdwallet-core/src/wallet.ts
+++ b/packages/hdwallet-core/src/wallet.ts
@@ -1,5 +1,3 @@
-import _ from "lodash";
-
 import { BinanceWallet, BinanceWalletInfo } from "./binance";
 import { BTCInputScriptType, BTCWallet, BTCWalletInfo } from "./bitcoin";
 import { CosmosWallet, CosmosWalletInfo } from "./cosmos";
@@ -14,6 +12,7 @@ import { SecretWallet, SecretWalletInfo } from "./secret";
 import { TerraWallet, TerraWalletInfo } from "./terra";
 import { ThorchainWallet, ThorchainWalletInfo } from "./thorchain";
 import { Transport } from "./transport";
+import { isObject } from "./utils";
 
 export type BIP32Path = Array<number>;
 
@@ -118,107 +117,107 @@ export type Symbol = string;
  */
 
 export function supportsBTC(wallet: HDWallet): wallet is BTCWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsBTC;
+  return isObject(wallet) && (wallet as any)._supportsBTC;
 }
 
 export function infoBTC(info: HDWalletInfo): info is BTCWalletInfo {
-  return _.isObject(info) && (info as any)._supportsBTCInfo;
+  return isObject(info) && (info as any)._supportsBTCInfo;
 }
 
 export function supportsETH(wallet: HDWallet): wallet is ETHWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsETH;
+  return isObject(wallet) && (wallet as any)._supportsETH;
 }
 
 export function infoETH(info: HDWalletInfo): info is ETHWalletInfo {
-  return _.isObject(info) && (info as any)._supportsETHInfo;
+  return isObject(info) && (info as any)._supportsETHInfo;
 }
 
 export function supportsCosmos(wallet: HDWallet): wallet is CosmosWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsCosmos;
+  return isObject(wallet) && (wallet as any)._supportsCosmos;
 }
 
 export function supportsEthSwitchChain(wallet: HDWallet): wallet is ETHWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsEthSwitchChain;
+  return isObject(wallet) && (wallet as any)._supportsEthSwitchChain;
 }
 
 export function infoCosmos(info: HDWalletInfo): info is CosmosWalletInfo {
-  return _.isObject(info) && (info as any)._supportsCosmosInfo;
+  return isObject(info) && (info as any)._supportsCosmosInfo;
 }
 
 export function supportsOsmosis(wallet: HDWallet): wallet is OsmosisWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsOsmosis;
+  return isObject(wallet) && (wallet as any)._supportsOsmosis;
 }
 
 export function infoOsmosis(info: HDWalletInfo): info is OsmosisWalletInfo {
-  return _.isObject(info) && (info as any)._supportsOsmosisInfo;
+  return isObject(info) && (info as any)._supportsOsmosisInfo;
 }
 
 export function supportsThorchain(wallet: HDWallet): wallet is ThorchainWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsThorchain;
+  return isObject(wallet) && (wallet as any)._supportsThorchain;
 }
 
 export function infoThorchain(info: HDWalletInfo): info is ThorchainWalletInfo {
-  return _.isObject(info) && (info as any)._supportsThorchainInfo;
+  return isObject(info) && (info as any)._supportsThorchainInfo;
 }
 
 export function supportsEos(wallet: HDWallet): wallet is EosWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsEos;
+  return isObject(wallet) && (wallet as any)._supportsEos;
 }
 
 export function infoEos(info: HDWalletInfo): info is EosWalletInfo {
-  return _.isObject(info) && (info as any)._supportsEosInfo;
+  return isObject(info) && (info as any)._supportsEosInfo;
 }
 
 export function supportsFio(wallet: HDWallet): wallet is FioWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsFio;
+  return isObject(wallet) && (wallet as any)._supportsFio;
 }
 
 export function infoFio(info: HDWalletInfo): info is FioWalletInfo {
-  return _.isObject(info) && (info as any)._supportsFioInfo;
+  return isObject(info) && (info as any)._supportsFioInfo;
 }
 
 export function supportsSecret(wallet: HDWallet): wallet is SecretWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsSecret;
+  return isObject(wallet) && (wallet as any)._supportsSecret;
 }
 
 export function infoSecret(info: HDWalletInfo): info is SecretWalletInfo {
-  return _.isObject(info) && (info as any)._supportsSecretInfo;
+  return isObject(info) && (info as any)._supportsSecretInfo;
 }
 
 export function supportsTerra(wallet: HDWallet): wallet is TerraWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsTerra;
+  return isObject(wallet) && (wallet as any)._supportsTerra;
 }
 
 export function infoTerra(info: HDWalletInfo): info is TerraWalletInfo {
-  return _.isObject(info) && (info as any)._supportsTerraInfo;
+  return isObject(info) && (info as any)._supportsTerraInfo;
 }
 
 export function supportsKava(wallet: HDWallet): wallet is KavaWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsKava;
+  return isObject(wallet) && (wallet as any)._supportsKava;
 }
 
 export function infoKava(info: HDWalletInfo): info is KavaWalletInfo {
-  return _.isObject(info) && (info as any)._supportsKavaInfo;
+  return isObject(info) && (info as any)._supportsKavaInfo;
 }
 
 export function supportsRipple(wallet: HDWallet): wallet is RippleWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsRipple;
+  return isObject(wallet) && (wallet as any)._supportsRipple;
 }
 
 export function infoRipple(info: HDWalletInfo): info is RippleWalletInfo {
-  return _.isObject(info) && (info as any)._supportsRippleInfo;
+  return isObject(info) && (info as any)._supportsRippleInfo;
 }
 
 export function supportsBinance(wallet: HDWallet): wallet is BinanceWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsBinance;
+  return isObject(wallet) && (wallet as any)._supportsBinance;
 }
 
 export function infoBinance(info: HDWalletInfo): info is BinanceWalletInfo {
-  return _.isObject(info) && (info as any)._supportsBinanceInfo;
+  return isObject(info) && (info as any)._supportsBinanceInfo;
 }
 
 export function supportsDebugLink(wallet: HDWallet): wallet is DebugLinkWallet {
-  return _.isObject(wallet) && (wallet as any)._supportsDebugLink;
+  return isObject(wallet) && (wallet as any)._supportsDebugLink;
 }
 
 export interface HDWalletInfo {

--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -1,7 +1,6 @@
 import * as core from "@shapeshiftoss/hdwallet-core";
 import * as bip39 from "bip39";
 import * as eventemitter2 from "eventemitter2";
-import _ from "lodash";
 
 import type { NativeAdapterArgs } from "./adapter";
 import { MixinNativeBinanceWallet, MixinNativeBinanceWalletInfo } from "./binance";
@@ -411,7 +410,7 @@ export class NativeHDWallet
 }
 
 export function isNative(wallet: core.HDWallet): wallet is NativeHDWallet {
-  return _.isObject(wallet) && (wallet as any)._isNative;
+  return core.isObject(wallet) && (wallet as any)._isNative;
 }
 
 export function info() {


### PR DESCRIPTION
The `isObject()` function from lodash causes runtime errors in the ShapeShift MetaMask snap. This PR replaces `isObject()` in hdwallet-native