### PR TITLE
add omitLock

### DIFF
--- a/packages/hdwallet-keepkey/src/transport.ts
+++ b/packages/hdwallet-keepkey/src/transport.ts
@@ -353,6 +353,7 @@ export class Transport extends core.Transport {
       this.callInProgress = { main: undefined, debug: undefined };
       const cancelMsg = new Messages.Cancel();
       await this.call(Messages.MessageType.MESSAGETYPE_CANCEL, cancelMsg, {
+        omitLock: this.userActionRequired,
         noWait: this.userActionRequired,
       });
     } catch (e) {


### PR DESCRIPTION
This omitLock was needed for proper action Canceling. In order to abort actions a user wishes to not take, or reset the state of the keepkey action by a dapp, the device needs to be able to omit the queue locking. 