### PR TITLE
Fix Typographical Errors in CONTRIBUTING.md and README.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@
 
   Please see ShapeShift's [responsible disclosure program](https://corp.shapeshift.io/responsible-disclosure-program/).
 
-- When contributing to HDWallet, please discus the change you want to make via
+- When contributing to HDWallet, please discuss the change you want to make via
   a GitHub issue before making a change and submitting a PR.
 
 #### Submitting a Patch

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To compile and watch the browser bundle, run:
 yarn dev:sandbox
 ```
 
-This will launch an ssl webserver that runs at `https://localhost:1234`, with
+This will launch a ssl webserver that runs at `https://localhost:1234`, with
 a small demo app that shows how to use various HDWallet functionality.
 
 We use [Zeit Now](https://zeit.co/home) for continuous deployment of this


### PR DESCRIPTION
This PR addresses two minor typographical errors in the documentation:

1. **CONTRIBUTING.md**: Corrected "discus" to "discuss" to use the correct verb.
2. **README.md**: Replaced "an" with "a" before "ssl webserver" for grammatical accuracy.

These updates enhance clarity and ensure proper grammar in the documentation.
