### PR TITLE
fix: adjust solana build tx function to work with programs

### DIFF
--- a/packages/hdwallet-core/src/solana.ts
+++ b/packages/hdwallet-core/src/solana.ts
@@ -21,9 +21,9 @@ export interface SolanaTxInstruction {
 export interface SolanaSignTx {
   addressNList: BIP32Path;
   /** to is the destination pubkey for the transfer */
-  to: string;
+  to?: string;
   /** value is the amount to transfer in micro lamports*/
-  value: string;
+  value?: string;
   /** blockHash is used for expiry determination */
   blockHash: string;
   /** computeUnitLimit is the maximum number of compute units allowed to be consumed by the transaction */

--- a/packages/hdwallet-phantom/src/solana.ts
+++ b/packages/hdwallet-phantom/src/solana.ts
@@ -18,7 +18,9 @@ function toTransactionInstructions(instructions: core.SolanaTxInstruction[]): Tr
   return instructions.map(
     (instruction) =>
       new TransactionInstruction({
-        keys: instruction.keys.map((key) => Object.assign(key, { pubkey: new PublicKey(key.pubkey) })),
+        keys: instruction.keys.map((key) =>
+          Object.assign(key, { pubkey: new PublicKey(key.pubkey), isSigner: key.isSigner, isWritable: key.isWritable })
+        ),
         programId: new PublicKey(instruction.programId),
         data: instruction.data,
       })


### PR DESCRIPTION
- Making to and value optional in SolanaSignTx as when you use program you don't need a `to` and `value` as it's contained inside the instructions
- Also added the possibility to use `isSigner` and `isWritable` inside each instruction as multiple solana accounts can sign an instruction (delegating something etc), it's needed for jupiter swaps