### PR TITLE
Fix project sandbox examples

### DIFF
--- a/examples/sandbox/vite.config.ts
+++ b/examples/sandbox/vite.config.ts
@@ -20,6 +20,7 @@ const config: UserConfig = {
   ],
   build: {
     commonjsOptions: {
+      include: [/node_modules/, /packages\/hdwallet-.+\/dist\/.*\.js$/],
       transformMixedEsModules: true,
     },
     target: "esnext",


### PR DESCRIPTION
This PR updates the build.commonjsOptions in vite.config.ts to explicitly include the compiled CommonJS files from the internal hdwallet-* packages in the monorepo. These packages are written in TypeScript and compiled to CommonJS, and since they are internal dependencies, Vite does not transpile them by default. This results in runtime errors such as:

`Uncaught ReferenceError: require is not defined`

Reason:
Vite does not automatically apply CommonJS transformation to linked internal packages unless explicitly configured to do so. This is expected behavior when using internal packages that are not exported as ES Modules.

Reference: Related Vite issue: https://github.com/vitejs/vite/issues/5668#:~:text=I%27m%20trying%20to%20migrate%20CRA,I%20built%20a%20minimal%20reproduction