### PR TITLE
feat: don't cache utxo addresses

### DIFF
--- a/packages/hdwallet-metamask-shapeshift-multichain/src/shapeshift-multichain.ts
+++ b/packages/hdwallet-metamask-shapeshift-multichain/src/shapeshift-multichain.ts
@@ -487,11 +487,7 @@ export class MetaMaskShapeShiftMultiChainHDWallet
     return this.info.bitcoinNextAccountPath(msg);
   }
 
-  addressCache: Map<string, string> = new Map();
   public async btcGetAddress(msg: core.BTCGetAddress): Promise<string | null> {
-    const key = JSON.stringify(msg);
-    const maybeCachedAddress = this.addressCache.get(key);
-    if (maybeCachedAddress) return maybeCachedAddress;
     const value = await (async () => {
       switch (msg.coin) {
         case "Bitcoin":
@@ -508,7 +504,6 @@ export class MetaMaskShapeShiftMultiChainHDWallet
     })();
     if (!value || typeof value !== "string") return null;
 
-    this.addressCache.set(key, value);
     return value;
   }
 


### PR DESCRIPTION
Additional safety on top of https://github.com/shapeshift/web/pull/5469 against wrongly caching UTXO addresses for MM snaps.