### PR TITLE
feat: implement hdwallet-native isLocked on mnemonic required

### DIFF
--- a/packages/hdwallet-native/src/native.ts
+++ b/packages/hdwallet-native/src/native.ts
@@ -294,8 +294,8 @@ export class NativeHDWallet
     return !!this.#initialized;
   }
 
-  async isLocked(): Promise<boolean> {
-    return false;
+  public async isLocked(): Promise<boolean> {
+    return !!this.#masterKey;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
Pretty much does what this says on the box - this will allow us to call `isLocked()` instead of relying too much on cilent-side magic, see https://github.com/shapeshift/web/pull/3923