### PR TITLE
handle pin mismatch

### DIFF
--- a/packages/hdwallet-keepkey/src/transport.ts
+++ b/packages/hdwallet-keepkey/src/transport.ts
@@ -322,7 +322,12 @@ export class Transport extends core.Transport {
         response.message.code === Types.FailureType.FAILURE_ACTIONCANCELLED
       ) {
         this.callInProgress = { main: undefined, debug: undefined };
-        throw new core.ActionCancelled();
+        if (response.message.message === "PINs do not match") {
+          response.message.code = Types.FailureType.FAILURE_PINMISMATCH;
+          throw response;
+        } else {
+          throw new core.ActionCancelled();
+        }
       }
       if (response.message_type === core.Events.FAILURE) throw response;
       return response;


### PR DESCRIPTION
This patch sending the expected pin code for the handled case of a user attempting to set a new pin with mismatching pins. This patch is required for proper keepkey onboarding. 